### PR TITLE
refine ipam's host-local example

### DIFF
--- a/plugins/ipam/host-local/README.md
+++ b/plugins/ipam/host-local/README.md
@@ -49,14 +49,19 @@ We can test it out on the command-line:
 ```bash
 $ export CNI_COMMAND=ADD
 $ export CNI_CONTAINERID=f81d4fae-7dec-11d0-a765-00a0c91e6bf6
-$ echo '{ "name": "default", "ipam": { "type": "host-local", "subnet": "203.0.113.0/24" } }' | ./host-local
+$ export CNI_NETNS=test
+$ export CNI_IFNAME=eth0
+$ export CNI_PATH=/PATH/TO/CNI/PLUGINS/bin  # the cni binaries path
+$ echo '{ "name": "default", "ipam": { "type": "host-local", "subnet": "203.0.113.0/24" } }' | /PATH/TO/host-local
 ```
 
 ```json
 {
     "ip4": {
-        "ip": "203.0.113.1/24"
-    }
+        "ip": "203.0.113.2/24",
+		"gateway": "203.0.113.1"
+    },
+	"dns": {}
 }
 ```
 


### PR DESCRIPTION
I tried the `host-local` example and got the following error:

```
root@neutronctrl:/home/ubuntu/git/src/github.com/containernetworking/plugins/bin# echo '{"name": "default", "ipam": {"type": "host-local", "subnet": "203.0.113.0/24"}}' | ./host-local
CNI_NETNS env variable missing
CNI_IFNAME env variable missing
CNI_PATH env variable missing
{
    "code": 100,
    "msg": "required env variables missing"
}
```

It suggested that I should add some environment variables.
This PR is to supplement the needed environment variables and get the targeted result:

```
root@neutronctrl:/home/ubuntu/git/src/github.com/containernetworking/plugins/bin# echo '{ "name": "default", "ipam": { "type": "host-local", "subnet": "203.0.113.0/24" } }' | ./host-local
{
    "ip4": {
        "ip": "203.0.113.3/24",
        "gateway": "203.0.113.1"
    },
    "dns": {}
}
```