### PR TITLE
portmap: Don't accept a port number of 0

### DIFF
--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const TIMEOUT = 20
+
 var _ = Describe("portmap integration tests", func() {
 
 	var configList *libcni.NetworkConfigList
@@ -173,7 +175,7 @@ var _ = Describe("portmap integration tests", func() {
 
 		close(done)
 
-	}, 5)
+	}, TIMEOUT*3)
 })
 
 // testEchoServer returns true if we found an echo server on the port
@@ -186,7 +188,7 @@ func testEchoServer(address string) bool {
 	}
 	defer conn.Close()
 
-	conn.SetDeadline(time.Now().Add(20 * time.Second))
+	conn.SetDeadline(time.Now().Add(TIMEOUT * time.Second))
 	fmt.Fprintln(GinkgoWriter, "connected to", address)
 
 	message := "Aliquid melius quam pessimum optimum non est."
@@ -196,7 +198,7 @@ func testEchoServer(address string) bool {
 		return false
 	}
 
-	conn.SetDeadline(time.Now().Add(20 * time.Second))
+	conn.SetDeadline(time.Now().Add(TIMEOUT * time.Second))
 	fmt.Fprintln(GinkgoWriter, "reading...")
 	response := make([]byte, len(message))
 	_, err = conn.Read(response)


### PR DESCRIPTION
This also adds more testing around configuration parsing.

This was inspired by k8s bug that passed a port number of 0, but I realized that there was some logic not under test that really should be.