### PR TITLE
flannel: set the cniVersion on the delegated config

### DIFF
--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -224,6 +224,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 			n.Delegate["isGateway"] = true
 		}
 	}
+	if n.CNIVersion != "" {
+		n.Delegate["cniVersion"] = n.CNIVersion
+	}
 
 	n.Delegate["ipam"] = map[string]interface{}{
 		"type":   "host-local",

--- a/plugins/meta/flannel/flannel_test.go
+++ b/plugins/meta/flannel/flannel_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -102,7 +103,7 @@ FLANNEL_IPMASQ=true
 				defer GinkgoRecover()
 
 				By("calling ADD")
-				_, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(input), func() error {
+				resI, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(input), func() error {
 					return cmdAdd(args)
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -131,6 +132,10 @@ FLANNEL_IPMASQ=true
 }
 `
 				Expect(netConfBytes).Should(MatchJSON(expected))
+
+				result, err := current.NewResultFromResult(resI)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.IPs).To(HaveLen(1))
 
 				By("calling DEL")
 				err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {


### PR DESCRIPTION
This prevented flannel from returning any useful information about created interfaces. This broke plugin chaining.

Fixes: #23 