### PR TITLE
plugins/portmap: fix test flake

### DIFF
--- a/plugins/meta/portmap/portmap_suite_test.go
+++ b/plugins/meta/portmap/portmap_suite_test.go
@@ -32,7 +32,7 @@ func TestPortmap(t *testing.T) {
 	RunSpecs(t, "portmap Suite")
 }
 
-// OpenEchoServer opens a server that handles one connection before closing.
+// OpenEchoServer opens a server that listens until closeChan is closed.
 // It opens on a random port and sends the port number on portChan when
 // the server is up and running. If an error is encountered, closes portChan.
 // If closeChan is closed, closes the socket.


### PR DESCRIPTION
The source address selection was random, and sometimes we picked a
source address that the container didn't have a route to. Adding a
default route fixes that!