### PR TITLE
bridge: setup ebtables dedup rules if promisc mode is specified.

### DIFF
--- a/pkg/bridge/bridge.go
+++ b/pkg/bridge/bridge.go
@@ -1,0 +1,100 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+
+	"github.com/containernetworking/plugins/pkg/bridge/ebtables"
+	utilexec "github.com/containernetworking/plugins/pkg/exec"
+)
+
+const (
+	dedupChain  = "CNI-DEDUP"
+	filterTable = "filter"
+	outputChain = "OUTPUT"
+)
+
+// AddDedupRules adds two ebtables rules providing the following:
+// 1) Allow the bridge IP address when using the src bridge mac
+// 2) Block any other IP in the network sourced with the bridge interface's mac
+//    address.
+// For example if the bridge address is 192.16.1.1/24 the following ebtables
+// rules will be setup.
+//  -t filter -A CNI-DEDUP -p IPv4 -s <bridge-mac> -o veth+ --ip-src 192.168.1.1 -j ACCEPT
+//  -t filter -A CNI-DEDUP -p IPv4 -s <bridge-mac> -o veth+ --ip-src 192.168.1.0/24 -j DROP
+func AddDedupRules(mac, ip, nw string, family uint16) error {
+	ebt, err := ebtables.New(utilexec.New())
+	if err != nil {
+		return err
+	}
+	if err := ebt.NewChain(filterTable, dedupChain); err != nil {
+		// Make chain creation idempotent.
+		if !strings.Contains(err.Error(), "already exists") {
+			return err
+		}
+	}
+
+	var common_args []string
+	switch family {
+	case syscall.AF_INET:
+		common_args = []string{"-p", "IPv4", "-s", mac, "-o", "veth+", "--ip-src"}
+	case syscall.AF_INET6:
+		common_args = []string{"-p", "IPv6", "-s", mac, "-o", "veth+", "--ip6-src"}
+	default:
+		return fmt.Errorf("unsupported protocol family %q", family)
+	}
+
+	if err := ebt.AppendUnique(filterTable, dedupChain, append(common_args, ip, "-j", "ACCEPT")...); err != nil {
+		return err
+	}
+	if err := ebt.AppendUnique(filterTable, dedupChain, append(common_args, nw, "-j", "DROP")...); err != nil {
+		return err
+	}
+
+	if err := ebt.AppendUnique(filterTable, outputChain, "-j", dedupChain); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+// DeleteDedupRules delets all ebtables rules under the "CNI-DEDUP" chain
+// including the chain.
+func DeleteDedupRules() error {
+	ebt, err := ebtables.New(utilexec.New())
+	if err != nil {
+		return err
+	}
+	if err := ebt.Delete(filterTable, outputChain, "-j", dedupChain); err != nil {
+		// Make rule deletion idempotent.
+		if strings.Contains(err.Error(), "Illegal target name") {
+			return nil
+		}
+		return err
+	}
+	if err := ebt.DeleteChain(filterTable, dedupChain); err != nil {
+		// Make chain deletion idempotent.
+		if strings.Contains(err.Error(), "Illegal target name") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/bridge/ebtables/ebtables.go
+++ b/pkg/bridge/ebtables/ebtables.go
@@ -1,0 +1,180 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebtables
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	osexec "os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	utilexec "github.com/containernetworking/plugins/pkg/exec"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+)
+
+const (
+	sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
+)
+
+type ExitError interface {
+	Error() string
+	ExitStatus() int
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("exit status %v: %v", e.ExitStatus(), e.msg)
+}
+
+func (e *Error) ExitStatus() int {
+	return e.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+type Error struct {
+	*osexec.ExitError
+	msg string
+}
+
+var _ ExitError = &Error{}
+
+type EBTables struct {
+	path string
+	exec utilexec.Interface
+}
+
+func New(exec utilexec.Interface) (*EBTables, error) {
+	path, err := exec.LookPath("ebtables")
+	if err != nil {
+		return nil, err
+	}
+
+	ebt := EBTables{
+		path: path,
+		exec: exec,
+	}
+
+	modprobe, err := ebt.exec.LookPath("modprobe")
+	if err != nil {
+		return nil, err
+	}
+
+	var _, stderr bytes.Buffer
+	cmd := ebt.exec.Command(modprobe, "br-netfilter")
+	cmd.SetStderr(&stderr)
+
+	if err := cmd.Run(); err != nil {
+		return nil, &Error{(err.(*osexec.ExitError)), stderr.String()}
+	}
+
+	// Allow iptables to see bridged traffic, do this best effort.
+	sysctl.Sysctl(sysctlBridgeCallIPTables, "1")
+
+	return &ebt, nil
+}
+
+// List lists the current rules in the specified chain and table.
+func (ebt *EBTables) List(table, chain string) ([]string, error) {
+	cmd := []string{"-t", table, "-L", chain, "--Lmac2"}
+	var stdout bytes.Buffer
+	if err := ebt.runWithOutput(cmd, &stdout); err != nil {
+		return nil, err
+	}
+	var rules []string
+	for _, r := range strings.Split(stdout.String(), "\n") {
+		// Skip blank lines and lines like "Bridge table: filter"
+		r = strings.TrimSpace(r)
+		if strings.HasPrefix(r, "Bridge") || r == "" {
+			continue
+		}
+		rules = append(rules, r)
+	}
+	return rules, nil
+}
+
+// Exists returns true if the rule specified matches an existing rule in the
+// specified chain and table.
+func (ebt *EBTables) Exists(table, chain string, rule ...string) (bool, error) {
+	rules, err := ebt.List(table, chain)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rules {
+		if r == strings.Join(rule, " ") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Insert inserts a rule into the specified table and chain at the specified
+// position.
+func (ebt *EBTables) Insert(table, chain string, pos int, rule ...string) error {
+	cmd := append([]string{"-t", table, "-I", chain, strconv.Itoa(pos)}, rule...)
+	return ebt.run(cmd...)
+}
+
+// Append appends a rule to the specified chain and table.
+func (ebt *EBTables) Append(table, chain string, rule ...string) error {
+	cmd := append([]string{"-t", table, "-A", chain}, rule...)
+	return ebt.run(cmd...)
+}
+
+// AppendUnique appends a rule only if the rule does not exist.
+func (ebt *EBTables) AppendUnique(table, chain string, rule ...string) error {
+	exists, err := ebt.Exists(table, chain, rule...)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return ebt.Append(table, chain, rule...)
+	}
+	return nil
+}
+
+// Delete removes a rule from the specified chain and table.
+func (ebt *EBTables) Delete(table, chain string, rule ...string) error {
+	cmd := append([]string{"-t", table, "-D", chain}, rule...)
+	return ebt.run(cmd...)
+}
+
+// NewChain creates a new ebtables chain.
+func (ebt *EBTables) NewChain(table, chain string) error {
+	return ebt.run("-t", table, "-N", chain)
+}
+
+// DeleteChain removes an ebtables chain.
+func (ebt *EBTables) DeleteChain(table, chain string) error {
+	return ebt.run("-t", table, "-X", chain)
+}
+
+func (ebt *EBTables) run(args ...string) error {
+	return ebt.runWithOutput(args, nil)
+}
+
+func (ebt *EBTables) runWithOutput(args []string, stdout io.Writer) error {
+	args = append([]string{"--concurrent"}, args...)
+	var stderr bytes.Buffer
+	cmd := ebt.exec.Command(ebt.path, args...)
+	cmd.SetStdout(stdout)
+	cmd.SetStderr(&stderr)
+	if err := cmd.Run(); err != nil {
+		return &Error{(err.(*osexec.ExitError)), stderr.String()}
+	}
+	return nil
+}

--- a/pkg/bridge/ebtables/ebtables_suite_test.go
+++ b/pkg/bridge/ebtables/ebtables_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebtables_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestBridge(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EBTables Suite")
+}

--- a/pkg/bridge/ebtables/ebtables_test.go
+++ b/pkg/bridge/ebtables/ebtables_test.go
@@ -1,0 +1,147 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebtables
+
+import (
+	utilexec "github.com/containernetworking/plugins/pkg/exec"
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EBTables Operations", func() {
+	const (
+		testChain   = "test"
+		filterTable = "filter"
+	)
+
+	var (
+		testNS ns.NetNS
+		ebt    *EBTables
+		err    error
+	)
+
+	BeforeEach(func() {
+		ebt, err = New(utilexec.New())
+		Expect(err).NotTo(HaveOccurred())
+		testNS, err = ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.NewChain(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+	})
+
+	AfterEach(func() {
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			Expect(testNS.Close()).To(Succeed())
+			err = ebt.DeleteChain(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+	})
+
+	It("Appends a rule (IPv4)", func() {
+
+		mac := "4e:4f:41:48:00:00"
+		ip := "10.1.1.1"
+		common_args := []string{"-p", "IPv4", "-s", mac, "-o", "veth+", "--ip-src"}
+
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			rules, err := ebt.List(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(rules)).To(Equal(1))
+			return nil
+		})
+	})
+
+	It("Appends a rule (IPv6)", func() {
+
+		mac := "4e:4f:41:48:00:00"
+		ip := "FD6D:8D64:AF0C::1"
+		common_args := []string{"-p", "IPv6", "-s", mac, "-o", "veth+", "--ip6-src"}
+
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			rules, err := ebt.List(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(rules)).To(Equal(1))
+			return nil
+		})
+	})
+
+	It("Does not append an existing rule", func() {
+		mac := "4e:4f:41:48:00:00"
+		ip := "10.1.1.1"
+		common_args := []string{"-p", "IPv4", "-s", mac, "-o", "veth+", "--ip-src"}
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			rules, err := ebt.List(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(rules)).To(Equal(1))
+			return nil
+		})
+	})
+
+	It("Inserts a rule.", func() {
+		mac := "4e:4f:41:48:00:00"
+		ip := "10.1.1.2"
+		common_args := []string{"-p", "IPv4", "-s", mac, "-o", "veth+", "--ip-src"}
+
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			err = ebt.Insert(filterTable, testChain, 1, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			rules, err := ebt.List(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			// Make sure its the first rule.
+			Expect(rules[0]).To(Equal("-p IPv4 -s 4e:4f:41:48:00:00 -o veth+ --ip-src 10.1.1.2 -j ACCEPT"))
+			Expect(len(rules)).To(Equal(2))
+			return nil
+		})
+	})
+
+	It("Deletes a rule", func() {
+		mac := "4e:4f:41:48:00:00"
+		ip := "10.1.1.1"
+		common_args := []string{"-p", "IPv4", "-s", mac, "-o", "veth+", "--ip-src"}
+
+		_ = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = ebt.AppendUnique(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			err = ebt.Delete(filterTable, testChain, append(common_args, ip, "-j", "ACCEPT")...)
+			Expect(err).NotTo(HaveOccurred())
+			rules, err := ebt.List(filterTable, testChain)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(rules)).To(Equal(0))
+			return nil
+		})
+	})
+})

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,0 +1,66 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"io"
+	osexec "os/exec"
+)
+
+type cmdWrapper osexec.Cmd
+
+var _ Cmd = &cmdWrapper{}
+
+type Cmd interface {
+	Run() error
+	SetStderr(io.Writer)
+	SetStdout(io.Writer)
+	SetStdin(io.Reader)
+}
+
+type Interface interface {
+	Command(cmd string, args ...string) Cmd
+	LookPath(file string) (string, error)
+}
+
+type executor struct{}
+
+func New() Interface {
+	return &executor{}
+}
+
+func (executor *executor) Command(cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.Command(cmd, args...))
+}
+
+func (executor *executor) LookPath(file string) (string, error) {
+	return osexec.LookPath(file)
+}
+
+func (cmd *cmdWrapper) Run() error {
+	return (*osexec.Cmd)(cmd).Run()
+}
+
+func (cmd *cmdWrapper) SetStdin(in io.Reader) {
+	cmd.Stdin = in
+}
+
+func (cmd *cmdWrapper) SetStdout(out io.Writer) {
+	cmd.Stdout = out
+}
+
+func (cmd *cmdWrapper) SetStderr(out io.Writer) {
+	cmd.Stderr = out
+}

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ source ./build.sh
 
 echo "Running tests"
 
-TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/main/loopback plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/meta/flannel plugins/main/vlan plugins/sample pkg/ip pkg/ipam pkg/ns pkg/utils pkg/utils/hwaddr pkg/utils/sysctl plugins/meta/portmap"
+TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/main/loopback plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/meta/flannel plugins/main/vlan plugins/sample pkg/bridge/ebtables pkg/ip pkg/ipam pkg/ns pkg/utils pkg/utils/hwaddr pkg/utils/sysctl plugins/meta/portmap"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
This is required to prevent duplicate packets when promiscuous mode is set on the bridge interface.
This is related to moving kubernetes "kubenet" functionality out of kubernetes and into the bridge plugin.
https://github.com/kubernetes/kubernetes/issues/38890

Original issue requiring the deduplication: https://github.com/kubernetes/kubernetes/issues/25793
Original Kubernetes PR fixing the issue: https://github.com/kubernetes/kubernetes/pull/28717