### PR TITLE
Greatly reduce build time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,12 +20,16 @@ mkdir -p "${PWD}/bin"
 
 echo "Building plugins"
 PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/* plugins/sample"
+ppids=""
 for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"
 		echo "  $plugin"
 		go build -o ${PWD}/bin/$plugin -i -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
+		ppids="$ppids $!"
 	fi
 done
 
-wait
+for ppid in $ppids; do
+	wait $ppid
+done

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"
 		echo "  $plugin"
-		go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
+		go build -o ${PWD}/bin/$plugin -i -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
 	fi
 done
 

--- a/build.sh
+++ b/build.sh
@@ -24,13 +24,7 @@ for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"
 		echo "  $plugin"
-		# use go install so we don't duplicate work
-		if [ -n "$FASTBUILD" ]
-		then
-			GOBIN=${PWD}/bin go install -pkgdir $GOPATH/pkg "$@" $REPO_PATH/$d
-		else
-			go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
-		fi
+		go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
 	fi
 done
 

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,9 @@ for d in $PLUGINS; do
 		then
 			GOBIN=${PWD}/bin go install -pkgdir $GOPATH/pkg "$@" $REPO_PATH/$d
 		else
-			go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d"
+			go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d" &
 		fi
 	fi
 done
+
+wait


### PR DESCRIPTION
Before:
```
time ./build.sh 
Building plugins
  flannel
  portmap
  tuning
  bridge
  ipvlan
  loopback
  macvlan
  ptp
  vlan
  dhcp
  host-local
  sample

real	1m3.570s
user	1m55.950s
sys	0m19.707s
```

After:
```
time ./build.sh 
Building plugins
  flannel
  portmap
  tuning
  bridge
  ipvlan
  loopback
  macvlan
  ptp
  vlan
  dhcp
  host-local
  sample

real	0m27.567s
user	2m28.666s
sys	0m25.343s
```

The tests above were done on OS X with an `Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz` (4 cores/8 threads) and 16 GB of RAM. I'm sure this will be a bit faster (and take less resources) on Linux since I'm going through the cross compiler here.