### PR TITLE
ipam/host-local: support sets of disjoint ranges

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/range_set.go
+++ b/plugins/ipam/host-local/backend/allocator/range_set.go
@@ -1,0 +1,97 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// Contains returns true if any range in this set contains an IP
+func (s *RangeSet) Contains(addr net.IP) bool {
+	r, _ := s.RangeFor(addr)
+	return r != nil
+}
+
+// RangeFor finds the range that contains an IP, or nil if not found
+func (s *RangeSet) RangeFor(addr net.IP) (*Range, error) {
+	if err := canonicalizeIP(&addr); err != nil {
+		return nil, err
+	}
+
+	for _, r := range *s {
+		if r.Contains(addr) {
+			return &r, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s not in range set %s", addr.String(), s.String())
+}
+
+// Overlaps returns true if any ranges in any set overlap with this one
+func (s *RangeSet) Overlaps(p1 *RangeSet) bool {
+	for _, r := range *s {
+		for _, r1 := range *p1 {
+			if r.Overlaps(&r1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Canonicalize ensures the RangeSet is in a standard form, and detects any
+// invalid input. Call Range.Canonicalize() on every Range in the set
+func (s *RangeSet) Canonicalize() error {
+	if len(*s) == 0 {
+		return fmt.Errorf("empty range set")
+	}
+
+	fam := 0
+	for i, _ := range *s {
+		if err := (*s)[i].Canonicalize(); err != nil {
+			return err
+		}
+		if i == 0 {
+			fam = len((*s)[i].RangeStart)
+		} else {
+			if fam != len((*s)[i].RangeStart) {
+				return fmt.Errorf("mixed address families")
+			}
+		}
+	}
+
+	// Make sure none of the ranges in the set overlap
+	l := len(*s)
+	for i, r1 := range (*s)[:l-1] {
+		for _, r2 := range (*s)[i+1:] {
+			if r1.Overlaps(&r2) {
+				return fmt.Errorf("subnets %s and %s overlap", r1.String(), r2.String())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *RangeSet) String() string {
+	out := []string{}
+	for _, r := range *s {
+		out = append(out, r.String())
+	}
+
+	return strings.Join(out, ",")
+}

--- a/plugins/ipam/host-local/backend/allocator/range_set_test.go
+++ b/plugins/ipam/host-local/backend/allocator/range_set_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("range sets", func() {
+	It("should detect set membership correctly", func() {
+		p := RangeSet{
+			Range{Subnet: mustSubnet("192.168.0.0/24")},
+			Range{Subnet: mustSubnet("172.16.1.0/24")},
+		}
+
+		err := p.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(p.Contains(net.IP{192, 168, 0, 55})).To(BeTrue())
+
+		r, err := p.RangeFor(net.IP{192, 168, 0, 55})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(r).To(Equal(&p[0]))
+
+		r, err = p.RangeFor(net.IP{192, 168, 99, 99})
+		Expect(r).To(BeNil())
+		Expect(err).To(MatchError("192.168.99.99 not in range set 192.168.0.1-192.168.0.254,172.16.1.1-172.16.1.254"))
+
+	})
+
+	It("should discover overlaps within a set", func() {
+		p := RangeSet{
+			{Subnet: mustSubnet("192.168.0.0/20")},
+			{Subnet: mustSubnet("192.168.2.0/24")},
+		}
+
+		err := p.Canonicalize()
+		Expect(err).To(MatchError("subnets 192.168.0.1-192.168.15.254 and 192.168.2.1-192.168.2.254 overlap"))
+	})
+
+	It("should discover overlaps outside a set", func() {
+		p1 := RangeSet{
+			{Subnet: mustSubnet("192.168.0.0/20")},
+		}
+		p2 := RangeSet{
+			{Subnet: mustSubnet("192.168.2.0/24")},
+		}
+
+		p1.Canonicalize()
+		p2.Canonicalize()
+
+		Expect(p1.Overlaps(&p2)).To(BeTrue())
+		Expect(p2.Overlaps(&p1)).To(BeTrue())
+	})
+})

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -45,17 +45,17 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "dataDir": "%s",
+"cniVersion": "0.3.1",
+"name": "mynet",
+"type": "ipvlan",
+"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"dataDir": "%s",
 		"resolvConf": "%s/resolv.conf",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24" },
-			{ "subnet": "2001:db8:1::0/64" }
+			[{ "subnet": "10.1.2.0/24" }, {"subnet": "10.2.2.0/24"}],
+			[{ "subnet": "2001:db8:1::0/64" }]
 		],
 		"routes": [
 			{"dst": "0.0.0.0/0"},
@@ -63,7 +63,7 @@ var _ = Describe("host-local Operations", func() {
 			{"dst": "192.168.0.0/16", "gw": "1.1.1.1"},
 			{"dst": "2001:db8:2::0/64", "gw": "2001:db8:3::1"}
 		]
-    }
+	}
 }`, tmpDir, tmpDir)
 
 		args := &skel.CmdArgs{
@@ -117,12 +117,12 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("dummy"))
 
-		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.CgECAQ==")
+		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("10.1.2.2"))
 
-		lastFilePath2 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.IAENuAABAAAAAAAAAAAAAQ==")
+		lastFilePath2 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.1")
 		contents, err = ioutil.ReadFile(lastFilePath2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("2001:db8:1::2"))
@@ -147,15 +147,15 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.0",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.1.2.0/24",
-        "dataDir": "%s"
-    }
+	"cniVersion": "0.3.0",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.1.2.0/24",
+		"dataDir": "%s"
+	}
 }`, tmpDir)
 
 		args := &skel.CmdArgs{
@@ -184,16 +184,16 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.1.0",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.1.2.0/24",
-        "dataDir": "%s",
-	"resolvConf": "%s/resolv.conf"
-    }
+	"cniVersion": "0.1.0",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.1.2.0/24",
+		"dataDir": "%s",
+		"resolvConf": "%s/resolv.conf"
+	}
 }`, tmpDir, tmpDir)
 
 		args := &skel.CmdArgs{
@@ -224,7 +224,7 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("dummy"))
 
-		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip.CgECAQ==")
+		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("10.1.2.2"))
@@ -250,15 +250,15 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.1.2.0/24",
-        "dataDir": "%s"
-    }
+	"cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.1.2.0/24",
+		"dataDir": "%s"
+	}
 }`, tmpDir)
 
 		args := &skel.CmdArgs{
@@ -301,15 +301,15 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.2.0",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.1.2.0/24",
-        "dataDir": "%s"
-    }
+	"cniVersion": "0.2.0",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.1.2.0/24",
+		"dataDir": "%s"
+	}
 }`, tmpDir)
 
 		args := &skel.CmdArgs{
@@ -336,17 +336,17 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "dataDir": "%s",
+	"cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"dataDir": "%s",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24" }
+			[{ "subnet": "10.1.2.0/24" }]
 		]
-    },
+	},
 	"args": {
 		"cni": {
 			"ips": ["10.1.2.88"]
@@ -384,18 +384,18 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "dataDir": "%s",
+	"cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"dataDir": "%s",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24" },
-			{ "subnet": "10.1.3.0/24" }
+			[{ "subnet": "10.1.2.0/24" }],
+			[{ "subnet": "10.1.3.0/24" }]
 		]
-    },
+	},
 	"args": {
 		"cni": {
 			"ips": ["10.1.2.88", "10.1.3.77"]
@@ -434,18 +434,18 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "dataDir": "%s",
+	"cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"dataDir": "%s",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24" },
-			{ "subnet": "2001:db8:1::/24" }
+			[{"subnet":"172.16.1.0/24"}, { "subnet": "10.1.2.0/24" }],
+			[{ "subnet": "2001:db8:1::/24" }]
 		]
-    },
+	},
 	"args": {
 		"cni": {
 			"ips": ["10.1.2.88", "2001:db8:1::999"]
@@ -481,18 +481,18 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.3.1",
-    "name": "mynet",
-    "type": "ipvlan",
-    "master": "foo0",
-    "ipam": {
-        "type": "host-local",
-        "dataDir": "%s",
+	"cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "ipvlan",
+	"master": "foo0",
+	"ipam": {
+		"type": "host-local",
+		"dataDir": "%s",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24" },
-			{ "subnet": "10.1.3.0/24" }
+			[{ "subnet": "10.1.2.0/24" }],
+			[{ "subnet": "10.1.3.0/24" }]
 		]
-    },
+	},
 	"args": {
 		"cni": {
 			"ips": ["10.1.2.88", "10.1.2.77"]

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -66,13 +66,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		requestedIPs[ip.String()] = ip
 	}
 
-	for idx, ipRange := range ipamConf.Ranges {
-		allocator := allocator.NewIPAllocator(ipamConf.Name, ipRange, store)
+	for idx, rangeset := range ipamConf.Ranges {
+		allocator := allocator.NewIPAllocator(&rangeset, store, idx)
 
 		// Check to see if there are any custom IPs requested in this range.
 		var requestedIP net.IP
 		for k, ip := range requestedIPs {
-			if ipRange.IPInRange(ip) == nil {
+			if rangeset.Contains(ip) {
 				requestedIP = ip
 				delete(requestedIPs, k)
 				break
@@ -124,8 +124,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	// Loop through all ranges, releasing all IPs, even if an error occurs
 	var errors []string
-	for _, ipRange := range ipamConf.Ranges {
-		ipAllocator := allocator.NewIPAllocator(ipamConf.Name, ipRange, store)
+	for idx, rangeset := range ipamConf.Ranges {
+		ipAllocator := allocator.NewIPAllocator(&rangeset, store, idx)
 
 		err := ipAllocator.Release(args.ContainerID)
 		if err != nil {

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -94,14 +94,14 @@ const (
 	rangesStartStr = `,
         "ranges": [`
 	rangeSubnetConfStr = `
-            {
+            [{
                 "subnet":  "%s"
-            }`
+            }]`
 	rangeSubnetGWConfStr = `
-            {
+            [{
                 "subnet":  "%s",
                 "gateway": "%s"
-            }`
+            }]`
 	rangesEndStr = `
         ]`
 

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -155,8 +155,8 @@ var _ = Describe("ptp Operations", func() {
     "ipam": {
         "type": "host-local",
 		"ranges": [
-			{ "subnet": "10.1.2.0/24"},
-			{ "subnet": "2001:db8:1::0/66"}
+			[{ "subnet": "10.1.2.0/24"}],
+			[{ "subnet": "2001:db8:1::0/66"}]
 		]
     }
 }`


### PR DESCRIPTION
In real-world address allocations, disjoint address ranges are common. Therefore, the host-local allocator should support them.

This change still allows for multiple IPs in a single configuration, but also allows for a "set of subnets."

I'm not entirely happy with the configuration format - currently an array of arrays. I could be convinced to write a custom JSON deserializer that accepts either an array or a single object.

Fixes: #45