### PR TITLE
Don't run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
 
 script:
  - |
-   if [ "${TARGET}" == "amd64" ]; then
-     GOARCH="${TARGET}" ./test.sh
+   if [ "${TARGET}" == $( go env GOARCH ) ]; then
+     FASTBUILD=1 GOARCH="${TARGET}" ./test.sh
    else
      GOARCH="${TARGET}" ./build.sh
    fi

--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,7 @@ fi
 split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
 
-sudo -E bash -c "umask 0; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test ${TEST}"
+sudo -E bash -c "umask 0; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test ${TEST} -test.parallel 1"
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -l $FMT)


### PR DESCRIPTION
Go runs tests in parallel by default, one of the tests was switching namespaces.

Turn of parallelism.