### PR TITLE
Extend IPAM route types

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,38 +8,38 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/containernetworking/cni/libcni",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/invoke",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/skel",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/020",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/current",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/version",
-			"Comment": "v0.6.0-rc1",
-			"Rev": "a2da8f8d7fd8e6dc25f336408a8ac86f050fbd88"
+			"Comment": "v0.6.0-5-g1238e8f",
+			"Rev": "1238e8feab5e855dcac0f3f1851192e9f9e44a30"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-iptables/iptables",

--- a/pkg/ip/route_linux.go
+++ b/pkg/ip/route_linux.go
@@ -30,6 +30,15 @@ func AddRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
 	})
 }
 
+// AddBlockingRoute adds a universally-scoped blocking route.
+func AddBlockingRoute(ipn *net.IPNet, rtType int) error {
+	return netlink.RouteAdd(&netlink.Route{
+		Scope: netlink.SCOPE_UNIVERSE,
+		Dst:   ipn,
+		Type:  rtType,
+	})
+}
+
 // AddHostRoute adds a host-scoped route to a device.
 func AddHostRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
 	return netlink.RouteAdd(&netlink.Route{

--- a/vendor/github.com/containernetworking/cni/libcni/conf.go
+++ b/vendor/github.com/containernetworking/cni/libcni/conf.go
@@ -45,6 +45,9 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
 		return nil, fmt.Errorf("error parsing configuration: %s", err)
 	}
+	if conf.Network.Type == "" {
+		return nil, fmt.Errorf("error parsing configuration: missing 'type'")
+	}
 	return conf, nil
 }
 

--- a/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
@@ -172,13 +172,15 @@ func (r *Result) convertTo020() (*types020.Result, error) {
 		is4 := route.Dst.IP.To4() != nil
 		if is4 && oldResult.IP4 != nil {
 			oldResult.IP4.Routes = append(oldResult.IP4.Routes, types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
+				Dst:  route.Dst,
+				GW:   route.GW,
+				Type: route.Type,
 			})
 		} else if !is4 && oldResult.IP6 != nil {
 			oldResult.IP6.Routes = append(oldResult.IP6.Routes, types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
+				Dst:  route.Dst,
+				GW:   route.GW,
+				Type: route.Type,
 			})
 		}
 	}


### PR DESCRIPTION
### Summary
Only unicast routes are supported today via the IPAM `route` struct. This PR extends this by supporting other blocking route types. Related to PR https://github.com/containernetworking/cni/pull/498

### Details
The `type` field can be used to specify the following 'blocking' routes:
* unreachable
* blackhole
* prohibit

The `type` is inferred as `unicast` by default.

The following type's are not supported:
* local
* broadcast
* throw
* nat
* anycast
* multicast

Example:
```
{
  ...
  "ipam": {
    "type": "host-local",
    "subnet": "10.22.0.0/16",
    "routes": [
      { "dst": "0.0.0.0/0" },
      { "dst": "169.254.169.254/32", "type":"blackhole" }
    ]
  }
}
```

### Testing
Test suite passed (mostly; macvlan suite always fails on ec2). Tested locally that I can add a `blackhole` route. 

```
$ cat /etc/cni/net.d/10-mynet.conf
{
        "cniVersion": "0.3.0",
        "name": "mynet",
        "type": "bridge",
        "bridge": "cni0",
        "isGateway": true,
        "ipMasq": true,
        "ipam": {
                "type": "host-local",
                "subnet": "10.22.0.0/16",
                "routes": [
                        { "dst": "0.0.0.0/0" },
                        { "dst": "169.254.169.254/32", "type":"blackhole" }
                ]
        }
}
$ sudo CNI_PATH=$CNI_PATH ./docker-run.sh busybox ip route show
default via 10.22.0.1 dev eth0
10.22.0.0/16 dev eth0 scope link  src 10.22.0.37
blackhole 169.254.169.254

$ ./test.sh 2>&1 | tee test.log
Building plugins
  flannel
  portmap
  tuning
  bridge
  ipvlan
  loopback
  macvlan
  ptp
  vlan
  dhcp
  host-local
  sample
Running tests
ok      github.com/containernetworking/plugins/plugins/ipam/dhcp        0.008s
ok      github.com/containernetworking/plugins/plugins/ipam/host-local  0.021s
ok      github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator        0.078s
ok      github.com/containernetworking/plugins/plugins/main/loopback    4.969s
ok      github.com/containernetworking/plugins/plugins/main/ipvlan      2.804s
Running Suite: macvlan Suite
============================
Random Seed: 1503423448
Will run 3 of 3 specs

• Failure [0.042 seconds]
macvlan Operations
/home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:226
  creates an macvlan link in a non-default namespace [It]
  /home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:101

  Expected error:
      <*errors.errorString | 0xc820166060>: {
          s: "failed to create macvlan: operation not supported",
      }
      failed to create macvlan: operation not supported
  not to have occurred

  /home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:86
------------------------------
• Failure [0.236 seconds]
macvlan Operations
/home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:226
  configures and deconfigures a macvlan link with ADD/DEL [It]
  /home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:187

  Expected error:
      <*errors.errorString | 0xc820167340>: {
          s: "failed to create macvlan: operation not supported",
      }
      failed to create macvlan: operation not supported
  not to have occurred

  /home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:135
------------------------------
•

Summarizing 2 Failures:

[Fail] macvlan Operations [It] creates an macvlan link in a non-default namespace
/home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:86

[Fail] macvlan Operations [It] configures and deconfigures a macvlan link with ADD/DEL
/home/ec2-user/workspace/src/github.com/containernetworking/plugins/gopath/src/github.com/containernetworking/plugins/plugins/main/macvlan/macvlan_test.go:135

Ran 3 of 3 Specs in 0.570 seconds
FAIL! -- 1 Passed | 2 Failed | 0 Pending | 0 Skipped --- FAIL: TestMacvlan (0.57s)
FAIL
FAIL    github.com/containernetworking/plugins/plugins/main/macvlan     0.574s
ok      github.com/containernetworking/plugins/plugins/main/bridge      19.009s
ok      github.com/containernetworking/plugins/plugins/main/ptp 5.702s
ok      github.com/containernetworking/plugins/plugins/meta/flannel     3.070s
ok      github.com/containernetworking/plugins/plugins/main/vlan        0.711s
ok      github.com/containernetworking/plugins/plugins/sample   0.854s
ok      github.com/containernetworking/plugins/pkg/ip   2.544s
ok      github.com/containernetworking/plugins/pkg/ipam 2.648s
ok      github.com/containernetworking/plugins/pkg/ns   3.745s
ok      github.com/containernetworking/plugins/pkg/utils        0.003s
ok      github.com/containernetworking/plugins/pkg/utils/hwaddr 0.004s
?       github.com/containernetworking/plugins/pkg/utils/sysctl [no test files]
ok      github.com/containernetworking/plugins/plugins/meta/portmap     2.031s
```