### PR TITLE
travis: run with ginkgo -p instead of go test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 
 env:
   global:
-  - PATH=$GOROOT/bin:$PATH
+  - PATH=$GOROOT/bin:$GOPATH/bin:$PATH
   matrix:
   - TARGET=amd64
   - TARGET=arm
@@ -18,6 +18,9 @@ env:
 
 matrix:
   fast_finish: true
+
+install:
+  - go get github.com/onsi/ginkgo/ginkgo
 
 script:
  - |


### PR DESCRIPTION
may help reduce test-pollution due to namespace-affinity

see http://onsi.github.io/ginkgo/#parallel-specs

ref: https://github.com/containernetworking/plugins/pull/56#issuecomment-325675507

cc: @squeed 