### PR TITLE
host-local FileLock is used by value instead of by reference

### DIFF
--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -31,7 +31,7 @@ var defaultDataDir = "/var/lib/cni/networks"
 // Store is a simple disk-backed store that creates one file per IP
 // address in a given directory. The contents of the file are the container ID.
 type Store struct {
-	FileLock
+	*FileLock
 	dataDir string
 }
 
@@ -51,7 +51,7 @@ func New(network, dataDir string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Store{*lk, dir}, nil
+	return &Store{lk, dir}, nil
 }
 
 func (s *Store) Reserve(id string, ip net.IP, rangeID string) (bool, error) {

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ source ./build.sh
 
 echo "Running tests"
 
-TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/main/loopback plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/meta/flannel plugins/main/vlan plugins/sample pkg/ip pkg/ipam pkg/ns pkg/utils pkg/utils/hwaddr pkg/utils/sysctl plugins/meta/portmap"
+TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/ipam/host-local/backend/disk plugins/main/loopback plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/meta/flannel plugins/main/vlan plugins/sample pkg/ip pkg/ipam pkg/ns pkg/utils pkg/utils/hwaddr pkg/utils/sysctl plugins/meta/portmap"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
Without this change

```
go vet ./plugins/ipam/host-local/backend/disk
```

returns
```
plugins/ipam/host-local/backend/disk/backend.go:54: literal copies lock value from *lk: disk.FileLock
exit status 1
```

see the [go vet heuristic here](https://github.com/golang/go/blob/d77d4f509c61a8e1eaadeabca86ee48710bd8030/src/cmd/vet/copylock.go#L230-L232).