### PR TITLE
Test all packages

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,10 @@ source ./build.sh
 
 echo "Running tests"
 
-TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/ipam/host-local/backend/disk plugins/main/loopback plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/meta/flannel plugins/main/vlan plugins/sample pkg/ip pkg/ipam pkg/ns pkg/utils pkg/utils/hwaddr pkg/utils/sysctl plugins/meta/portmap"
+# test everything that's not in vendor
+pushd "$GOPATH/src/$REPO_PATH" >/dev/null
+  TESTABLE="$(go list ./... | grep -v vendor | xargs echo)"
+popd >/dev/null
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
@@ -25,16 +28,12 @@ else
 	FMT="$TEST"
 fi
 
-# split TEST into an array and prepend REPO_PATH to each local package
-split=(${TEST// / })
-TEST=${split[@]/#/${REPO_PATH}/}
-
 sudo -E bash -c "umask 0; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test ${TEST}"
 
 echo "Checking gofmt..."
-fmtRes=$(gofmt -l $FMT)
+fmtRes=$(go fmt $FMT)
 if [ -n "${fmtRes}" ]; then
-	echo -e "gofmt checking failed:\n${fmtRes}"
+	echo -e "go fmt checking failed:\n${fmtRes}"
 	exit 255
 fi
 


### PR DESCRIPTION
~~Don't merge yet, this depends on:~~

~~- #65: Upgrade to Go 1.9 so that we get the benefits of [ignoring `vendor` by default](https://golang.org/doc/go1.9#vendor-dotdotdot)~~ 
*Removed this requirement*

~~- #66: fix up lingering `go vet` warnings~~
*DONE*

**UPDATE**: no longer depends on Go 1.9, this is good-to-go as is.
