### PR TITLE
portmap integration test: echo server runs in separate process

### DIFF
--- a/plugins/meta/portmap/echosvr/echosvr_test.go
+++ b/plugins/meta/portmap/echosvr/echosvr_test.go
@@ -1,0 +1,74 @@
+package main_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var binaryPath string
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	binaryPath, err := gexec.Build("github.com/containernetworking/plugins/plugins/meta/portmap/echosvr")
+	Expect(err).NotTo(HaveOccurred())
+	return []byte(binaryPath)
+}, func(data []byte) {
+	binaryPath = string(data)
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})
+
+var _ = Describe("Echosvr", func() {
+	var session *gexec.Session
+	BeforeEach(func() {
+		var err error
+		cmd := exec.Command(binaryPath)
+		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		session.Terminate().Wait()
+	})
+
+	It("starts and doesn't terminate immediately", func() {
+		Consistently(session).ShouldNot(gexec.Exit())
+	})
+
+	tryConnect := func() (net.Conn, error) {
+		programOutput := session.Out.Contents()
+		addr := strings.TrimSpace(string(programOutput))
+
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return conn, err
+	}
+
+	It("prints its listening address to stdout", func() {
+		Eventually(session.Out).Should(gbytes.Say("\n"))
+		conn, err := tryConnect()
+		Expect(err).NotTo(HaveOccurred())
+		conn.Close()
+	})
+
+	It("will echo data back to us", func() {
+		Eventually(session.Out).Should(gbytes.Say("\n"))
+		conn, err := tryConnect()
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		fmt.Fprintf(conn, "hello")
+		Expect(ioutil.ReadAll(conn)).To(Equal([]byte("hello")))
+	})
+})

--- a/plugins/meta/portmap/echosvr/init_test.go
+++ b/plugins/meta/portmap/echosvr/init_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestEchosvr(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Echosvr Suite")
+}

--- a/plugins/meta/portmap/echosvr/main.go
+++ b/plugins/meta/portmap/echosvr/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func main() {
+	listener, err := net.Listen("tcp", ":")
+	if err != nil {
+		panic(err)
+	}
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("127.0.0.1:%s\n", port)
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			panic(err)
+		}
+		go handleConnection(conn)
+	}
+}
+
+func handleConnection(conn net.Conn) {
+	buf := make([]byte, 512)
+	nBytesRead, _ := conn.Read(buf)
+	conn.Write(buf[0:nBytesRead])
+	conn.Close()
+}


### PR DESCRIPTION
this way we're not mixing goroutines and namespaces


when running 
```
ginkgo -untilItFails -timeout 3s -p
```
with the single integration spec focused, it used to fail after about 5 runs.  with this change, i got 95 successes in a row.


however, this won't fix everything.   when I unfocus the integration spec, I still get failures due to namespace affinity, but now after about 10 runs.


~~UPDATE: travis says `"nsenter": executable file not found in $PATH` :-(~~

Update: it's green! 🍏 💚 🥗 !