### PR TITLE
Newly added `host-device` doesn't compile.

### DIFF
--- a/plugins/host-device/host-device.go
+++ b/plugins/host-device/host-device.go
@@ -24,9 +24,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/host-device/host-device_test.go
+++ b/plugins/host-device/host-device_test.go
@@ -15,9 +15,9 @@
 package main
 
 import (
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/testutils"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"


### PR DESCRIPTION
`host-device` is using non-exist packages.

Signed-off-by: Lantao Liu <lantaol@google.com>