### PR TITLE
Host-device fixes

### DIFF
--- a/plugins/host-device/host-device.go
+++ b/plugins/host-device/host-device.go
@@ -24,9 +24,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/host-device/host-device.go
+++ b/plugins/host-device/host-device.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -64,6 +65,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer containerNs.Close()
+	defer (&current.Result{}).Print()
 	return addLink(cfg.Device, cfg.HWAddr, cfg.KernelPath, containerNs)
 }
 
@@ -77,6 +79,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer containerNs.Close()
+	defer fmt.Println(`{}`)
 	return removeLink(cfg.Device, cfg.HWAddr, cfg.KernelPath, containerNs)
 }
 

--- a/plugins/host-device/host-device.go
+++ b/plugins/host-device/host-device.go
@@ -115,9 +115,7 @@ func getLink(devname, hwaddr, kernelpath string) (netlink.Link, error) {
 	}
 
 	if len(devname) > 0 {
-		if m, err := netlink.LinkByName(devname); err == nil {
-			return m, nil
-		}
+		return netlink.LinkByName(devname)
 	} else if len(hwaddr) > 0 {
 		hwAddr, err := net.ParseMAC(hwaddr)
 		if err != nil {

--- a/plugins/host-device/host-device_test.go
+++ b/plugins/host-device/host-device_test.go
@@ -15,6 +15,9 @@
 package main
 
 import (
+	"fmt"
+	"math/rand"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
@@ -23,15 +26,16 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-var ifname = "dummy0"
-
 var _ = Describe("base functionality", func() {
 	var originalNS ns.NetNS
+	var ifname string
 
 	BeforeEach(func() {
 		var err error
 		originalNS, err = ns.NewNS()
 		Expect(err).NotTo(HaveOccurred())
+
+		ifname = fmt.Sprintf("dummy-%x", rand.Int31())
 	})
 
 	AfterEach(func() {
@@ -61,19 +65,23 @@ var _ = Describe("base functionality", func() {
 		targetNS, err := ns.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		conf := `{
+		conf := fmt.Sprintf(`{
 			"cniVersion": "0.3.0",
 			"name": "cni-plugin-host-device-test",
 			"type": "host-device",
-			"device": ifname
-		}`
+			"device": %q
+		}`, ifname)
 		args := &skel.CmdArgs{
 			ContainerID: "dummy",
 			Netns:       targetNS.Path(),
 			IfName:      ifname,
 			StdinData:   []byte(conf),
 		}
-		_, _, err = testutils.CmdAddWithResult(targetNS.Path(), ifname, []byte(conf), func() error { return cmdAdd(args) })
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			_, _, err := testutils.CmdAddWithResult(targetNS.Path(), ifname, []byte(conf), func() error { return cmdAdd(args) })
+			return err
+		})
 		Expect(err).NotTo(HaveOccurred())
 
 		// assert that dummy0 is now in the target namespace

--- a/plugins/host-device/host-device_test.go
+++ b/plugins/host-device/host-device_test.go
@@ -15,9 +15,9 @@
 package main
 
 import (
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/testutils"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"


### PR DESCRIPTION
Fixes errors in the `host-device` plugin, and its test, which were introduced in #3.

Includes change from #73.

@containernetworking/cni-maintainers a couple other issues that I encountered while fixing this:
- should this plugin, and loopback, go to the trouble of returning a `cniVersion` that matches the config version?  Since neither one returns any kind of interesting result, I say no.  But its technically a spec violation...
- what should be the meaning of the `CNI_IFNAME` environment variable in this plugin?    The plugin ignores it today... but it could potentially substitute for the `device` config field.

Anyhow, this should at least get CI green again.