### PR TITLE
Don't let DHCP IPAM plugin fail on missing lease

### DIFF
--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -91,10 +91,9 @@ func (d *DHCP) Release(args *skel.CmdArgs, reply *struct{}) error {
 
 	if l := d.getLease(args.ContainerID, conf.Name); l != nil {
 		l.Stop()
-		return nil
 	}
 
-	return fmt.Errorf("lease not found: %v/%v", args.ContainerID, conf.Name)
+	return nil
 }
 
 func (d *DHCP) getLease(contID, netName string) *DHCPLease {


### PR DESCRIPTION
There are at least two reasons why a lease is not present:

 * The dhcp ipam daemon was restarted
 * ON add the IPAM plugin failed

Don't fail the IPAM invocation when the lease is not present, to allow
proper device cleanup on CNI delete invocations.