### PR TITLE
portmap: support hairpin, improve performance

### DIFF
--- a/plugins/meta/portmap/chain.go
+++ b/plugins/meta/portmap/chain.go
@@ -25,12 +25,14 @@ import (
 type chain struct {
 	table       string
 	name        string
-	entryRule   []string // the rule that enters this chain
 	entryChains []string // the chains to add the entry rule
+
+	entryRules [][]string // the rules that "point" to this chain
+	rules      [][]string // the rules this chain contains
 }
 
 // setup idempotently creates the chain. It will not error if the chain exists.
-func (c *chain) setup(ipt *iptables.IPTables, rules [][]string) error {
+func (c *chain) setup(ipt *iptables.IPTables) error {
 	// create the chain
 	exists, err := chainExists(ipt, c.table, c.name)
 	if err != nil {
@@ -43,17 +45,21 @@ func (c *chain) setup(ipt *iptables.IPTables, rules [][]string) error {
 	}
 
 	// Add the rules to the chain
-	for i := len(rules) - 1; i >= 0; i-- {
-		if err := prependUnique(ipt, c.table, c.name, rules[i]); err != nil {
+	for i := len(c.rules) - 1; i >= 0; i-- {
+		if err := prependUnique(ipt, c.table, c.name, c.rules[i]); err != nil {
 			return err
 		}
 	}
 
-	// Add the entry rules
-	entryRule := append(c.entryRule, "-j", c.name)
+	// Add the entry rules to the entry chains
 	for _, entryChain := range c.entryChains {
-		if err := prependUnique(ipt, c.table, entryChain, entryRule); err != nil {
-			return err
+		for i := len(c.entryRules) - 1; i >= 0; i-- {
+			r := []string{}
+			r = append(r, c.entryRules[i]...)
+			r = append(r, "-j", c.name)
+			if err := prependUnique(ipt, c.table, entryChain, r); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/plugins/meta/portmap/chain_test.go
+++ b/plugins/meta/portmap/chain_test.go
@@ -49,8 +49,12 @@ var _ = Describe("chain tests", func() {
 		testChain = chain{
 			table:       TABLE,
 			name:        chainName,
-			entryRule:   []string{"-d", "203.0.113.1"},
 			entryChains: []string{tlChainName},
+			entryRules:  [][]string{{"-d", "203.0.113.1"}},
+			rules: [][]string{
+				{"-m", "comment", "--comment", "test 1", "-j", "RETURN"},
+				{"-m", "comment", "--comment", "test 2", "-j", "RETURN"},
+			},
 		}
 
 		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv4)
@@ -90,11 +94,7 @@ var _ = Describe("chain tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create the chain
-		chainRules := [][]string{
-			{"-m", "comment", "--comment", "test 1", "-j", "RETURN"},
-			{"-m", "comment", "--comment", "test 2", "-j", "RETURN"},
-		}
-		err = testChain.setup(ipt, chainRules)
+		err = testChain.setup(ipt)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify the chain exists
@@ -151,15 +151,11 @@ var _ = Describe("chain tests", func() {
 	It("creates chains idempotently", func() {
 		defer cleanup()
 
-		// Create the chain
-		chainRules := [][]string{
-			{"-m", "comment", "--comment", "test", "-j", "RETURN"},
-		}
-		err := testChain.setup(ipt, chainRules)
+		err := testChain.setup(ipt)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create it again!
-		err = testChain.setup(ipt, chainRules)
+		err = testChain.setup(ipt)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make sure there are only two rules
@@ -167,18 +163,14 @@ var _ = Describe("chain tests", func() {
 		rules, err := ipt.List(TABLE, testChain.name)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(len(rules)).To(Equal(2))
+		Expect(len(rules)).To(Equal(3))
 
 	})
 
 	It("deletes chains idempotently", func() {
 		defer cleanup()
 
-		// Create the chain
-		chainRules := [][]string{
-			{"-m", "comment", "--comment", "test", "-j", "RETURN"},
-		}
-		err := testChain.setup(ipt, chainRules)
+		err := testChain.setup(ipt)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = testChain.teardown(ipt)

--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"time"
+	"strconv"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -124,12 +126,19 @@ var _ = Describe("portmap integration tests", func() {
 		// we'll also manually check the iptables chains
 		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 		Expect(err).NotTo(HaveOccurred())
-		dnatChainName := genDnatChain("cni-portmap-unit-test", runtimeConfig.ContainerID, nil).name
+		dnatChainName := genDnatChain("cni-portmap-unit-test", runtimeConfig.ContainerID).name
 
 		// Create the network
 		resI, err := cniConf.AddNetworkList(configList, &runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
 		defer deleteNetwork()
+
+		// Undo Docker's forwarding policy
+		cmd := exec.Command("iptables", "-t", "filter",
+			"-P", "FORWARD", "ACCEPT")
+		cmd.Stderr = GinkgoWriter
+		err = cmd.Run()
+		Expect(err).NotTo(HaveOccurred())
 
 		// Check the chain exists
 		_, err = ipt.List("nat", dnatChainName)
@@ -155,13 +164,16 @@ var _ = Describe("portmap integration tests", func() {
 			hostIP, hostPort, contIP, containerPort)
 
 		// Sanity check: verify that the container is reachable directly
-		contOK := testEchoServer(fmt.Sprintf("%s:%d", contIP.String(), containerPort))
+		contOK := testEchoServer(contIP.String(), containerPort, "")
 
 		// Verify that a connection to the forwarded port works
-		dnatOK := testEchoServer(fmt.Sprintf("%s:%d", hostIP, hostPort))
+		dnatOK := testEchoServer(hostIP, hostPort, "")
 
 		// Verify that a connection to localhost works
-		snatOK := testEchoServer(fmt.Sprintf("%s:%d", "127.0.0.1", hostPort))
+		snatOK := testEchoServer("127.0.0.1", hostPort, "")
+
+		// verify that hairpin works
+		hairpinOK := testEchoServer(hostIP, hostPort, targetNS.Path())
 
 		// Cleanup
 		session.Terminate()
@@ -182,6 +194,9 @@ var _ = Describe("portmap integration tests", func() {
 		if !snatOK {
 			Fail("connection to 127.0.0.1 was not forwarded")
 		}
+		if !hairpinOK {
+			Fail("Hairpin connection failed")
+		}
 
 		close(done)
 
@@ -189,40 +204,33 @@ var _ = Describe("portmap integration tests", func() {
 })
 
 // testEchoServer returns true if we found an echo server on the port
-func testEchoServer(address string) bool {
-	fmt.Fprintln(GinkgoWriter, "dialing", address)
-	conn, err := net.Dial("tcp", address)
-	if err != nil {
-		fmt.Fprintln(GinkgoWriter, "connection to", address, "failed:", err)
-		return false
-	}
-	defer conn.Close()
-
-	conn.SetDeadline(time.Now().Add(TIMEOUT * time.Second))
-	fmt.Fprintln(GinkgoWriter, "connected to", address)
-
+func testEchoServer(address string, port int, netns string) bool {
 	message := "Aliquid melius quam pessimum optimum non est."
-	_, err = fmt.Fprint(conn, message)
+
+	bin, err := exec.LookPath("nc")
+	Expect(err).NotTo(HaveOccurred())
+	var cmd *exec.Cmd
+	if netns != "" {
+		netns = filepath.Base(netns)
+		cmd = exec.Command("ip", "netns", "exec", netns, bin, "-v", address, strconv.Itoa(port))
+	} else {
+		cmd = exec.Command("nc", address, strconv.Itoa(port))
+	}
+	cmd.Stdin = bytes.NewBufferString(message)
+	cmd.Stderr = GinkgoWriter
+	out, err := cmd.Output()
 	if err != nil {
-		fmt.Fprintln(GinkgoWriter, "sending message to", address, " failed:", err)
+		fmt.Fprintln(GinkgoWriter, "got non-zero exit from ", cmd.Args)
 		return false
 	}
 
-	conn.SetDeadline(time.Now().Add(TIMEOUT * time.Second))
-	fmt.Fprintln(GinkgoWriter, "reading...")
-	response := make([]byte, len(message))
-	_, err = conn.Read(response)
-	if err != nil {
-		fmt.Fprintln(GinkgoWriter, "receiving message from", address, " failed:", err)
+	if string(out) != message {
+		fmt.Fprintln(GinkgoWriter, "returned message didn't match?")
+		fmt.Fprintln(GinkgoWriter, string(out))
 		return false
 	}
 
-	fmt.Fprintln(GinkgoWriter, "read...")
-	if string(response) == message {
-		return true
-	}
-	fmt.Fprintln(GinkgoWriter, "returned message didn't match?")
-	return false
+	return true
 }
 
 func getLocalIP() string {


### PR DESCRIPTION
This change improves the performance of the portmap plugin and fixes hairpin, when a container is mapped back to itself.

Performance is improved by using a multiport test to reduce rule traversal, and by using a masquerade mark.

Hairpin is fixed by enabling masquerading for hairpin traffic.

Fixes: #68