### PR TITLE
pkg/ip: don't return error from DelLinkByNameAddr() if no addresses exist

### DIFF
--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -182,7 +182,7 @@ func DelLinkByNameAddr(ifName string) ([]*net.IPNet, error) {
 	}
 
 	addrs, err := netlink.AddrList(iface, netlink.FAMILY_ALL)
-	if err != nil || len(addrs) == 0 {
+	if err != nil {
 		return nil, fmt.Errorf("failed to get IP addresses for %q: %v", ifName, err)
 	}
 


### PR DESCRIPTION
For some reason no addresses on the interface returned an error, despite
having a testcase that explicitly tested for success.

@containernetworking/cni-maintainers 