### PR TITLE
ipam/host-local: Accept ip ranges as a runtime argument

### DIFF
--- a/plugins/ipam/host-local/README.md
+++ b/plugins/ipam/host-local/README.md
@@ -120,6 +120,10 @@ The following [args conventions](https://github.com/containernetworking/cni/blob
 
 * `ips` (array of strings): A list of custom IPs to attempt to allocate
 
+The following [Capability Args](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md) are supported:
+
+* `ipRanges`: The exact same as the `ranges` array - a list of address pools
+
 ### Custom IP allocation
 For every requested custom IP, the `host-local` allocator will request that IP
 if it falls within one of the `range` objects. Thus it is possible to specify

--- a/plugins/ipam/host-local/backend/allocator/config_test.go
+++ b/plugins/ipam/host-local/backend/allocator/config_test.go
@@ -132,12 +132,18 @@ var _ = Describe("IPAM config", func() {
 		}))
 	})
 
-	It("Should parse a mixed config", func() {
+	It("Should parse a mixed config with runtime args", func() {
 		input := `{
 			"cniVersion": "0.3.1",
 			"name": "mynet",
 			"type": "ipvlan",
 			"master": "foo0",
+			"runtimeConfig": {
+				"irrelevant": "a",
+				"ipRanges": [
+					[{ "subnet": "12.1.3.0/24" }]
+				]
+			},
 			"ipam": {
 				"type": "host-local",
 				"subnet": "10.1.2.0/24",
@@ -162,6 +168,17 @@ var _ = Describe("IPAM config", func() {
 			Name: "mynet",
 			Type: "host-local",
 			Ranges: []RangeSet{
+				{ // The RuntimeConfig should always be first
+					{
+						RangeStart: net.IP{12, 1, 3, 1},
+						RangeEnd:   net.IP{12, 1, 3, 254},
+						Gateway:    net.IP{12, 1, 3, 1},
+						Subnet: types.IPNet{
+							IP:   net.IP{12, 1, 3, 0},
+							Mask: net.CIDRMask(24, 32),
+						},
+					},
+				},
 				{
 					{
 						RangeStart: net.IP{10, 1, 2, 9},


### PR DESCRIPTION
This allows for the runtime to dynamically request IP ranges.

Fixes: #95