### PR TITLE
pkg/ipam: Skip ip.SettleAddresses if only IPv4 is used

### DIFF
--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -65,7 +65,9 @@ func ConfigureIface(ifName string, res *current.Result) error {
 		}
 	}
 
-	ip.SettleAddresses(ifName, 10)
+	if v6gw != nil {
+		ip.SettleAddresses(ifName, 10)
+	}
 
 	for _, r := range res.Routes {
 		routeIsV4 := r.Dst.IP.To4() != nil


### PR DESCRIPTION
This change improves the performance of the ipam.ConfigureIface.
Some plugins are slow because of the ip.SettleAddress in ipam.ConfigureIface.
It seems to be only needed for IPv6, so should be skipped if only IPv4 is used.