### PR TITLE
pkg/ip: don't write to /proc/sys if ipforward enabled

### DIFF
--- a/pkg/ip/ipforward_linux.go
+++ b/pkg/ip/ipforward_linux.go
@@ -15,6 +15,7 @@
 package ip
 
 import (
+	"bytes"
 	"io/ioutil"
 
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -51,5 +52,10 @@ func EnableForward(ips []*current.IPConfig) error {
 }
 
 func echo1(f string) error {
+	if content, err := ioutil.ReadFile(f); err == nil {
+		if bytes.Equal(bytes.TrimSpace(content), []byte("1")) {
+			return nil
+		}
+	}
 	return ioutil.WriteFile(f, []byte("1"), 0644)
 }

--- a/pkg/ip/ipforward_linux_test.go
+++ b/pkg/ip/ipforward_linux_test.go
@@ -1,0 +1,31 @@
+package ip
+
+import (
+	"io/ioutil"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IpforwardLinux", func() {
+	It("echo1 must not write the file if content is 1", func() {
+		file, err := ioutil.TempFile(os.TempDir(), "containernetworking")
+		defer os.Remove(file.Name())
+		err = echo1(file.Name())
+		Expect(err).NotTo(HaveOccurred())
+		statBefore, err := file.Stat()
+		Expect(err).NotTo(HaveOccurred())
+
+		// take a duration here, otherwise next file modification operation time
+		// will be same as previous one.
+		time.Sleep(100 * time.Millisecond)
+
+		err = echo1(file.Name())
+		Expect(err).NotTo(HaveOccurred())
+		statAfter, err := file.Stat()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(statBefore.ModTime()).To(Equal(statAfter.ModTime()))
+	})
+})


### PR DESCRIPTION
This enables setup in a container env like systemd nspawn
where /proc/sys is mouted as read only.

Signed-off-by: Shengjing Zhu <i@zhsj.me>