### PR TITLE
travis: bump golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 env:
   global:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
     apt-get update -y || (sleep 40 && apt-get update -y)
     apt-get install -y git
 
-    wget -qO- https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+    wget -qO- https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz | tar -C /usr/local -xz
 
     echo 'export GOPATH=/go' >> /root/.bashrc
     echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> /root/.bashrc


### PR DESCRIPTION
- test against Go 1.10
- stop testing against Go 1.8

since Go language maintainers no longer support 1.8
see: https://golang.org/doc/devel/release.html#policy

see also: https://github.com/containernetworking/cni/pull/538