### PR TITLE
allow building with custom Go binary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ fi
 
 export GO15VENDOREXPERIMENT=1
 export GOPATH=${PWD}/gopath
+export GO="${GO:-go}"
 
 mkdir -p "${PWD}/bin"
 
@@ -27,9 +28,9 @@ for d in $PLUGINS; do
 		# use go install so we don't duplicate work
 		if [ -n "$FASTBUILD" ]
 		then
-			GOBIN=${PWD}/bin go install -pkgdir $GOPATH/pkg "$@" $REPO_PATH/$d
+			GOBIN=${PWD}/bin $GO install -pkgdir $GOPATH/pkg "$@" $REPO_PATH/$d
 		else
-			go build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d"
+			$GO build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d"
 		fi
 	fi
 done


### PR DESCRIPTION
I need to build deb packages using golang-1.10 on Ubuntu Xenial which is
present in a non-default location while /usr/bin/go is at golang-1.6.

With this commit I can simply run:
`GO=/usr/lib/go-1.10/bin/go ./build.sh`
to use golang-1.10.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>