### PR TITLE
traffic shaping: take configuration via a runtimeConfig

### DIFF
--- a/integration/testdata/chained-bridge-bandwidth/network-chain-test.conflist
+++ b/integration/testdata/chained-bridge-bandwidth/network-chain-test.conflist
@@ -14,10 +14,14 @@
         },
         {
             "type": "bandwidth",
-            "ingressRate": 8000,
-            "ingressBurst": 16000,
-            "egressRate": 8000,
-            "egressBurst": 16000
+            "runtimeConfig": {
+                "bandWidth": {
+                    "ingressRate": 8000,
+                    "ingressBurst": 16000,
+                    "egressRate": 8000,
+                    "egressBurst": 16000
+                }
+            }
         }
     ]
 }

--- a/integration/testdata/chained-ptp-bandwidth.conflist
+++ b/integration/testdata/chained-ptp-bandwidth.conflist
@@ -13,10 +13,14 @@
         },
         {
             "type": "bandwidth",
-            "ingressRate": 800,
-            "ingressBurst": 200,
-            "egressRate": 800,
-            "egressBurst": 200
+            "runtimeConfig": {
+                "bandWidth": {
+                    "ingressRate": 800,
+                    "ingressBurst": 200,
+                    "egressRate": 800,
+                    "egressBurst": 200
+                }
+            }
         }
     ]
 }

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -77,10 +77,14 @@ var _ = Describe("bandwidth test", func() {
 	"cniVersion": "0.3.0",
 	"name": "cni-plugin-bandwidth-test",
 	"type": "bandwidth",
-	"ingressRate": 8,
-	"ingressBurst": 8,
-	"egressRate": 16,
-	"egressBurst": 9,
+	"runtimeConfig": {
+		"bandWidth": {
+			"ingressRate": 8,
+			"ingressBurst": 8,
+			"egressRate": 16,
+			"egressBurst": 9
+		}
+	},
 	"prevResult": {
 		"interfaces": [
 			{
@@ -174,10 +178,14 @@ var _ = Describe("bandwidth test", func() {
 	"cniVersion": "0.3.0",
 	"name": "cni-plugin-bandwidth-test",
 	"type": "bandwidth",
-	"ingressRate": 0,
-	"ingressBurst": 0,
-	"egressRate": 8,
-	"egressBurst": 1,
+	"runtimeConfig": {
+		"bandWidth": {
+			"ingressRate": 0,
+			"ingressBurst": 0,
+			"egressRate": 8,
+			"egressBurst": 1
+		}
+	},
 	"prevResult": {
 		"interfaces": [
 			{
@@ -243,10 +251,14 @@ var _ = Describe("bandwidth test", func() {
 	"cniVersion": "0.3.0",
 	"name": "cni-plugin-bandwidth-test",
 	"type": "bandwidth",
-	"egressRate": 0,
-	"egressBurst": 0,
-	"ingressRate": 8,
-	"ingressBurst": 1,
+	"runtimeConfig": {
+		"bandWidth": {
+			"egressRate": 0,
+			"egressBurst": 0,
+			"ingressRate": 8,
+			"ingressBurst": 1
+		}
+	},
 	"prevResult": {
 		"interfaces": [
 			{
@@ -314,10 +326,14 @@ var _ = Describe("bandwidth test", func() {
 	"cniVersion": "0.3.0",
 	"name": "cni-plugin-bandwidth-test",
 	"type": "bandwidth",
-	"ingressRate": 0,
-	"ingressBurst": 123,
-	"egressRate": 123,
-	"egressBurst": 123,
+	"runtimeConfig": {
+		"bandWidth": {
+			"ingressRate": 0,
+			"ingressBurst": 123,
+			"egressRate": 123,
+			"egressBurst": 123
+		}
+	},
 	"prevResult": {
 		"interfaces": [
 			{
@@ -366,10 +382,14 @@ var _ = Describe("bandwidth test", func() {
 	"cniVersion": "0.3.0",
 	"name": "cni-plugin-bandwidth-test",
 	"type": "bandwidth",
-	"ingressRate": 8,
-	"ingressBurst": 8,
-	"egressRate": 9,
-	"egressBurst": 9,
+	"runtimeConfig": {
+		"bandWidth": {
+			"ingressRate": 8,
+			"ingressBurst": 8,
+			"egressRate": 9,
+			"egressBurst": 9
+		}
+	},
 	"prevResult": {
 		"interfaces": [
 			{
@@ -484,7 +504,8 @@ var _ = Describe("bandwidth test", func() {
 				containerWithTbfResult, err := current.GetResult(containerWithTbfRes)
 				Expect(err).NotTo(HaveOccurred())
 
-				tbfPluginConf := PluginConf{
+				tbfPluginConf := PluginConf{}
+				tbfPluginConf.RuntimeConfig.BandWidth = &BandWidthEntry{
 					IngressBurst: burstInBits,
 					IngressRate:  rateInBits,
 					EgressBurst:  burstInBits,

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -17,30 +17,39 @@ package main
 import (
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-
-	"errors"
 	"github.com/containernetworking/plugins/pkg/ip"
+
 	"github.com/vishvananda/netlink"
 )
 
-type PluginConf struct {
-	types.NetConf
-	RuntimeConfig *struct{} `json:"runtimeConfig"`
-
-	RawPrevResult *map[string]interface{} `json:"prevResult"`
-	PrevResult    *current.Result         `json:"-"`
-
+// BandWidthEntry corresponds to a single entry in the bandwidth argument,
+// see CONVENTIONS.md
+type BandWidthEntry struct {
 	IngressRate  int `json:"ingressRate"`  //Bandwidth rate in Kbps for traffic through container. 0 for no limit. If ingressRate is set, ingressBurst must also be set
 	IngressBurst int `json:"ingressBurst"` //Bandwidth burst in Kb for traffic through container. 0 for no limit. If ingressBurst is set, ingressRate must also be set
 
 	EgressRate  int `json:"egressRate"`  //Bandwidth rate in Kbps for traffic through container. 0 for no limit. If egressRate is set, egressBurst must also be set
 	EgressBurst int `json:"egressBurst"` //Bandwidth burst in Kb for traffic through container. 0 for no limit. If egressBurst is set, egressRate must also be set
+}
+
+type PluginConf struct {
+	types.NetConf
+
+	RuntimeConfig struct {
+		BandWidth *BandWidthEntry `json:"bandWidth,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
+
+	// RuntimeConfig *struct{} `json:"runtimeConfig"`
+
+	RawPrevResult *map[string]interface{} `json:"prevResult"`
+	PrevResult    *current.Result         `json:"-"`
 }
 
 // parseConfig parses the supplied configuration (and prevResult) from stdin.
@@ -67,13 +76,15 @@ func parseConfig(stdin []byte) (*PluginConf, error) {
 		}
 	}
 
-	err := validateRateAndBurst(conf.IngressRate, conf.IngressBurst)
-	if err != nil {
-		return nil, err
-	}
-	err = validateRateAndBurst(conf.EgressRate, conf.EgressBurst)
-	if err != nil {
-		return nil, err
+	if conf.RuntimeConfig.BandWidth != nil {
+		err := validateRateAndBurst(conf.RuntimeConfig.BandWidth.IngressRate, conf.RuntimeConfig.BandWidth.IngressBurst)
+		if err != nil {
+			return nil, err
+		}
+		err = validateRateAndBurst(conf.RuntimeConfig.BandWidth.EgressRate, conf.RuntimeConfig.BandWidth.EgressBurst)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &conf, nil
@@ -135,8 +146,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	bandwidth := conf.RuntimeConfig.BandWidth
 	//no traffic shaping was requested, so just no-op and quit
-	if conf.IngressRate == 0 && conf.IngressBurst == 0 && conf.EgressRate == 0 && conf.EgressBurst == 0 {
+	if bandwidth == nil || (bandwidth.IngressRate == 0 && bandwidth.IngressBurst == 0 && bandwidth.EgressRate == 0 && bandwidth.EgressBurst == 0) {
 		return types.PrintResult(conf.PrevResult, conf.CNIVersion)
 	}
 
@@ -149,14 +161,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if conf.IngressRate > 0 && conf.IngressBurst > 0 {
-		err = CreateIngressQdisc(conf.IngressRate, conf.IngressBurst, hostInterface.Name)
+	if bandwidth.IngressRate > 0 && bandwidth.IngressBurst > 0 {
+		err = CreateIngressQdisc(bandwidth.IngressRate, bandwidth.IngressBurst, hostInterface.Name)
 		if err != nil {
 			return err
 		}
 	}
 
-	if conf.EgressRate > 0 && conf.EgressBurst > 0 {
+	if bandwidth.EgressRate > 0 && bandwidth.EgressBurst > 0 {
 		mtu, err := getMTU(hostInterface.Name)
 		if err != nil {
 			return err
@@ -181,7 +193,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Name: ifbDeviceName,
 			Mac:  ifbDevice.Attrs().HardwareAddr.String(),
 		})
-		err = CreateEgressQdisc(conf.EgressRate, conf.EgressBurst, hostInterface.Name, ifbDeviceName)
+		err = CreateEgressQdisc(bandwidth.EgressRate, bandwidth.EgressBurst, hostInterface.Name, ifbDeviceName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
To make it easier to supply bandwidth in a dynamic manner, the traffic shaping plugin should support a capability arg.

Fixes: #133