### PR TITLE
build: some small improvements; bump to go1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 bin/
 gopath/
 .vagrant
+
+/release-*

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -e
+cd $(dirname "$0")
 
 if [ "$(uname)" == "Darwin" ]; then
-	export GOOS=linux
+	export GOOS="${GOOS:-linux}"
 fi
 
 ORG_PATH="github.com/containernetworking"
@@ -13,7 +14,6 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
 fi
 
-export GO15VENDOREXPERIMENT=1
 export GOPATH=${PWD}/gopath
 export GO="${GO:-go}"
 
@@ -25,12 +25,6 @@ for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"
 		echo "  $plugin"
-		# use go install so we don't duplicate work
-		if [ -n "$FASTBUILD" ]
-		then
-			GOBIN=${PWD}/bin $GO install -pkgdir $GOPATH/pkg "$@" $REPO_PATH/$d
-		else
-			$GO build -o "${PWD}/bin/$plugin" -pkgdir "$GOPATH/pkg" "$@" "$REPO_PATH/$d"
-		fi
+		$GO build -o "${PWD}/bin/$plugin" "$@" "$REPO_PATH"/$d
 	fi
 done

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Suite")
+	RunSpecs(t, "integration")
 }
 
 var echoServerBinaryPath string

--- a/pkg/ip/ip_suite_test.go
+++ b/pkg/ip/ip_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestIp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ip Suite")
+	RunSpecs(t, "pkg/ip")
 }

--- a/pkg/ipam/ipam_suite_test.go
+++ b/pkg/ipam/ipam_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestIpam(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ipam Suite")
+	RunSpecs(t, "pkg/ipam")
 }

--- a/pkg/ns/ns_suite_test.go
+++ b/pkg/ns/ns_suite_test.go
@@ -30,5 +30,5 @@ func TestNs(t *testing.T) {
 	runtime.LockOSThread()
 
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "pkg/ns Suite")
+	RunSpecs(t, "pkg/ns")
 }

--- a/pkg/testutils/echosvr/init_test.go
+++ b/pkg/testutils/echosvr/init_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestEchosvr(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Testutils Echosvr Suite")
+	RunSpecs(t, "pkg/testutils/echosvr")
 }

--- a/pkg/utils/hwaddr/hwaddr_suite_test.go
+++ b/pkg/utils/hwaddr/hwaddr_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestHwaddr(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Hwaddr Suite")
+	RunSpecs(t, "pkg/utils/hwaddr")
 }

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Utils Suite")
+	RunSpecs(t, "pkg/utils")
 }

--- a/plugins/ipam/dhcp/dhcp_suite_test.go
+++ b/plugins/ipam/dhcp/dhcp_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestDHCP(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "DHCP Suite")
+	RunSpecs(t, "plugins/ipam/dhcp")
 }

--- a/plugins/ipam/host-local/backend/allocator/allocator_suite_test.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestAllocator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Allocator Suite")
+	RunSpecs(t, "plugins/ipam/host-local/backend/allocator")
 }

--- a/plugins/ipam/host-local/backend/disk/disk_suite_test.go
+++ b/plugins/ipam/host-local/backend/disk/disk_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestLock(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Disk Suite")
+	RunSpecs(t, "plugins/ipam/host-local/backend/disk")
 }

--- a/plugins/ipam/host-local/host_local_suite_test.go
+++ b/plugins/ipam/host-local/host_local_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestHostLocal(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "HostLocal Suite")
+	RunSpecs(t, "plugins/ipam/host-local")
 }

--- a/plugins/main/bridge/bridge_suite_test.go
+++ b/plugins/main/bridge/bridge_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestBridge(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "bridge Suite")
+	RunSpecs(t, "plugins/main/bridge")
 }

--- a/plugins/main/host-device/host-device_suite_test.go
+++ b/plugins/main/host-device/host-device_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestVlan(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "host-device Suite")
+	RunSpecs(t, "plugins/main/host-device")
 }

--- a/plugins/main/ipvlan/ipvlan_suite_test.go
+++ b/plugins/main/ipvlan/ipvlan_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestIpvlan(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "ipvlan Suite")
+	RunSpecs(t, "plugins/main/ipvlan")
 }

--- a/plugins/main/loopback/loopback_suite_test.go
+++ b/plugins/main/loopback/loopback_suite_test.go
@@ -27,7 +27,7 @@ var pathToLoPlugin string
 
 func TestLoopback(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Loopback Suite")
+	RunSpecs(t, "plugins/main/loopback")
 }
 
 var _ = BeforeSuite(func() {

--- a/plugins/main/macvlan/macvlan_suite_test.go
+++ b/plugins/main/macvlan/macvlan_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestMacvlan(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "macvlan Suite")
+	RunSpecs(t, "plugins/main/macvlan")
 }

--- a/plugins/main/ptp/ptp_suite_test.go
+++ b/plugins/main/ptp/ptp_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestPtp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "ptp Suite")
+	RunSpecs(t, "plugins/main/ptp")
 }

--- a/plugins/main/vlan/vlan_suite_test.go
+++ b/plugins/main/vlan/vlan_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestVlan(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "vlan Suite")
+	RunSpecs(t, "plugins/main/vlan")
 }

--- a/plugins/meta/bandwidth/bandwidth_suite_test.go
+++ b/plugins/meta/bandwidth/bandwidth_suite_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestTBF(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "bandwidth suite")
+	RunSpecs(t, "plugins/meta/bandwidth")
 }
 
 var echoServerBinaryPath string

--- a/plugins/meta/flannel/flannel_suite_test.go
+++ b/plugins/meta/flannel/flannel_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestFlannel(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Flannel Suite")
+	RunSpecs(t, "plugins/meta/flannel")
 }

--- a/plugins/meta/portmap/portmap_suite_test.go
+++ b/plugins/meta/portmap/portmap_suite_test.go
@@ -37,7 +37,7 @@ func TestPortmap(t *testing.T) {
 	rand.Seed(config.GinkgoConfig.RandomSeed)
 
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "portmap Suite")
+	RunSpecs(t, "plugins/meta/portmap")
 }
 
 var echoServerBinaryPath string

--- a/plugins/meta/tuning/tuning_suite_test.go
+++ b/plugins/meta/tuning/tuning_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestTuning(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "tuning Suite")
+	RunSpecs(t, "plugins/meta/tuning")
 }

--- a/plugins/sample/sample_suite_test.go
+++ b/plugins/sample/sample_suite_test.go
@@ -11,5 +11,5 @@ import (
 
 func TestSample(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "sample suite")
+	RunSpecs(t, "plugins/sample")
 }

--- a/test.sh
+++ b/test.sh
@@ -10,17 +10,12 @@ source ./build.sh
 
 echo "Running tests"
 
-# test everything that's not in vendor
-pushd "$GOPATH/src/$REPO_PATH" >/dev/null
-  ALL_PKGS="$(go list ./... | grep -v vendor | xargs echo)"
-popd >/dev/null
-
 GINKGO_FLAGS="-p --randomizeAllSpecs --randomizeSuites --failOnPending --progress"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
   GINKGO_FLAGS="$GINKGO_FLAGS -r ."
-  LINT_TARGETS="$ALL_PKGS"
+  LINT_TARGETS="./..."
 
 # user has provided PKG override
 else
@@ -28,9 +23,9 @@ else
   LINT_TARGETS="$PKG"
 fi
 
-cd "$GOPATH/src/$REPO_PATH"
-sudo -E bash -c "umask 0; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} ginkgo ${GINKGO_FLAGS}"
+sudo -E bash -c "umask 0; cd ${GOPATH}/src/${REPO_PATH}; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} ginkgo ${GINKGO_FLAGS}"
 
+cd ${GOPATH}/src/${REPO_PATH};
 echo "Checking gofmt..."
 fmtRes=$(go fmt $LINT_TARGETS)
 if [ -n "${fmtRes}" ]; then


### PR DESCRIPTION
- bump to go 1.10
- Add a linker tag with the build version
- Remove fastbuild, go builds are cached now
- use better ginkgo suite names