### PR TITLE
host-device: Ensure device is down before rename

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -143,6 +143,11 @@ func moveLinkOut(containerNs ns.NetNS, ifName string) error {
 		if err != nil {
 			return fmt.Errorf("failed to find %q: %v", ifName, err)
 		}
+
+		// Devices can be renamed only when down
+		if err := netlink.LinkSetDown(dev); err != nil {
+			return fmt.Errorf("failed to set %q down: %v", ifName, err)
+		}
 		// Rename device to it's original name
 		if err := netlink.LinkSetName(dev, dev.Attrs().Alias); err != nil {
 			return fmt.Errorf("failed to restore %q to original name %q: %v", ifName, dev.Attrs().Alias, err)


### PR DESCRIPTION
If the device is in state up trying to set the name during `DEL` fails with "device or resource busy".

Steps to reproduce:
```
$> ip netns add demo
$> echo '{"cniVersion":"0.3.1", "device":"ens224"}' | CNI_COMMAND=ADD CNI_NETNS=/var/run/netns/demo CNI_IFNAME=eth0 CNI_PATH=/opt/cni/bin /opt/cni/bin/host-device
{
    "cniVersion": "0.3.1",
    "interfaces": [
        {
            "name": "eth0",
            "mac": "fa:16:3e:ed:73:7b",
            "sandbox": "/var/run/netns/demo"
        }
    ],
    "dns": {}
}
$> ip netns exec demo ifconfig eth0 up
$> echo '{"cniVersion":"0.3.1", "device":"ens224"}' | CNI_COMMAND=DEL CNI_NETNS=/var/run/netns/demo CNI_IFNAME=eth0 CNI_PATH=/opt/cni/bin /opt/cni/bin/host-device
{
    "code": 100,
    "msg": "failed to restore \"eth0\" to original name \"ens224\": device or resource busy"
}
```