### PR TITLE
plugins/testutils: pass CNI_CONTAINERID to plugins in testcases

### DIFF
--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -231,7 +231,7 @@ var _ = Describe("DHCP Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			r, _, err := testutils.CmdAddWithResult(targetNS.Path(), contVethName, []byte(conf), func() error {
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -245,7 +245,7 @@ var _ = Describe("DHCP Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		err = originalNS.Do(func(ns.NetNS) error {
-			return testutils.CmdDelWithResult(targetNS.Path(), contVethName, func() error {
+			return testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 		})
@@ -273,7 +273,7 @@ var _ = Describe("DHCP Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			r, _, err := testutils.CmdAddWithResult(targetNS.Path(), contVethName, []byte(conf), func() error {
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -299,7 +299,7 @@ var _ = Describe("DHCP Operations", func() {
 				started.Wait()
 
 				err = originalNS.Do(func(ns.NetNS) error {
-					return testutils.CmdDelWithResult(targetNS.Path(), contVethName, func() error {
+					return testutils.CmdDelWithArgs(args, func() error {
 						return cmdDel(args)
 					})
 				})
@@ -310,7 +310,7 @@ var _ = Describe("DHCP Operations", func() {
 		wg.Wait()
 
 		err = originalNS.Do(func(ns.NetNS) error {
-			return testutils.CmdDelWithResult(targetNS.Path(), contVethName, func() error {
+			return testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 		})

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -75,7 +75,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, raw, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -111,12 +111,12 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath1 := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath1)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal("dummy"))
+		Expect(string(contents)).To(Equal(args.ContainerID))
 
 		ipFilePath2 := filepath.Join(tmpDir, disk.GetEscapedPath("mynet", "2001:db8:1::2"))
 		contents, err = ioutil.ReadFile(ipFilePath2)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal("dummy"))
+		Expect(string(contents)).To(Equal(args.ContainerID))
 
 		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath1)
@@ -128,7 +128,7 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("2001:db8:1::2"))
 		// Release the IP
-		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -167,7 +167,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Release the IP
-		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -205,7 +205,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, raw, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -223,7 +223,7 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal("dummy"))
+		Expect(string(contents)).To(Equal(args.ContainerID))
 
 		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath)
@@ -233,7 +233,7 @@ var _ = Describe("host-local Operations", func() {
 		Expect(result.DNS).To(Equal(types.DNS{Nameservers: []string{"192.0.2.3"}}))
 
 		// Release the IP
-		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -270,7 +270,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, _, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -284,7 +284,7 @@ var _ = Describe("host-local Operations", func() {
 		Expect(string(contents)).To(Equal("dummy"))
 
 		// Release the IP
-		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -321,7 +321,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		_, out, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		_, out, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -363,7 +363,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, _, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -412,7 +412,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, _, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -462,7 +462,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, _, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -509,7 +509,7 @@ var _ = Describe("host-local Operations", func() {
 		}
 
 		// Allocate the IP
-		_, _, err = testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		_, _, err = testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).To(HaveOccurred())

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -67,7 +67,7 @@ var _ = Describe("static Operations", func() {
 		}
 
 		// Allocate the IP
-		r, raw, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("static Operations", func() {
 		}))
 
 		// Release the IP
-		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -143,7 +143,7 @@ var _ = Describe("static Operations", func() {
 		}
 
 		// Release the IP
-		err := testutils.CmdDelWithResult(nspath, ifname, func() error {
+		err := testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -148,12 +148,15 @@ func (tc testCase) rangesConfig() string {
 	return conf + rangesEndStr
 }
 
+var counter uint
+
 // createCmdArgs generates network configuration and creates command
 // arguments for a test case.
 func (tc testCase) createCmdArgs(targetNS ns.NetNS) *skel.CmdArgs {
 	conf := tc.netConfJSON()
+	defer func() { counter += 1 }()
 	return &skel.CmdArgs{
-		ContainerID: "dummy",
+		ContainerID: fmt.Sprintf("dummy-%d", counter),
 		Netns:       targetNS.Path(),
 		IfName:      IFNAME,
 		StdinData:   []byte(conf),
@@ -246,7 +249,7 @@ func (tester *testerV03x) cmdAddTest(tc testCase) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		r, raw, err := testutils.CmdAddWithResult(tester.targetNS.Path(), IFNAME, tester.args.StdinData, func() error {
+		r, raw, err := testutils.CmdAddWithArgs(tester.args, func() error {
 			return cmdAdd(tester.args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -374,7 +377,7 @@ func (tester *testerV03x) cmdDelTest(tc testCase) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		err := testutils.CmdDelWithResult(tester.targetNS.Path(), IFNAME, func() error {
+		err := testutils.CmdDelWithArgs(tester.args, func() error {
 			return cmdDel(tester.args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -424,7 +427,7 @@ func (tester *testerV01xOr02x) cmdAddTest(tc testCase) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		r, raw, err := testutils.CmdAddWithResult(tester.targetNS.Path(), IFNAME, tester.args.StdinData, func() error {
+		r, raw, err := testutils.CmdAddWithArgs(tester.args, func() error {
 			return cmdAdd(tester.args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -513,7 +516,7 @@ func (tester *testerV01xOr02x) cmdDelTest(tc testCase) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		err := testutils.CmdDelWithResult(tester.targetNS.Path(), IFNAME, func() error {
+		err := testutils.CmdDelWithArgs(tester.args, func() error {
 			return cmdDel(tester.args)
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -85,7 +85,7 @@ var _ = Describe("base functionality", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			var err error
-			resI, _, err = testutils.CmdAddWithResult(targetNS.Path(), CNI_IFNAME, []byte(conf), func() error { return cmdAdd(args) })
+			resI, _, err = testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
 			return err
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -123,7 +123,9 @@ var _ = Describe("base functionality", func() {
 		// Check that deleting the device moves it back and restores the name
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
-			err = testutils.CmdDelWithResult(targetNS.Path(), CNI_IFNAME, func() error { return cmdDel(args) })
+			err = testutils.CmdDelWithArgs(args, func() error {
+				return cmdDel(args)
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err := netlink.LinkByName(ifname)
@@ -147,7 +149,7 @@ var _ = Describe("base functionality", func() {
 			IfName:      ifname,
 			StdinData:   []byte(conf),
 		}
-		_, _, err := testutils.CmdAddWithResult(originalNS.Path(), ifname, []byte(conf), func() error { return cmdAdd(args) })
+		_, _, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
 		Expect(err).To(MatchError(`specify either "device", "hwaddr" or "kernelpath"`))
 
 	})

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -49,7 +49,7 @@ func ipvlanAddDelTest(conf, IFNAME string, originalNS ns.NetNS) {
 	err = originalNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		r, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+		r, _, err := testutils.CmdAddWithArgs(args, func() error {
 			return cmdAdd(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -86,7 +86,7 @@ func ipvlanAddDelTest(conf, IFNAME string, originalNS ns.NetNS) {
 	err = originalNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+		err = testutils.CmdDelWithArgs(args, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -248,7 +248,7 @@ var _ = Describe("ipvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err = testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -30,10 +30,9 @@ import (
 
 var _ = Describe("Loopback", func() {
 	var (
-		networkNS   ns.NetNS
-		containerID string
-		command     *exec.Cmd
-		environ     []string
+		networkNS ns.NetNS
+		command   *exec.Cmd
+		environ   []string
 	)
 
 	BeforeEach(func() {
@@ -44,7 +43,7 @@ var _ = Describe("Loopback", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		environ = []string{
-			fmt.Sprintf("CNI_CONTAINERID=%s", containerID),
+			fmt.Sprintf("CNI_CONTAINERID=%s", "dummy"),
 			fmt.Sprintf("CNI_NETNS=%s", networkNS.Path()),
 			fmt.Sprintf("CNI_IFNAME=%s", "this is ignored"),
 			fmt.Sprintf("CNI_ARGS=%s", "none"),

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -129,7 +129,7 @@ var _ = Describe("macvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			r, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -166,7 +166,7 @@ var _ = Describe("macvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err := testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -214,7 +214,7 @@ var _ = Describe("macvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err := testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ptp Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			resI, _, err = testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+			resI, _, err = testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("ptp Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err := testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -207,7 +207,7 @@ var _ = Describe("ptp Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err := testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -178,7 +178,7 @@ var _ = Describe("vlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			r, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -215,7 +215,7 @@ var _ = Describe("vlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+			err = testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -114,7 +114,7 @@ var _ = Describe("bandwidth test", func() {
 
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
-				r, out, err := testutils.CmdAddWithResult(containerNs.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				r, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 				result, err := current.GetResult(r)
 				Expect(err).NotTo(HaveOccurred())
@@ -212,7 +212,7 @@ var _ = Describe("bandwidth test", func() {
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, out, err := testutils.CmdAddWithResult(containerNs.Path(), ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
+				_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 
 				_, err = netlink.LinkByName(ifbDeviceName)
@@ -281,7 +281,7 @@ var _ = Describe("bandwidth test", func() {
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, out, err := testutils.CmdAddWithResult(containerNs.Path(), ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
+				_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 
 				_, err = netlink.LinkByName(ifbDeviceName)
@@ -353,7 +353,7 @@ var _ = Describe("bandwidth test", func() {
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, _, err := testutils.CmdAddWithResult(containerNs.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).To(MatchError("if burst is set, rate must also be set"))
 				return nil
 			})).To(Succeed())
@@ -405,7 +405,7 @@ var _ = Describe("bandwidth test", func() {
 
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
-				r, out, err := testutils.CmdAddWithResult(containerNs.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				r, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 				result, err := current.GetResult(r)
 				Expect(err).NotTo(HaveOccurred())
@@ -512,7 +512,7 @@ var _ = Describe("bandwidth test", func() {
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, _, err := testutils.CmdAddWithResult(containerNs.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).To(MatchError("if burst is set, rate must also be set"))
 				return nil
 			})).To(Succeed())
@@ -562,10 +562,10 @@ var _ = Describe("bandwidth test", func() {
 
 			Expect(hostNs.Do(func(netNS ns.NetNS) error {
 				defer GinkgoRecover()
-				_, out, err := testutils.CmdAddWithResult(containerNs.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 
-				err = testutils.CmdDelWithResult(containerNs.Path(), "", func() error { return cmdDel(args) })
+				err = testutils.CmdDel(containerNs.Path(), args.ContainerID, "", func() error { return cmdDel(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 
 				_, err = netlink.LinkByName(ifbDeviceName)
@@ -624,7 +624,7 @@ var _ = Describe("bandwidth test", func() {
 			Expect(hostNs.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				containerWithTbfRes, _, err = testutils.CmdAddWithResult(containerWithTbfNS.Path(), containerWithTbfIFName, []byte(ptpConf), func() error {
+				containerWithTbfRes, _, err = testutils.CmdAdd(containerWithTbfNS.Path(), "dummy", containerWithTbfIFName, []byte(ptpConf), func() error {
 					r, err := invoke.DelegateAdd("ptp", []byte(ptpConf))
 					Expect(r.Print()).To(Succeed())
 
@@ -632,7 +632,7 @@ var _ = Describe("bandwidth test", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				containerWithoutTbfRes, _, err = testutils.CmdAddWithResult(containerWithoutTbfNS.Path(), containerWithoutTbfIFName, []byte(ptpConf), func() error {
+				containerWithoutTbfRes, _, err = testutils.CmdAdd(containerWithoutTbfNS.Path(), "dummy2", containerWithoutTbfIFName, []byte(ptpConf), func() error {
 					r, err := invoke.DelegateAdd("ptp", []byte(ptpConf))
 					Expect(r.Print()).To(Succeed())
 
@@ -667,13 +667,13 @@ var _ = Describe("bandwidth test", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				args := &skel.CmdArgs{
-					ContainerID: "dummy",
+					ContainerID: "dummy3",
 					Netns:       containerWithTbfNS.Path(),
 					IfName:      containerWithTbfIFName,
 					StdinData:   []byte(conf),
 				}
 
-				_, out, err := testutils.CmdAddWithResult(containerWithTbfNS.Path(), "", []byte(conf), func() error { return cmdAdd(args) })
+				_, out, err := testutils.CmdAdd(containerWithTbfNS.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 				Expect(err).NotTo(HaveOccurred(), string(out))
 
 				return nil

--- a/plugins/meta/flannel/flannel_linux_test.go
+++ b/plugins/meta/flannel/flannel_linux_test.go
@@ -103,7 +103,7 @@ FLANNEL_IPMASQ=true
 				defer GinkgoRecover()
 
 				By("calling ADD")
-				resI, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(input), func() error {
+				resI, _, err := testutils.CmdAddWithArgs(args, func() error {
 					return cmdAdd(args)
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -138,7 +138,7 @@ FLANNEL_IPMASQ=true
 				Expect(result.IPs).To(HaveLen(1))
 
 				By("calling DEL")
-				err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				err = testutils.CmdDelWithArgs(args, func() error {
 					return cmdDel(args)
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -147,7 +147,7 @@ FLANNEL_IPMASQ=true
 				Expect(path).ShouldNot(BeAnExistingFile())
 
 				By("calling DEL again")
-				err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				err = testutils.CmdDelWithArgs(args, func() error {
 					return cmdDel(args)
 				})
 				By("check that plugin does not fail due to missing net config")

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -93,7 +93,7 @@ var _ = Describe("tuning plugin", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			r, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/sample/sample_linux_test.go
+++ b/plugins/sample/sample_linux_test.go
@@ -69,7 +69,7 @@ var _ = Describe("sample test", func() {
 			IfName:      ifname,
 			StdinData:   []byte(conf),
 		}
-		_, _, err := testutils.CmdAddWithResult(targetNs.Path(), "eth0", []byte(conf), func() error { return cmdAdd(args) })
+		_, _, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
 		Expect(err).NotTo(HaveOccurred())
 
 	})
@@ -104,7 +104,7 @@ var _ = Describe("sample test", func() {
 			IfName:      "eth0",
 			StdinData:   []byte(conf),
 		}
-		_, _, err := testutils.CmdAddWithResult(targetNs.Path(), "eth0", []byte(conf), func() error { return cmdAdd(args) })
+		_, _, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
 		Expect(err).To(MatchError("anotherAwesomeArg must be specified"))
 
 	})
@@ -130,7 +130,7 @@ var _ = Describe("sample test", func() {
 			IfName:      "eth0",
 			StdinData:   []byte(conf),
 		}
-		_, _, err := testutils.CmdAddWithResult(targetNs.Path(), "eth0", []byte(conf), func() error { return cmdAdd(args) })
+		_, _, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
 		Expect(err).NotTo(HaveOccurred())
 
 	})


### PR DESCRIPTION
Recent CNI specification changes require the container ID on ADD/DEL,
which the testcases were not providing.  Fix that up so things work
when this repo gets CNI revendored.

We switch over to CmdAddWithArgs()/CmdDelWithArgs() everywhere for simplicity, *except* the bandwidth plugin which has testcases that use a different interface name than is in its skel.CmdArgs.

@containernetworking/cni-maintainers @squeed @matthewdupre 