### PR TITLE
Introduce iplink plugin to change netlink attr (i.e. 'ip link' command)

### DIFF
--- a/plugins/linux_only.txt
+++ b/plugins/linux_only.txt
@@ -9,3 +9,4 @@ plugins/main/vlan
 plugins/meta/portmap
 plugins/meta/tuning
 plugins/meta/bandwidth
+plugins/meta/iplink

--- a/plugins/meta/iplink/README.md
+++ b/plugins/meta/iplink/README.md
@@ -1,0 +1,54 @@
+# iplink plugin
+
+## Overview
+
+This plugin changes some interface attributes, like 'ip link' command.
+It does not create any network interfaces and therefore does not bring connectivity by itself.
+This iplink plugin applies changes to interfaces created by previously applied plugins as meta plugin.
+It is only useful when used in addition to other plugins.
+
+## Example configuration
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "mynet",
+  "plugins": [
+    {
+      "type": "ptp",
+      "ipMasq": true,
+      "mtu": 512,
+      "ipam": {
+          "type": "host-local",
+          "subnet": "10.0.0.0/24"
+      },
+      "dns": {
+        "nameservers": [ "10.1.0.1" ]
+      }
+    },
+    {
+      "name": "myiplink",
+      "type": "iplink",
+      "promisc": true,
+      "mac": "c2:b0:57:49:47:f1",
+      "mtu": 1454
+    }
+  ]
+}
+```
+
+## Network configuration reference
+
+* `type` (string, required): "iplink"
+* `mac` (string, optional): MAC address (i.e. hardware address) of interface
+* `mtu` (integer, optional): MTU of interface
+* `promisc` (bool, optional): Change the promiscas mode of interface
+
+## Supported arguments
+The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
+
+* `MAC`: request a specific MAC address for the interface 
+
+    (example: CNI_ARGS="IgnoreUnknown=true;MAC=c2:11:22:33:44:55")
+
+Note: You may add `IgnoreUnknown=true` to allow loose CNI argument verification (see CNI's issue[#560](https://github.com/containernetworking/cni/issues/560)).

--- a/plugins/meta/iplink/README.md
+++ b/plugins/meta/iplink/README.md
@@ -2,10 +2,9 @@
 
 ## Overview
 
-This plugin changes some interface attributes, like 'ip link' command.
-It does not create any network interfaces and therefore does not bring connectivity by itself.
-This iplink plugin applies changes to interfaces created by previously applied plugins as meta plugin.
-It is only useful when used in addition to other plugins.
+This plugin provides a method to change interface attributes, like 'ip link' command.
+It can be used in a chain to apply several specific changes to interface previously configured
+by other plugin.
 
 ## Example configuration
 

--- a/plugins/meta/iplink/iplink_suite_test.go
+++ b/plugins/meta/iplink/iplink_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIplink(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Iplink Suite")
+}

--- a/plugins/meta/iplink/iplink_test.go
+++ b/plugins/meta/iplink/iplink_test.go
@@ -1,0 +1,291 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	"net"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Iplink plugin", func() {
+	var originalNS ns.NetNS
+	const IFNAME string = "dummy0"
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: IFNAME,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	It("configures and deconfigures promiscas mode with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+	"promisc": true,
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Promisc).To(Equal(1))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures mtu with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+	"mtu": 1454,
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().MTU).To(Equal(1454))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures mac address (from conf file) with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+	"mac": "c2:11:22:33:44:55",
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			hw, err := net.ParseMAC("c2:11:22:33:44:55")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().HardwareAddr).To(Equal(hw))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures mac address (from CNI_ARGS) with ADD/DEL", func() {
+		conf := []byte(`{
+	"name": "test",
+	"type": "iplink",
+	"cniVersion": "0.3.1",
+	"prevResult": {
+		"interfaces": [
+			{"name": "dummy0", "sandbox":"netns"}
+		],
+		"ips": [
+			{
+				"version": "4",
+				"address": "10.0.0.2/24",
+				"gateway": "10.0.0.1",
+				"interface": 0
+			}
+		]
+	}
+}`)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       originalNS.Path(),
+			IfName:      IFNAME,
+			StdinData:   conf,
+			Args:        "IgnoreUnknown=true;MAC=c2:11:22:33:44:66",
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(1))
+			Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			hw, err := net.ParseMAC("c2:11:22:33:44:66")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().HardwareAddr).To(Equal(hw))
+
+			err = testutils.CmdDel(originalNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/plugins/meta/iplink/main.go
+++ b/plugins/meta/iplink/main.go
@@ -1,0 +1,223 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a "meta-plugin". It reads in its own netconf, it does not create
+// any network interface but just changes the network sysctl.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+/*
+ * Current support ip link command:
+ + ip link set promisc <bool>
+ + ip link set address <mac addr>
+ + ip link set mtu <numeric>
+
+--- syntax
+{
+  "name": "myiplink",
+  "type": "iplink",
+  "iplink": {
+          "promisc": "true",
+          "macaddress": "new mac addr",
+          "mtu": "1454",
+  }
+}
+*/
+
+// TuningConf represents the network tuning configuration.
+type IpLinkConf struct {
+	//SysCtl        map[string]string      `json:"sysctl"`
+	//IpLink        map[string]string      `json:"iplink"`
+	Mac     string `json:"mac,omitempty"`
+	Promisc bool   `json:"promisc,omitempty"`
+	Mtu     int    `json:"mtu,omitempty"`
+}
+
+type PluginConf struct {
+	types.NetConf
+
+	RuntimeConfig struct {
+		IpLinkConf *IpLinkConf `json:"iplink,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
+
+	RawPrevResult map[string]interface{} `json:"prevResult,omitempty"`
+	PrevResult    *current.Result        `json:"-"`
+
+	*IpLinkConf
+}
+
+type MACEnvArgs struct {
+	types.CommonArgs
+	MAC types.UnmarshallableString `json:"mac,omitempty"`
+}
+
+func changeMacAddr(ifName string, newMacAddr string) error {
+	addr, err := net.ParseMAC(newMacAddr)
+	if err != nil {
+		return fmt.Errorf("Invalid args %v for MAC addr: %v", newMacAddr, err)
+	}
+
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+	}
+
+	err = netlink.LinkSetDown(link)
+	if err != nil {
+		return fmt.Errorf("Failed to set %s down: %v", ifName, err)
+	}
+	err = netlink.LinkSetHardwareAddr(link, addr)
+	if err != nil {
+		return fmt.Errorf("Failed to set %s address to %s: %v", ifName, newMacAddr, err)
+	}
+	return netlink.LinkSetUp(link)
+}
+
+func updateResultsMacAddr(config PluginConf, ifName string, newMacAddr string) error {
+	for _, i := range config.PrevResult.Interfaces {
+		if i.Name == ifName {
+			i.Mac = newMacAddr
+		}
+	}
+	return nil
+}
+
+func changePromisc(ifName string, val bool) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+	}
+
+	if val {
+		return netlink.SetPromiscOn(link)
+	}
+	return netlink.SetPromiscOff(link)
+}
+
+func changeMtu(ifName string, mtu int) error {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+	}
+	return netlink.LinkSetMTU(link, mtu)
+}
+
+func parseConf(data []byte, envArgs string) (*PluginConf, error) {
+	conf := PluginConf{IpLinkConf: &IpLinkConf{Promisc: false, Mtu: -1}}
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return nil, fmt.Errorf("failed to load netconf: %v", err)
+	}
+
+	// Parse custom MAC from both env args
+	if envArgs != "" {
+		e := MACEnvArgs{}
+		err := types.LoadArgs(envArgs, &e)
+		if err != nil {
+			return nil, err
+		}
+
+		if e.MAC != "" {
+			conf.Mac = string(e.MAC)
+		}
+	}
+
+	if conf.IpLinkConf == nil && conf.RuntimeConfig.IpLinkConf != nil {
+		conf.IpLinkConf = conf.RuntimeConfig.IpLinkConf
+	}
+
+	// Parse previous result.
+	if conf.RawPrevResult != nil {
+		resultBytes, err := json.Marshal(conf.RawPrevResult)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize prevResult: %v", err)
+		}
+		res, err := version.NewResult(conf.CNIVersion, resultBytes)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse prevResult: %v", err)
+		}
+		conf.RawPrevResult = nil
+		conf.PrevResult, err = current.NewResultFromResult(res)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert result to current version: %v", err)
+		}
+	}
+
+	return &conf, nil
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	conf, err := parseConf(args.StdinData, args.Args)
+	if err != nil {
+		return err
+	}
+
+	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		var err error
+
+		if conf.Mac != "" {
+			if err = changeMacAddr(args.IfName, conf.Mac); err == nil {
+				err = updateResultsMacAddr(*conf, args.IfName, conf.Mac)
+			}
+		}
+
+		if conf.Promisc != false {
+			if err = changePromisc(args.IfName, true); err != nil {
+				return err
+			}
+		}
+
+		if conf.Mtu != -1 {
+			if err = changeMtu(args.IfName, conf.Mtu); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return types.PrintResult(conf.PrevResult, conf.CNIVersion)
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	// TODO: the settings are not reverted to the previous values. Reverting the
+	// settings is not useful when the whole container goes away but it could be
+	// useful in scenarios where plugins are added and removed at runtime.
+	return nil
+}
+
+func cmdGet(args *skel.CmdArgs) error {
+	// TODO: implement
+	return fmt.Errorf("not implemented")
+}
+
+func main() {
+	// TODO: implement plugin version
+	skel.PluginMain(cmdAdd, cmdDel, cmdGet, version.PluginSupports("0.3.0", "0.3.1", version.Current()), "TODO")
+}

--- a/plugins/meta/iplink/main.go
+++ b/plugins/meta/iplink/main.go
@@ -30,28 +30,8 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-/*
- * Current support ip link command:
- + ip link set promisc <bool>
- + ip link set address <mac addr>
- + ip link set mtu <numeric>
-
---- syntax
-{
-  "name": "myiplink",
-  "type": "iplink",
-  "iplink": {
-          "promisc": "true",
-          "macaddress": "new mac addr",
-          "mtu": "1454",
-  }
-}
-*/
-
-// TuningConf represents the network tuning configuration.
+// IpLinkConf represents the network tuning configuration.
 type IpLinkConf struct {
-	//SysCtl        map[string]string      `json:"sysctl"`
-	//IpLink        map[string]string      `json:"iplink"`
 	Mac     string `json:"mac,omitempty"`
 	Promisc bool   `json:"promisc,omitempty"`
 	Mtu     int    `json:"mtu,omitempty"`
@@ -78,21 +58,21 @@ type MACEnvArgs struct {
 func changeMacAddr(ifName string, newMacAddr string) error {
 	addr, err := net.ParseMAC(newMacAddr)
 	if err != nil {
-		return fmt.Errorf("Invalid args %v for MAC addr: %v", newMacAddr, err)
+		return fmt.Errorf("invalid args %v for MAC addr: %v", newMacAddr, err)
 	}
 
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
-		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+		return fmt.Errorf("failed to get %q: %v", ifName, err)
 	}
 
 	err = netlink.LinkSetDown(link)
 	if err != nil {
-		return fmt.Errorf("Failed to set %s down: %v", ifName, err)
+		return fmt.Errorf("failed to set %q down: %v", ifName, err)
 	}
 	err = netlink.LinkSetHardwareAddr(link, addr)
 	if err != nil {
-		return fmt.Errorf("Failed to set %s address to %s: %v", ifName, newMacAddr, err)
+		return fmt.Errorf("failed to set %q address to %q: %v", ifName, newMacAddr, err)
 	}
 	return netlink.LinkSetUp(link)
 }
@@ -109,7 +89,7 @@ func updateResultsMacAddr(config PluginConf, ifName string, newMacAddr string) e
 func changePromisc(ifName string, val bool) error {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
-		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+		return fmt.Errorf("failed to get %q: %v", ifName, err)
 	}
 
 	if val {
@@ -121,7 +101,7 @@ func changePromisc(ifName string, val bool) error {
 func changeMtu(ifName string, mtu int) error {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
-		return fmt.Errorf("Failed to get %s: %v", ifName, err)
+		return fmt.Errorf("failed to get %q: %v", ifName, err)
 	}
 	return netlink.LinkSetMTU(link, mtu)
 }
@@ -175,7 +155,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+	err = ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
 		var err error
 
 		if conf.Mac != "" {


### PR DESCRIPTION
This change introduces iplink plugin, used to change interface attributes with netlink, like 'ip link' command. Currently MTU, MAC and promiscas are supported.