### PR TITLE
Support CNI_ARGS in static IPAM plugin

### DIFF
--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -38,16 +38,17 @@ static IPAM is very simple IPAM plugin that assigns IPv4 and IPv6 addresses stat
 ## Network configuration reference
 
 * `type` (string, required): "static"
-* `addresses` (array, optional): an array of arrays of ip address objects:
+* `addresses` (array, optional): an array of ip address objects:
 	* `address` (string, required): CIDR notation IP address.
 	* `gateway` (string, optional): IP inside of "subnet" to designate as the gateway.
 * `routes` (string, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `dns` (string, optional): the dictionary with "nameservers", "domain" and "search".
 
 ## Supported arguments
+
 The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
 
-* `IP`: request a specific IP address from a subnet
+* `IP`: request a specific IP address
 * `SUBNET`: request a specific subnet
 * `GATEWAY`: request a specific gateway address
 

--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -48,7 +48,7 @@ static IPAM is very simple IPAM plugin that assigns IPv4 and IPv6 addresses stat
 
 The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
 
-* `IP`: request a specific CIDR notation IP address
+* `IP`: request a specific CIDR notation IP addresses, comma separated
 * `GATEWAY`: request a specific gateway address
 
     (example: CNI_ARGS="IP=10.10.0.1/24;GATEWAY=10.10.0.254")

--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -48,8 +48,7 @@ static IPAM is very simple IPAM plugin that assigns IPv4 and IPv6 addresses stat
 
 The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
 
-* `IP`: request a specific IP address
-* `SUBNET`: request a specific subnet
+* `IP`: request a specific CIDR notation IP address
 * `GATEWAY`: request a specific gateway address
 
-    (example: CNI_ARGS="IP=10.10.0.1;SUBNET=10.10.0.0/24;GATEWAY=10.10.0.254")
+    (example: CNI_ARGS="IP=10.10.0.1/24;GATEWAY=10.10.0.254")

--- a/plugins/ipam/static/README.md
+++ b/plugins/ipam/static/README.md
@@ -38,8 +38,17 @@ static IPAM is very simple IPAM plugin that assigns IPv4 and IPv6 addresses stat
 ## Network configuration reference
 
 * `type` (string, required): "static"
-* `addresses` (array, required): an array of arrays of ip address objects:
+* `addresses` (array, optional): an array of arrays of ip address objects:
 	* `address` (string, required): CIDR notation IP address.
 	* `gateway` (string, optional): IP inside of "subnet" to designate as the gateway.
 * `routes` (string, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `dns` (string, optional): the dictionary with "nameservers", "domain" and "search".
+
+## Supported arguments
+The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
+
+* `IP`: request a specific IP address from a subnet
+* `SUBNET`: request a specific subnet
+* `GATEWAY`: request a specific gateway address
+
+    (example: CNI_ARGS="IP=10.10.0.1;SUBNET=10.10.0.0/24;GATEWAY=10.10.0.254")

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -45,8 +45,7 @@ type IPAMConfig struct {
 
 type IPAMEnvArgs struct {
 	types.CommonArgs
-	IP      net.IP                     `json:"ip,omitempty"`
-	SUBNET  types.UnmarshallableString `json:"subnet,omitempty"`
+	IP      types.UnmarshallableString `json:"ip,omitempty"`
 	GATEWAY net.IP                     `json:"gateway,omitempty"`
 }
 
@@ -116,13 +115,13 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 			return nil, "", err
 		}
 
-		if e.IP != nil && e.SUBNET != "" {
-			_, subnet, err := net.ParseCIDR(string(e.SUBNET))
+		if e.IP != "" {
+			ip, subnet, err := net.ParseCIDR(string(e.IP))
 			if err != nil {
-				return nil, "", fmt.Errorf("invalid CIDR %s: %s", e.SUBNET, err)
+				return nil, "", fmt.Errorf("invalid CIDR %s: %s", e.IP, err)
 			}
 
-			addr := Address{Address: net.IPNet{IP: e.IP, Mask: subnet.Mask}}
+			addr := Address{Address: net.IPNet{IP: ip, Mask: subnet.Mask}}
 			if e.GATEWAY != nil {
 				addr.Gateway = e.GATEWAY
 			}

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -30,12 +30,9 @@ import (
 // The top-level network config - IPAM plugins are passed the full configuration
 // of the calling plugin, not just the IPAM section.
 type Net struct {
-	Name          string      `json:"name"`
-	CNIVersion    string      `json:"cniVersion"`
-	IPAM          *IPAMConfig `json:"ipam"`
-	RuntimeConfig struct {
-		Addresses []Address `json:"addresses,omitempty"`
-	} `json:"runtimeConfig,omitempty"`
+	Name       string      `json:"name"`
+	CNIVersion string      `json:"cniVersion"`
+	IPAM       *IPAMConfig `json:"ipam"`
 }
 
 type IPAMConfig struct {
@@ -85,10 +82,6 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 
 	if n.IPAM == nil {
 		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
-	}
-
-	if len(n.RuntimeConfig.Addresses) != 0 {
-		n.IPAM.Addresses = append(n.RuntimeConfig.Addresses, n.IPAM.Addresses...)
 	}
 
 	// Validate all ranges

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -130,7 +130,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 
 				ip, subnet, err := net.ParseCIDR(ipstr)
 				if err != nil {
-					return nil, "", fmt.Errorf("invalid CIDR %s: %s", e.IP, err)
+					return nil, "", fmt.Errorf("invalid CIDR %s: %s", ipstr, err)
 				}
 
 				addr := Address{Address: net.IPNet{IP: ip, Mask: subnet.Mask}}

--- a/plugins/ipam/static/static_suite_test.go
+++ b/plugins/ipam/static/static_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestStatic(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Static Suite")
+	RunSpecs(t, "plugins/ipam/static")
 }

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -148,6 +148,68 @@ var _ = Describe("static Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("allocates and releases addresses with ADD/DEL, with ENV variables", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"master": "foo0",
+			"ipam": {
+				"type": "static",
+				"routes": [
+					{ "dst": "0.0.0.0/0" },
+					{ "dst": "192.168.0.0/16", "gw": "10.10.5.1" }],
+				"dns": {
+					"nameservers" : ["8.8.8.8"],
+					"domain": "example.com",
+					"search": [ "example.com" ]
+				}
+			}
+		}`
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+			Args:        "IP=10.10.0.1;SUBNET=10.10.0.0/24;GATEWAY=10.10.0.254",
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "4",
+				Address: mustCIDR("10.10.0.1/24"),
+				Gateway: net.ParseIP("10.10.0.254"),
+			}))
+
+		Expect(len(result.IPs)).To(Equal(1))
+
+		Expect(result.Routes).To(Equal([]*types.Route{
+			{Dst: mustCIDR("0.0.0.0/0")},
+			{Dst: mustCIDR("192.168.0.0/16"), GW: net.ParseIP("10.10.5.1")},
+		}))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 func mustCIDR(s string) net.IPNet {

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -176,7 +176,7 @@ var _ = Describe("static Operations", func() {
 			Netns:       nspath,
 			IfName:      ifname,
 			StdinData:   []byte(conf),
-			Args:        "IP=10.10.0.1;SUBNET=10.10.0.0/24;GATEWAY=10.10.0.254",
+			Args:        "IP=10.10.0.1/24;GATEWAY=10.10.0.254",
 		}
 
 		// Allocate the IP

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -210,6 +210,61 @@ var _ = Describe("static Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("allocates and releases multiple addresses with ADD/DEL, with ENV variables", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"master": "foo0",
+			"ipam": {
+				"type": "static"
+			}
+		}`
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+			Args:        "IP=10.10.0.1/24,11.11.0.1/24;GATEWAY=10.10.0.254",
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "4",
+				Address: mustCIDR("10.10.0.1/24"),
+				Gateway: net.ParseIP("10.10.0.254"),
+			}))
+		Expect(*result.IPs[1]).To(Equal(
+			current.IPConfig{
+				Version: "4",
+				Address: mustCIDR("11.11.0.1/24"),
+				Gateway: nil,
+			}))
+
+		Expect(len(result.IPs)).To(Equal(2))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 func mustCIDR(s string) net.IPNet {


### PR DESCRIPTION
This change is to add CNI_ARGS support in static IPAM plugin.
When IP/SUBNET/GATEWAY are given in CNI_ARGS, static IPAM adds
these info in addition to config files.

To configure ip address only from CNI_ARGS, 'address' field in config
is changed to optional from required.