### PR TITLE
ipam/host-local: Update for spec v0.7

### DIFF
--- a/pkg/testutils/cmd.go
+++ b/pkg/testutils/cmd.go
@@ -31,8 +31,8 @@ func envCleanup() {
 	os.Unsetenv("CNI_CONTAINERID")
 }
 
-func CmdAdd(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() error) (types.Result, []byte, error) {
-	os.Setenv("CNI_COMMAND", "ADD")
+func cmdAddOrGet(command, cniNetns, cniContainerID, cniIfname string, conf []byte, f func() error) (types.Result, []byte, error) {
+	os.Setenv("CNI_COMMAND", command)
 	os.Setenv("CNI_PATH", os.Getenv("PATH"))
 	os.Setenv("CNI_NETNS", cniNetns)
 	os.Setenv("CNI_IFNAME", cniIfname)
@@ -77,8 +77,20 @@ func CmdAdd(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() er
 	return result, out, nil
 }
 
+func CmdAdd(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() error) (types.Result, []byte, error) {
+	return cmdAddOrGet("ADD", cniNetns, cniContainerID, cniIfname, conf, f)
+}
+
+func CmdGet(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() error) (types.Result, []byte, error) {
+	return cmdAddOrGet("GET", cniNetns, cniContainerID, cniIfname, conf, f)
+}
+
 func CmdAddWithArgs(args *skel.CmdArgs, f func() error) (types.Result, []byte, error) {
 	return CmdAdd(args.Netns, args.ContainerID, args.IfName, args.StdinData, f)
+}
+
+func CmdGetWithArgs(args *skel.CmdArgs, f func() error) (types.Result, []byte, error) {
+	return CmdGet(args.Netns, args.ContainerID, args.IfName, args.StdinData, f)
 }
 
 func CmdDel(cniNetns, cniContainerID, cniIfname string, f func() error) error {

--- a/plugins/ipam/host-local/backend/disk/backend_test.go
+++ b/plugins/ipam/host-local/backend/disk/backend_test.go
@@ -1,0 +1,141 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Disk backend test suite", func() {
+
+	var store *Store
+	var tmpDir string
+	var netDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = ioutil.TempDir("", "host_local_artifacts")
+		Expect(err).NotTo(HaveOccurred())
+		tmpDir = filepath.ToSlash(tmpDir)
+		netDir = filepath.Join(tmpDir, "netname")
+
+		store, err = New("netname", tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if tmpDir != "" {
+			os.RemoveAll(tmpDir)
+		}
+	})
+
+	It("writes the correct reservation file", func() {
+		id := backend.Key{ID: "asdf", IF: "eth1"}
+
+		ok, err := store.Reserve(id, ip("10.0.0.1"), "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		res, err := ioutil.ReadFile(GetEscapedPath(netDir, "10.0.0.1"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(MatchJSON([]byte(`{"kind":"host-local-v1","value":{"id":"asdf","if":"eth1"}}`)))
+
+		ok, err = store.Reserve(id, ip("10.0.0.1"), "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("treats v0 reservations as reserved", func() {
+		err := ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.2"), []byte("asdf"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		id := backend.Key{ID: "asdf", IF: "eth1"}
+		ok, err := store.Reserve(id, ip("10.0.0.2"), "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("cleans up v0 and v1 reservations", func() {
+		// write a v0 with the same and different container ids
+		err := ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.2"), []byte("id1"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.3"), []byte("id2"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// write a v1 with same and different ids, and same and different ifs
+		err = ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.4"), WriteKey(&backend.Key{ID: "id1", IF: "eth0"}), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.5"), WriteKey(&backend.Key{ID: "id1", IF: "eth1"}), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// different container id
+		err = ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.6"), WriteKey(&backend.Key{ID: "id2", IF: "eth0"}), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ioutil.WriteFile(GetEscapedPath(netDir, "10.0.0.7"), WriteKey(&backend.Key{ID: "id2", IF: "eth1"}), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		k := backend.Key{ID: "id1", IF: "eth0"}
+
+		ips, err := store.GetByID(k)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ips).To(ConsistOf(
+			net.ParseIP("10.0.0.2"),
+			net.ParseIP("10.0.0.4"),
+		))
+
+		store.ReleaseByID(k)
+
+		// now when we clean up id1:eth0, we expect to have
+		// .3, .5, .6, and .7
+		for _, tc := range []struct {
+			ip    string
+			exist bool
+		}{
+			{"10.0.0.2", false},
+			{"10.0.0.3", true},
+			{"10.0.0.4", false},
+			{"10.0.0.5", true},
+			{"10.0.0.6", true},
+			{"10.0.0.7", true},
+		} {
+			path := GetEscapedPath(netDir, tc.ip)
+			_, err := os.Stat(path)
+			if tc.exist && err != nil {
+				Fail(fmt.Sprintf("Expected %s to exist", path))
+			} else if !tc.exist && err == nil {
+				Fail(fmt.Sprintf("Expected %s not to exist", path))
+			}
+		}
+
+	})
+
+})
+
+func ip(ip string) net.IP {
+	i := net.ParseIP(ip)
+	Expect(i).NotTo(BeEmpty())
+	return i
+}

--- a/plugins/ipam/host-local/backend/disk/disk_suite_test.go
+++ b/plugins/ipam/host-local/backend/disk/disk_suite_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestLock(t *testing.T) {
+func TestDisk(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "plugins/ipam/host-local/backend/disk")
 }

--- a/plugins/ipam/host-local/backend/disk/key.go
+++ b/plugins/ipam/host-local/backend/disk/key.go
@@ -1,0 +1,114 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend"
+)
+
+type kindValue struct {
+	Kind  string          `json:"kind"`
+	Value json.RawMessage `json:"value"`
+}
+
+type KeyKind string
+
+const KindReservationV0 = "host-local-v0"
+const KindReservationV1 = "host-local-v1"
+
+type ReservationV1JSON struct {
+	Kind  KeyKind       `json:"kind"`
+	Value ReservationV1 `json:"value"`
+}
+
+type ReservationV1 struct {
+	ID string `json:"id"`
+	IF string `json:"if"`
+}
+
+func (r *ReservationV1) Key() *backend.Key {
+	return &backend.Key{
+		ID: r.ID,
+		IF: r.IF,
+	}
+}
+
+// KeyFromFile parses an ip serialization record from a file
+func ReadKey(b []byte) (*backend.Key, KeyKind, error) {
+	kv := kindValue{}
+
+	err := json.Unmarshal(b, &kv)
+	// If it fails to unmarshal, assume it's the pre-json kind, where we just
+	// wrote the containerid to the file directly
+	if err != nil {
+		id := strings.TrimSpace(string(b))
+		return &backend.Key{ID: id}, KindReservationV0, nil
+	}
+
+	switch kv.Kind {
+	case "":
+		// sort of awkward, but probably just a weird container id
+		id := strings.TrimSpace(string(b))
+		return &backend.Key{ID: id}, KindReservationV0, nil
+	case KindReservationV1:
+		r := ReservationV1{}
+		err := json.Unmarshal(kv.Value, &r)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to unmarshal: %v", err)
+		}
+		return r.Key(), KindReservationV1, nil
+	}
+
+	return nil, "", fmt.Errorf("unknown key kind %s", kv.Kind)
+}
+
+// WriteKey shals a key to bytes
+func WriteKey(k *backend.Key) []byte {
+	r := ReservationV1JSON{
+		Kind: KindReservationV1,
+		Value: ReservationV1{
+			ID: k.ID,
+			IF: k.IF,
+		},
+	}
+	b, _ := json.Marshal(r)
+	return b
+}
+
+// Matches returns true if bytes (on disk) match a given key
+//
+// Previous editions of the CNI spec specified a primary key of (network, container id), but
+// cni v0.7.0 requires it to be (network, container id, ifname).  This changed
+// the store format from plain text to json. However, we want to be able to
+// clean up stores from old versions, so we will match if the if name is the same, or
+// if the ifname on disk is empty and we know it was stored in the old format
+func Matches(k *backend.Key, b []byte) (bool, error) {
+	k1, kind, err := ReadKey(b)
+	if err != nil {
+		return false, err
+	}
+
+	switch kind {
+	case KindReservationV0:
+		return k.ID == k1.ID, nil
+	case KindReservationV1:
+		return k.Equals(k1), nil
+	}
+	return false, fmt.Errorf("unreachable")
+}

--- a/plugins/ipam/host-local/backend/disk/key_test.go
+++ b/plugins/ipam/host-local/backend/disk/key_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ID parsing tests", func() {
+
+	It("Parses a v0 key", func() {
+		b := []byte("591df6e2-730c-11e8-84d4-507b9dee986d")
+		key, kind, err := ReadKey(b)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kind).To(BeEquivalentTo(KindReservationV0))
+
+		Expect(key).To(Equal(&backend.Key{ID: "591df6e2-730c-11e8-84d4-507b9dee986d"}))
+	})
+
+	It("Parses a v0 key that looks like json", func() {
+		b := []byte(`{"a":"b"}`)
+		key, kind, err := ReadKey(b)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kind).To(BeEquivalentTo(KindReservationV0))
+
+		Expect(key).To(Equal(&backend.Key{ID: `{"a":"b"}`}))
+
+	})
+
+	It("Parses a v1 key", func() {
+		b := []byte(`{"kind":"host-local-v1", "value":{"id": "asdfasdf", "if": "eth1"}}`)
+
+		key, kind, err := ReadKey(b)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kind).To(BeEquivalentTo(KindReservationV1))
+
+		Expect(key).To(Equal(&backend.Key{ID: "asdfasdf", IF: "eth1"}))
+	})
+
+	It("fails other kinds", func() {
+		b := []byte(`{"kind":"host-local-v99", "value":{"id": "asdfasdf", "if": "eth1"}}`)
+		key, kind, err := ReadKey(b)
+		Expect(key).To(BeNil())
+		Expect(kind).To(BeEmpty())
+		Expect(err).To(MatchError("unknown key kind host-local-v99"))
+	})
+})

--- a/plugins/ipam/host-local/backend/store.go
+++ b/plugins/ipam/host-local/backend/store.go
@@ -16,12 +16,34 @@ package backend
 
 import "net"
 
+// Key is the primary key for the store
+type Key struct {
+	ID string // the container ID
+	IF string // The container interface name
+}
+
+// Equals checks for key equality
+func (k *Key) Equals(k1 *Key) bool {
+	if k == nil && k1 == nil {
+		return true
+	}
+	if k == nil {
+		return false
+	}
+	if k1 == nil {
+		return false
+	}
+
+	return k.ID == k1.ID && k.IF == k1.IF
+}
+
 type Store interface {
 	Lock() error
 	Unlock() error
 	Close() error
-	Reserve(id string, ip net.IP, rangeID string) (bool, error)
+	Reserve(key Key, ip net.IP, rangeID string) (bool, error)
 	LastReservedIP(rangeID string) (net.IP, error)
 	Release(ip net.IP) error
-	ReleaseByID(id string) error
+	ReleaseByID(id Key) error
+	GetByID(id Key) ([]net.IP, error)
 }

--- a/plugins/ipam/host-local/backend/testing/fake_store.go
+++ b/plugins/ipam/host-local/backend/testing/fake_store.go
@@ -22,14 +22,14 @@ import (
 )
 
 type FakeStore struct {
-	ipMap          map[string]string
+	ipMap          map[string]backend.Key
 	lastReservedIP map[string]net.IP
 }
 
 // FakeStore implements the Store interface
 var _ backend.Store = &FakeStore{}
 
-func NewFakeStore(ipmap map[string]string, lastIPs map[string]net.IP) *FakeStore {
+func NewFakeStore(ipmap map[string]backend.Key, lastIPs map[string]net.IP) *FakeStore {
 	return &FakeStore{ipmap, lastIPs}
 }
 
@@ -45,7 +45,7 @@ func (s *FakeStore) Close() error {
 	return nil
 }
 
-func (s *FakeStore) Reserve(id string, ip net.IP, rangeID string) (bool, error) {
+func (s *FakeStore) Reserve(id backend.Key, ip net.IP, rangeID string) (bool, error) {
 	key := ip.String()
 	if _, ok := s.ipMap[key]; !ok {
 		s.ipMap[key] = id
@@ -68,10 +68,10 @@ func (s *FakeStore) Release(ip net.IP) error {
 	return nil
 }
 
-func (s *FakeStore) ReleaseByID(id string) error {
+func (s *FakeStore) ReleaseByID(id backend.Key) error {
 	toDelete := []string{}
 	for k, v := range s.ipMap {
-		if v == id {
+		if id.Equals(&v) {
 			toDelete = append(toDelete, k)
 		}
 	}
@@ -81,6 +81,17 @@ func (s *FakeStore) ReleaseByID(id string) error {
 	return nil
 }
 
-func (s *FakeStore) SetIPMap(m map[string]string) {
+func (s *FakeStore) GetByID(id backend.Key) ([]net.IP, error) {
+	out := []net.IP{}
+
+	for k, v := range s.ipMap {
+		if id.Equals(&v) {
+			out = append(out, net.ParseIP(k))
+		}
+	}
+	return out, nil
+}
+
+func (s *FakeStore) SetIPMap(m map[string]backend.Key) {
 	s.ipMap = m
 }


### PR DESCRIPTION
This updates the host-local ipam allocator for v0.7:
- It now supports GET
- It will allow allocating multiple IPs per network (with different
    interfaces)