### PR TITLE
Add build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,13 @@ are very busy and read the mailing lists.
 ## Getting Started
 
 - Fork the repository on GitHub
-- Read the [README](README.md) for build and test instructions
 - Play with the project, submit bugs, submit pull requests!
+
+
+## Building
+
+Each plugin is compiled simply with `go build`.  A script, `build.sh`,
+is supplied which will build all the plugins in the repo.
 
 ## Contribution workflow
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # plugins
 Some CNI network plugins, maintained by the containernetworking team. For more information, see the individual READMEs.
 
+Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
+
 ## Plugins supplied:
 ### Main: interface-creating
 * `bridge`: Creates a bridge, adds the host and the container to it.


### PR DESCRIPTION
I noticed that CONTRIBUTING told you to read the README and the README didn't tell you at all.
