### PR TITLE
l2-bridge cni plugin

### DIFF
--- a/plugins/main/l2-bridge/README.md
+++ b/plugins/main/l2-bridge/README.md
@@ -7,11 +7,13 @@ The containers receive one end of the veth pair with the other end connected to 
 No IP address is assigned to the veth pair.
 
 The network configuration specifies the name of the bridge to be used.
-If the bridge is missing, the plugin will fail.
+If the bridge is missing, the plugin will create one on first use.
+
 
 ## Example configuration
 ```
 {
+    "name": "mynet",
 	"cniVersion": "0.3.0",
 	"type": "l2-bridge",
 	"bridge": "mynet0",
@@ -21,6 +23,7 @@ If the bridge is missing, the plugin will fail.
 
 ## Network configuration reference
 
+* `name` (string, required): the name of the network.
 * `type` (string, required): "l2-bridge".
 * `bridge` (string, optional): name of the bridge to use.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.

--- a/plugins/main/l2-bridge/README.md
+++ b/plugins/main/l2-bridge/README.md
@@ -1,0 +1,29 @@
+# l2-bridge plugin
+
+## Overview
+
+With l2-bridge plugin, all containers (on the same host) are plugged into a bridge (virtual switch) that resides in the host network namespace.
+The containers receive one end of the veth pair with the other end connected to the bridge.
+No IP address is assigned to the veth pair.
+
+The network configuration specifies the name of the bridge to be used.
+If the bridge is missing, the plugin will fail.
+
+## Example configuration
+```
+{
+	"cniVersion": "0.3.0",
+	"type": "l2-bridge",
+	"bridge": "mynet0",
+	"ipam": {}
+}
+```
+
+## Network configuration reference
+
+* `type` (string, required): "l2-bridge".
+* `bridge` (string, optional): name of the bridge to use.
+* `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
+* `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
+* `ipam` (dictionary, required): Need to be an empty dictionary.
+* `promiscMode` (boolean, optional): set promiscuous mode on the bridge. Defaults to false.

--- a/plugins/main/l2-bridge/l2-bridge.go
+++ b/plugins/main/l2-bridge/l2-bridge.go
@@ -1,0 +1,225 @@
+// Copyright 2014 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"syscall"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// For testcases to force an error after IPAM has been performed
+var debugPostIPAMError error
+
+const defaultBrName = "cni0"
+
+type NetConf struct {
+	types.NetConf
+	BrName      string `json:"bridge"`
+	MTU         int    `json:"mtu"`
+	HairpinMode bool   `json:"hairpinMode"`
+	PromiscMode bool   `json:"promiscMode"`
+}
+
+func init() {
+	// this ensures that main runs only on main thread (thread group leader).
+	// since namespace ops (unshare, setns) are done for a single thread, we
+	// must ensure that the goroutine does not jump from OS thread to thread
+	runtime.LockOSThread()
+}
+
+func loadNetConf(bytes []byte) (*NetConf, string, error) {
+	n := &NetConf{
+		BrName: defaultBrName,
+	}
+	if err := json.Unmarshal(bytes, n); err != nil {
+		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
+	}
+	return n, n.CNIVersion, nil
+}
+
+func bridgeByName(name string) (*netlink.Bridge, error) {
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("could not lookup %q: %v", name, err)
+	}
+	br, ok := l.(*netlink.Bridge)
+	if !ok {
+		return nil, fmt.Errorf("%q already exists but is not a bridge", name)
+	}
+	return br, nil
+}
+
+func ensureBridge(brName string, mtu int, promiscMode bool) (*netlink.Bridge, error) {
+	br := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: brName,
+			MTU:  mtu,
+			// Let kernel use default txqueuelen; leaving it unset
+			// means 0, and a zero-length TX queue messes up FIFO
+			// traffic shapers which use TX queue length as the
+			// default packet limit
+			TxQLen: -1,
+		},
+	}
+
+	err := netlink.LinkAdd(br)
+	if err != nil && err != syscall.EEXIST {
+		return nil, fmt.Errorf("could not add %q: %v", brName, err)
+	}
+
+	if promiscMode {
+		if err := netlink.SetPromiscOn(br); err != nil {
+			return nil, fmt.Errorf("could not set promiscuous mode on %q: %v", brName, err)
+		}
+	}
+
+	// Re-fetch link to read all attributes and if it already existed,
+	// ensure it's really a bridge with similar configuration
+	br, err = bridgeByName(brName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := netlink.LinkSetUp(br); err != nil {
+		return nil, err
+	}
+
+	return br, nil
+}
+
+func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool) (*current.Interface, *current.Interface, error) {
+	contIface := &current.Interface{}
+	hostIface := &current.Interface{}
+
+	err := netns.Do(func(hostNS ns.NetNS) error {
+		// create the veth pair in the container and move host end into host netns
+		hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, hostNS)
+		if err != nil {
+			return err
+		}
+		contIface.Name = containerVeth.Name
+		contIface.Mac = containerVeth.HardwareAddr.String()
+		contIface.Sandbox = netns.Path()
+		hostIface.Name = hostVeth.Name
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// need to lookup hostVeth again as its index has changed during ns move
+	hostVeth, err := netlink.LinkByName(hostIface.Name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to lookup %q: %v", hostIface.Name, err)
+	}
+	hostIface.Mac = hostVeth.Attrs().HardwareAddr.String()
+
+	// connect host veth end to the bridge
+	if err := netlink.LinkSetMaster(hostVeth, br); err != nil {
+		return nil, nil, fmt.Errorf("failed to connect %q to bridge %v: %v", hostVeth.Attrs().Name, br.Attrs().Name, err)
+	}
+
+	// set hairpin mode
+	if err = netlink.LinkSetHairpin(hostVeth, hairpinMode); err != nil {
+		return nil, nil, fmt.Errorf("failed to setup hairpin mode for %v: %v", hostVeth.Attrs().Name, err)
+	}
+
+	return hostIface, contIface, nil
+}
+
+func setupBridge(n *NetConf) (*netlink.Bridge, *current.Interface, error) {
+	// create bridge if necessary
+	br, err := ensureBridge(n.BrName, n.MTU, n.PromiscMode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create bridge %q: %v", n.BrName, err)
+	}
+
+	return br, &current.Interface{
+		Name: br.Attrs().Name,
+		Mac:  br.Attrs().HardwareAddr.String(),
+	}, nil
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	n, cniVersion, err := loadNetConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	if n.HairpinMode && n.PromiscMode {
+		return fmt.Errorf("cannot set hairpin mode and promiscous mode at the same time.")
+	}
+
+	br, brInterface, err := setupBridge(n)
+	if err != nil {
+		return err
+	}
+
+	netns, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	}
+	defer netns.Close()
+
+	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode)
+	if err != nil {
+		return err
+	}
+
+	result := &current.Result{CNIVersion: cniVersion}
+	result.Interfaces = []*current.Interface{brInterface, hostInterface, containerInterface}
+
+	// Refetch the bridge since its MAC address may change when the first
+	// veth is added
+	br, err = bridgeByName(n.BrName)
+	if err != nil {
+		return err
+	}
+	brInterface.Mac = br.Attrs().HardwareAddr.String()
+
+	// Return an error requested by testcases, if any
+	if debugPostIPAMError != nil {
+		return debugPostIPAMError
+	}
+
+	return types.PrintResult(result, cniVersion)
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	_, _, err := loadNetConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+}
+
+func cmdGet(args *skel.CmdArgs) error {
+	return fmt.Errorf("not implemented")
+}

--- a/plugins/main/l2-bridge/l2-bridge_suite_test.go
+++ b/plugins/main/l2-bridge/l2-bridge_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestL2Bridge(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "plugins/main/l2-bridge")
+}

--- a/plugins/main/l2-bridge/l2-bridge_test.go
+++ b/plugins/main/l2-bridge/l2-bridge_test.go
@@ -1,0 +1,357 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	BRNAME = "bridge0"
+	IFNAME = "eth0"
+)
+
+// testCase defines the CNI network configuration and the expected
+// bridge addresses for a test case.
+type testCase struct {
+	cniVersion string // CNI Version
+}
+
+// Range definition for each entry in the ranges list
+type rangeInfo struct {
+	subnet  string
+	gateway string
+}
+
+// netConf() creates a NetConf structure for a test case.
+func (tc testCase) netConf() *NetConf {
+	return &NetConf{
+		NetConf: types.NetConf{
+			CNIVersion: tc.cniVersion,
+			Name:       "testConfig",
+			Type:       "l2-bridge",
+		},
+		BrName: BRNAME,
+		MTU:    5000,
+	}
+}
+
+// Snippets for generating a JSON network configuration string.
+const (
+	netConfStr = `
+	"cniVersion": "%s",
+	"name": "testConfig",
+	"type": "bridge",
+	"bridge": "%s"`
+)
+
+// netConfJSON() generates a JSON network configuration string
+// for a test case.
+func (tc testCase) netConfJSON(dataDir string) string {
+	conf := fmt.Sprintf(netConfStr, tc.cniVersion, BRNAME)
+	return "{" + conf + "\n}"
+}
+
+var counter uint
+
+// createCmdArgs generates network configuration and creates command
+// arguments for a test case.
+func (tc testCase) createCmdArgs(targetNS ns.NetNS, dataDir string) *skel.CmdArgs {
+	conf := tc.netConfJSON(dataDir)
+	defer func() { counter += 1 }()
+	return &skel.CmdArgs{
+		ContainerID: fmt.Sprintf("dummy-%d", counter),
+		Netns:       targetNS.Path(),
+		IfName:      IFNAME,
+		StdinData:   []byte(conf),
+	}
+}
+
+type cmdAddDelTester interface {
+	setNS(testNS ns.NetNS, targetNS ns.NetNS)
+	cmdAddTest(tc testCase, dataDir string)
+	cmdDelTest(tc testCase)
+}
+
+type testerV03x struct {
+	testNS   ns.NetNS
+	targetNS ns.NetNS
+	args     *skel.CmdArgs
+	vethName string
+}
+
+func (tester *testerV03x) setNS(testNS ns.NetNS, targetNS ns.NetNS) {
+	tester.testNS = testNS
+	tester.targetNS = targetNS
+}
+
+func (tester *testerV03x) cmdAddTest(tc testCase, dataDir string) {
+	// Generate network config and command arguments
+	tester.args = tc.createCmdArgs(tester.targetNS, dataDir)
+
+	// Execute cmdADD on the plugin
+	var result *current.Result
+	err := tester.testNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		r, raw, err := testutils.CmdAddWithArgs(tester.args, func() error {
+			return cmdAdd(tester.args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"interfaces\":")).Should(BeNumerically(">", 0))
+
+		result, err = current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(result.Interfaces)).To(Equal(3))
+		Expect(result.Interfaces[0].Name).To(Equal(BRNAME))
+		Expect(result.Interfaces[0].Mac).To(HaveLen(17))
+
+		Expect(result.Interfaces[1].Name).To(HavePrefix("veth"))
+		Expect(result.Interfaces[1].Mac).To(HaveLen(17))
+
+		Expect(result.Interfaces[2].Name).To(Equal(IFNAME))
+		Expect(result.Interfaces[2].Mac).To(HaveLen(17)) //mac is random
+		Expect(result.Interfaces[2].Sandbox).To(Equal(tester.targetNS.Path()))
+
+		// Make sure bridge link exists
+		link, err := netlink.LinkByName(result.Interfaces[0].Name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.Attrs().Name).To(Equal(BRNAME))
+		Expect(link).To(BeAssignableToTypeOf(&netlink.Bridge{}))
+		Expect(link.Attrs().HardwareAddr.String()).To(Equal(result.Interfaces[0].Mac))
+
+		// Check for the veth link in the main namespace
+		links, err := netlink.LinkList()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(links)).To(Equal(3)) // Bridge, veth, and loopback
+
+		link, err = netlink.LinkByName(result.Interfaces[1].Name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+		tester.vethName = result.Interfaces[1].Name
+
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Find the veth peer in the container namespace and the default route
+	err = tester.targetNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		link, err := netlink.LinkByName(IFNAME)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(link.Attrs().Name).To(Equal(IFNAME))
+		Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (tester *testerV03x) cmdDelTest(tc testCase) {
+	err := tester.testNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		err := testutils.CmdDelWithArgs(tester.args, func() error {
+			return cmdDel(tester.args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Make sure the host veth has been deleted
+	err = tester.targetNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		link, err := netlink.LinkByName(IFNAME)
+		Expect(err).To(HaveOccurred())
+		Expect(link).To(BeNil())
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Make sure the container veth has been deleted
+	err = tester.testNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		link, err := netlink.LinkByName(tester.vethName)
+		Expect(err).To(HaveOccurred())
+		Expect(link).To(BeNil())
+		return nil
+	})
+}
+
+func cmdAddDelTest(testNS ns.NetNS, tc testCase, dataDir string) {
+	// Get a Add/Del tester based on test case version
+	tester := &testerV03x{}
+
+	targetNS, err := testutils.NewNS()
+	Expect(err).NotTo(HaveOccurred())
+	defer targetNS.Close()
+	tester.setNS(testNS, targetNS)
+
+	// Test veth allocation
+	tester.cmdAddTest(tc, dataDir)
+
+	// Test veth Release
+	tester.cmdDelTest(tc)
+
+}
+
+var _ = Describe("bridge Operations", func() {
+	var originalNS ns.NetNS
+	var dataDir string
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		dataDir, err = ioutil.TempDir("", "bridge_test")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Do not emulate an error, each test will set this if needed
+		debugPostIPAMError = nil
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	It("creates a bridge", func() {
+		conf := testCase{cniVersion: "0.3.1"}.netConf()
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			bridge, _, err := setupBridge(conf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bridge.Attrs().Name).To(Equal(BRNAME))
+
+			// Double check that the link was added
+			link, err := netlink.LinkByName(BRNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			Expect(link.Attrs().Promisc).To(Equal(0))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("handles an existing bridge", func() {
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := netlink.LinkAdd(&netlink.Bridge{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: BRNAME,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			link, err := netlink.LinkByName(BRNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			ifindex := link.Attrs().Index
+
+			tc := testCase{cniVersion: "0.3.1"}
+			conf := tc.netConf()
+
+			bridge, _, err := setupBridge(conf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bridge.Attrs().Name).To(Equal(BRNAME))
+			Expect(bridge.Attrs().Index).To(Equal(ifindex))
+
+			// Double check that the link has the same ifindex
+			link, err = netlink.LinkByName(BRNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			Expect(link.Attrs().Index).To(Equal(ifindex))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures a bridge and veth with ADD/DEL for 0.3.0 config", func() {
+		tc := testCase{cniVersion: "0.3.0"}
+		cmdAddDelTest(originalNS, tc, dataDir)
+	})
+
+	It("configures and deconfigures a bridge and veth with ADD/DEL for 0.3.1 config", func() {
+		tc := testCase{cniVersion: "0.3.1"}
+		cmdAddDelTest(originalNS, tc, dataDir)
+	})
+
+	It("deconfigures an unconfigured bridge with DEL", func() {
+		tc := testCase{cniVersion: "0.3.0"}
+
+		tester := testerV03x{}
+		targetNS, err := testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNS.Close()
+		tester.setNS(originalNS, targetNS)
+		tester.args = tc.createCmdArgs(targetNS, dataDir)
+
+		// Execute cmdDEL on the plugin, expect no errors
+		tester.cmdDelTest(tc)
+	})
+
+	It("ensure promiscuous mode on bridge", func() {
+		const IFNAME = "bridge0"
+
+		conf := &NetConf{
+			NetConf: types.NetConf{
+				CNIVersion: "0.3.1",
+				Name:       "testConfig",
+				Type:       "bridge",
+			},
+			BrName:      IFNAME,
+			HairpinMode: false,
+			PromiscMode: true,
+			MTU:         5000,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			_, _, err := setupBridge(conf)
+			Expect(err).NotTo(HaveOccurred())
+
+			//Check if promiscuous mode is set correctly
+			link, err := netlink.LinkByName("bridge0")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(link.Attrs().Promisc).To(Equal(1))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Pure l2 bridge connected to a physical interface on the host.

Sample:
```
{
        "name":"mynet",
	"cniVersion": "0.3.0",
	"type": "l2-bridge",
	"bridge": "mynet0",
}
```

I will like to know if this is something that can be in this repo.
allow the pod to have a l2 interface.
for now the user need to create and connect the bridge to a physical interface on every host.  
 
PR for issue #182 