### PR TITLE
L2 bridge Implementation

### DIFF
--- a/plugins/main/bridge/README.md
+++ b/plugins/main/bridge/README.md
@@ -28,6 +28,17 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 }
 ```
 
+## Example L2-only configuration
+```
+{
+    "cniVersion": "0.3.1",
+	"name": "mynet",
+	"type": "bridge",
+	"bridge": "mynet0",
+	"ipam": {}
+}
+```
+
 ## Network configuration reference
 
 * `name` (string, required): the name of the network.
@@ -39,5 +50,5 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
-* `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `ipam` (dictionary, required): IPAM configuration to be used for this network. For L2-only network, create empty dictionary.
 * `promiscMode` (boolean, optional): set promiscuous mode on the bridge. Defaults to false.


### PR DESCRIPTION
This PR Change the bridge plugin to allow empty IPAM.

When the IPAM dictionary is empty the bridge plugin will connect a pure L2 interface(without any IP address on the interface) from the pod to a bridge on the host.

This PR will allow containers and everything running on top of them to have a pure L2 interface connected to a bridge. This can be useful for use cases of sniffing, running dhclient, give the pod a trunk interface, etc..  