### PR TITLE
Add description for mac/mtu/promisc in tuning README.md

### DIFF
--- a/plugins/meta/tuning/README.md
+++ b/plugins/meta/tuning/README.md
@@ -50,7 +50,7 @@ The parameters, "mac", "mtu" and "promisc", changes the interface attributes as 
 
 * `mac` (string, optional): MAC address (i.e. hardware address) of interface
 * `mtu` (integer, optional): MTU of interface
-* `promisc` (bool, optional): Change the promiscas mode of interface
+* `promisc` (bool, optional): Change the promiscuous mode of interface
 
 ## Supported arguments
 The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:

--- a/plugins/meta/tuning/README.md
+++ b/plugins/meta/tuning/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This plugin can change some system controls (sysctls) and several netlink attributes (promiscuous mode and mac) in the network namespace.
+This plugin can change some system controls (sysctls) and several interface attributes (promiscuous mode, MTU and MAC address) in the network namespace.
 It does not create any network interfaces and therefore does not bring connectivity by itself.
 It is only useful when used in addition to other plugins.
 
@@ -33,7 +33,7 @@ Some network sysctls are documented in the Linux sources:
 - [Documentation/networking/ip-sysctl.txt](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt)
 - [Documentation/networking/](https://www.kernel.org/doc/Documentation/networking/)
 
-## Netlink Operation
+## Interface Attribute Operation
 The parameters, "mac", "mtu" and "promisc", changes the interface attributes as followings:
 
 ```
@@ -46,7 +46,7 @@ The parameters, "mac", "mtu" and "promisc", changes the interface attributes as 
 }
 ```
 
-## Netlink configuration reference
+## Interface attribute configuration reference
 
 * `mac` (string, optional): MAC address (i.e. hardware address) of interface
 * `mtu` (integer, optional): MTU of interface

--- a/plugins/meta/tuning/README.md
+++ b/plugins/meta/tuning/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This plugin can change some system controls (sysctls) in the network namespace.
+This plugin can change some system controls (sysctls) and several netlink attributes (promiscuous mode and mac) in the network namespace.
 It does not create any network interfaces and therefore does not bring connectivity by itself.
 It is only useful when used in addition to other plugins.
 
-## Operation
+## System Controls Operation
 The following network configuration file
 ```
 {
@@ -32,3 +32,32 @@ Some network sysctls are documented in the Linux sources:
 - [Documentation/sysctl/net.txt](https://www.kernel.org/doc/Documentation/sysctl/net.txt)
 - [Documentation/networking/ip-sysctl.txt](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt)
 - [Documentation/networking/](https://www.kernel.org/doc/Documentation/networking/)
+
+## Netlink Operation
+The parameters, "mac", "mtu" and "promisc", changes the interface attributes as followings:
+
+```
+{
+  "name": "mytuning",
+  "type": "tuning",
+  "promisc": true,
+  "mac": "c2:b0:57:49:47:f1",
+  "mtu": 1454
+}
+```
+
+## Netlink configuration reference
+
+* `mac` (string, optional): MAC address (i.e. hardware address) of interface
+* `mtu` (integer, optional): MTU of interface
+* `promisc` (bool, optional): Change the promiscas mode of interface
+
+## Supported arguments
+The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
+
+* `MAC`: request a specific MAC address for the interface 
+
+    (example: CNI_ARGS="IgnoreUnknown=true;MAC=c2:11:22:33:44:55")
+
+Note: You may add `IgnoreUnknown=true` to allow loose CNI argument verification (see CNI's issue[#560](https://github.com/containernetworking/cni/issues/560)).
+

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -111,7 +111,7 @@ var _ = Describe("tuning plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("configures and deconfigures promiscas mode with ADD/DEL", func() {
+	It("configures and deconfigures promiscuous mode with ADD/DEL", func() {
 		conf := []byte(`{
 	"name": "test",
 	"type": "iplink",


### PR DESCRIPTION
This diff adds documents for #177 change (mac/mtu/promisc) in tuning README.md. Fixes #199.