### PR TITLE
Revert "Merge pull request #180 from squeed/v0.7-bump-iptables"

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/containernetworking/plugins",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v80",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -47,8 +47,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-iptables/iptables",
-			"Comment": "v0.4.0",
-			"Rev": "47f22b0dd3355c0ba570ba12b0b8a36bf214c04b"
+			"Comment": "v0.2.0",
+			"Rev": "259c8e6a4275d497442c721fa52204d7a58bde8b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/activation",

--- a/vendor/github.com/coreos/go-iptables/NOTICE
+++ b/vendor/github.com/coreos/go-iptables/NOTICE
@@ -1,5 +1,0 @@
-CoreOS Project
-Copyright 2018 CoreOS, Inc
-
-This product includes software developed at CoreOS, Inc.
-(http://www.coreos.com/).


### PR DESCRIPTION
This reverts commit 19f2f28178aa88772f69c4eeb3793d4a63c244b0, reversing
changes made to 72b62babeeb3d7b25c9809ea9eb9fc9c02cc0f71.

In other words, undo all the go-iptables madness and bring us back to where we were with v0.7.1