### PR TITLE
Correct misplace function name of 'CreateIngressQdisc' and 'CreateEgr…

### DIFF
--- a/plugins/meta/bandwidth/ifb_creator.go
+++ b/plugins/meta/bandwidth/ifb_creator.go
@@ -50,7 +50,7 @@ func TeardownIfb(deviceName string) error {
 	return err
 }
 
-func CreateIngressQdisc(rateInBits, burstInBits int, hostDeviceName string) error {
+func CreateEgressQdisc(rateInBits, burstInBits int, hostDeviceName string) error {
 	hostDevice, err := netlink.LinkByName(hostDeviceName)
 	if err != nil {
 		return fmt.Errorf("get host device: %s", err)
@@ -58,7 +58,7 @@ func CreateIngressQdisc(rateInBits, burstInBits int, hostDeviceName string) erro
 	return createTBF(rateInBits, burstInBits, hostDevice.Attrs().Index)
 }
 
-func CreateEgressQdisc(rateInBits, burstInBits int, hostDeviceName string, ifbDeviceName string) error {
+func CreateIngressQdisc(rateInBits, burstInBits int, hostDeviceName string, ifbDeviceName string) error {
 	ifbDevice, err := netlink.LinkByName(ifbDeviceName)
 	if err != nil {
 		return fmt.Errorf("get ifb device: %s", err)

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -172,14 +172,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if bandwidth.IngressRate > 0 && bandwidth.IngressBurst > 0 {
-		err = CreateIngressQdisc(bandwidth.IngressRate, bandwidth.IngressBurst, hostInterface.Name)
+	if bandwidth.EgressRate > 0 && bandwidth.EgressBurst > 0 {
+		err = CreateEgressQdisc(bandwidth.EgressRate, bandwidth.EgressBurst, hostInterface.Name)
 		if err != nil {
 			return err
 		}
 	}
 
-	if bandwidth.EgressRate > 0 && bandwidth.EgressBurst > 0 {
+	if bandwidth.IngressRate > 0 && bandwidth.IngressBurst > 0 {
 		mtu, err := getMTU(hostInterface.Name)
 		if err != nil {
 			return err
@@ -204,7 +204,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Name: ifbDeviceName,
 			Mac:  ifbDevice.Attrs().HardwareAddr.String(),
 		})
-		err = CreateEgressQdisc(bandwidth.EgressRate, bandwidth.EgressBurst, hostInterface.Name, ifbDeviceName)
+		err = CreateIngressQdisc(bandwidth.IngressRate, bandwidth.IngressBurst, hostInterface.Name, ifbDeviceName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The original version of `bandwidth` misplace the function name of `CreateIngressQdisc` and `CreateEgressQdisc`.

In original `CreateIngressQdisc()`, it create egress qdisc of network interface, so it 
should be `CreateEgressQdisc` and same as original `CreateEgressQdisc()`.