### PR TITLE
host-local: add ifname to file tracking IP address used 

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -41,7 +41,7 @@ func NewIPAllocator(s *RangeSet, store backend.Store, id int) *IPAllocator {
 }
 
 // Get alocates an IP
-func (a *IPAllocator) Get(id string, requestedIP net.IP) (*current.IPConfig, error) {
+func (a *IPAllocator) Get(id string, ifname string, requestedIP net.IP) (*current.IPConfig, error) {
 	a.store.Lock()
 	defer a.store.Unlock()
 
@@ -62,7 +62,7 @@ func (a *IPAllocator) Get(id string, requestedIP net.IP) (*current.IPConfig, err
 			return nil, fmt.Errorf("requested ip %s is subnet's gateway", requestedIP.String())
 		}
 
-		reserved, err := a.store.Reserve(id, requestedIP, a.rangeID)
+		reserved, err := a.store.Reserve(id, ifname, requestedIP, a.rangeID)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,7 @@ func (a *IPAllocator) Get(id string, requestedIP net.IP) (*current.IPConfig, err
 				break
 			}
 
-			reserved, err := a.store.Reserve(id, reservedIP.IP, a.rangeID)
+			reserved, err := a.store.Reserve(id, ifname, reservedIP.IP, a.rangeID)
 			if err != nil {
 				return nil, err
 			}
@@ -110,11 +110,11 @@ func (a *IPAllocator) Get(id string, requestedIP net.IP) (*current.IPConfig, err
 }
 
 // Release clears all IPs allocated for the container with given ID
-func (a *IPAllocator) Release(id string) error {
+func (a *IPAllocator) Release(id string, ifname string) error {
 	a.store.Lock()
 	defer a.store.Unlock()
 
-	return a.store.ReleaseByID(id)
+	return a.store.ReleaseByID(id, ifname)
 }
 
 type RangeIter struct {

--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -26,6 +26,7 @@ import (
 )
 
 const lastIPFilePrefix = "last_reserved_ip."
+const LineBreak = "\r\n"
 
 var defaultDataDir = "/var/lib/cni/networks"
 
@@ -65,7 +66,7 @@ func (s *Store) Reserve(id string, ifname string, ip net.IP, rangeID string) (bo
 	if err != nil {
 		return false, err
 	}
-	if _, err := f.WriteString(strings.TrimSpace(id) + "\n" + ifname); err != nil {
+	if _, err := f.WriteString(strings.TrimSpace(id) + LineBreak + ifname); err != nil {
 		f.Close()
 		os.Remove(f.Name())
 		return false, err
@@ -97,10 +98,7 @@ func (s *Store) Release(ip net.IP) error {
 	return os.Remove(GetEscapedPath(s.dataDir, ip.String()))
 }
 
-// N.B. This function eats errors to be tolerant and
-// release as much as possible
-func (s *Store) ReleaseByID(id string, ifname string) error {
-
+func (s *Store) ReleaseByKey(id string, ifname string, match string) (bool, error) {
 	found := false
 	err := filepath.Walk(s.dataDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
@@ -110,7 +108,7 @@ func (s *Store) ReleaseByID(id string, ifname string) error {
 		if err != nil {
 			return nil
 		}
-		if strings.TrimSpace(string(data)) == (strings.TrimSpace(id) + "\n" + ifname) {
+		if strings.TrimSpace(string(data)) == match {
 			if err := os.Remove(path); err != nil {
 				return nil
 			}
@@ -118,27 +116,21 @@ func (s *Store) ReleaseByID(id string, ifname string) error {
 		}
 		return nil
 	})
+	return found, err
 
-	if (!found) && (err == nil) {
-		err = filepath.Walk(s.dataDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() {
-				return nil
-			}
-			data, err := ioutil.ReadFile(path)
-			if err != nil {
-				return nil
-			}
-			isCurrent := strings.Contains(string(data), "\n")
+}
 
-			if !isCurrent {
-				if strings.TrimSpace(string(data)) == (strings.TrimSpace(id)) {
-					if err := os.Remove(path); err != nil {
-						return nil
-					}
-				}
-			}
-			return nil
-		})
+// N.B. This function eats errors to be tolerant and
+// release as much as possible
+func (s *Store) ReleaseByID(id string, ifname string) error {
+	found := false
+	match := strings.TrimSpace(id) + LineBreak + ifname
+	found, err := s.ReleaseByKey(id, ifname, match)
+
+	// For backwards compatibility, look for files written by a previous version
+	if !found && err == nil {
+		match := strings.TrimSpace(id)
+		found, err = s.ReleaseByKey(id, ifname, match)
 	}
 	return err
 }

--- a/plugins/ipam/host-local/backend/store.go
+++ b/plugins/ipam/host-local/backend/store.go
@@ -20,8 +20,8 @@ type Store interface {
 	Lock() error
 	Unlock() error
 	Close() error
-	Reserve(id string, ip net.IP, rangeID string) (bool, error)
+	Reserve(id string, ifname string, ip net.IP, rangeID string) (bool, error)
 	LastReservedIP(rangeID string) (net.IP, error)
 	Release(ip net.IP) error
-	ReleaseByID(id string) error
+	ReleaseByID(id string, ifname string) error
 }

--- a/plugins/ipam/host-local/backend/testing/fake_store.go
+++ b/plugins/ipam/host-local/backend/testing/fake_store.go
@@ -45,7 +45,7 @@ func (s *FakeStore) Close() error {
 	return nil
 }
 
-func (s *FakeStore) Reserve(id string, ip net.IP, rangeID string) (bool, error) {
+func (s *FakeStore) Reserve(id string, ifname string, ip net.IP, rangeID string) (bool, error) {
 	key := ip.String()
 	if _, ok := s.ipMap[key]; !ok {
 		s.ipMap[key] = id
@@ -68,7 +68,7 @@ func (s *FakeStore) Release(ip net.IP) error {
 	return nil
 }
 
-func (s *FakeStore) ReleaseByID(id string) error {
+func (s *FakeStore) ReleaseByID(id string, ifname string) error {
 	toDelete := []string{}
 	for k, v := range s.ipMap {
 		if v == id {

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -111,12 +111,12 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath1 := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath1)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID))
+		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
 
 		ipFilePath2 := filepath.Join(tmpDir, disk.GetEscapedPath("mynet", "2001:db8:1::2"))
 		contents, err = ioutil.ReadFile(ipFilePath2)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID))
+		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
 
 		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath1)
@@ -223,7 +223,7 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID))
+		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
 
 		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath)
@@ -281,7 +281,7 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath := filepath.Join(tmpDir, "mynet", result.IPs[0].Address.IP.String())
 		contents, err := ioutil.ReadFile(ipFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal("dummy"))
+		Expect(string(contents)).To(Equal("dummy" + "\n" + ifname))
 
 		// Release the IP
 		err = testutils.CmdDelWithArgs(args, func() error {

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -33,6 +33,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const LineBreak = "\r\n"
+
 var _ = Describe("host-local Operations", func() {
 	It("allocates and releases addresses with ADD/DEL", func() {
 		const ifname string = "eth0"
@@ -111,12 +113,12 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath1 := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath1)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
+		Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
 
 		ipFilePath2 := filepath.Join(tmpDir, disk.GetEscapedPath("mynet", "2001:db8:1::2"))
 		contents, err = ioutil.ReadFile(ipFilePath2)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
+		Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
 
 		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath1)
@@ -136,6 +138,173 @@ var _ = Describe("host-local Operations", func() {
 		_, err = os.Stat(ipFilePath1)
 		Expect(err).To(HaveOccurred())
 		_, err = os.Stat(ipFilePath2)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("allocates and releases addresses on specific interface with ADD/DEL", func() {
+		const ifname0 string = "eth0"
+		const ifname1 string = "eth1"
+		const nspath string = "/some/where"
+
+		tmpDir, err := getTmpDir()
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		conf0 := fmt.Sprintf(`{
+		"cniVersion": "0.3.1",
+		"name": "mynet0",
+		"type": "ipvlan",
+		"master": "foo0",
+			"ipam": {
+				"type": "host-local",
+				"dataDir": "%s",
+				"resolvConf": "%s/resolv.conf",
+				"ranges": [
+					[{ "subnet": "10.1.2.0/24" }]
+				]
+			}
+		}`, tmpDir, tmpDir)
+
+		conf1 := fmt.Sprintf(`{
+		"cniVersion": "0.3.1",
+		"name": "mynet1",
+		"type": "ipvlan",
+		"master": "foo1",
+			"ipam": {
+				"type": "host-local",
+				"dataDir": "%s",
+				"resolvConf": "%s/resolv.conf",
+				"ranges": [
+					[{ "subnet": "10.2.2.0/24" }]
+				]
+			}
+		}`, tmpDir, tmpDir)
+
+		args0 := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname0,
+			StdinData:   []byte(conf0),
+		}
+
+		// Allocate the IP
+		r0, raw, err := testutils.CmdAddWithArgs(args0, func() error {
+			return cmdAdd(args0)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		_, err = current.GetResult(r0)
+		Expect(err).NotTo(HaveOccurred())
+
+		args1 := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname1,
+			StdinData:   []byte(conf1),
+		}
+
+		// Allocate the IP
+		r1, raw, err := testutils.CmdAddWithArgs(args1, func() error {
+			return cmdAdd(args1)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		_, err = current.GetResult(r1)
+		Expect(err).NotTo(HaveOccurred())
+
+		ipFilePath0 := filepath.Join(tmpDir, "mynet0", "10.1.2.2")
+		contents, err := ioutil.ReadFile(ipFilePath0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal(args0.ContainerID + LineBreak + ifname0))
+
+		ipFilePath1 := filepath.Join(tmpDir, "mynet1", "10.2.2.2")
+		contents, err = ioutil.ReadFile(ipFilePath1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal(args1.ContainerID + LineBreak + ifname1))
+
+		// Release the IP on ifname0
+		err = testutils.CmdDelWithArgs(args0, func() error {
+			return cmdDel(args0)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(ipFilePath0)
+		Expect(err).To(HaveOccurred())
+
+		// reread ipFilePath1, ensure that ifname1 didn't get deleted
+		contents, err = ioutil.ReadFile(ipFilePath1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal(args1.ContainerID + LineBreak + ifname1))
+
+		// Release the IP on ifname1
+		err = testutils.CmdDelWithArgs(args1, func() error {
+			return cmdDel(args1)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = os.Stat(ipFilePath1)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Verify DEL works on backwards compatible allocate", func() {
+		const nspath string = "/some/where"
+		const ifname string = "eth0"
+
+		tmpDir, err := getTmpDir()
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+		"cniVersion": "0.3.1",
+		"name": "mynet",
+		"type": "ipvlan",
+		"master": "foo",
+			"ipam": {
+				"type": "host-local",
+				"dataDir": "%s",
+				"resolvConf": "%s/resolv.conf",
+				"ranges": [
+					[{ "subnet": "10.1.2.0/24" }]
+				]
+			}
+		}`, tmpDir, tmpDir)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		_, err = current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
+		contents, err := ioutil.ReadFile(ipFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
+		err = ioutil.WriteFile(ipFilePath, []byte(strings.TrimSpace(args.ContainerID)), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(ipFilePath)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -223,7 +392,7 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
 		contents, err := ioutil.ReadFile(ipFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal(args.ContainerID + "\n" + ifname))
+		Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
 
 		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
 		contents, err = ioutil.ReadFile(lastFilePath)
@@ -281,7 +450,7 @@ var _ = Describe("host-local Operations", func() {
 		ipFilePath := filepath.Join(tmpDir, "mynet", result.IPs[0].Address.IP.String())
 		contents, err := ioutil.ReadFile(ipFilePath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).To(Equal("dummy" + "\n" + ifname))
+		Expect(string(contents)).To(Equal("dummy" + LineBreak + ifname))
 
 		// Release the IP
 		err = testutils.CmdDelWithArgs(args, func() error {

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -85,11 +85,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 
-		ipConf, err := allocator.Get(args.ContainerID, requestedIP)
+		ipConf, err := allocator.Get(args.ContainerID, args.IfName, requestedIP)
 		if err != nil {
 			// Deallocate all already allocated IPs
 			for _, alloc := range allocs {
-				_ = alloc.Release(args.ContainerID)
+				_ = alloc.Release(args.ContainerID, args.IfName)
 			}
 			return fmt.Errorf("failed to allocate for range %d: %v", idx, err)
 		}
@@ -102,7 +102,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// If an IP was requested that wasn't fulfilled, fail
 	if len(requestedIPs) != 0 {
 		for _, alloc := range allocs {
-			_ = alloc.Release(args.ContainerID)
+			_ = alloc.Release(args.ContainerID, args.IfName)
 		}
 		errstr := "failed to allocate all requested IPs:"
 		for _, ip := range requestedIPs {
@@ -133,7 +133,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	for idx, rangeset := range ipamConf.Ranges {
 		ipAllocator := allocator.NewIPAllocator(&rangeset, store, idx)
 
-		err := ipAllocator.Release(args.ContainerID)
+		err := ipAllocator.Release(args.ContainerID, args.IfName)
 		if err != nil {
 			errors = append(errors, err.Error())
 		}


### PR DESCRIPTION

host-local: add ifname to file tracking IP address used 

Obtain ifname from CmdArgs and pass to backend 
In the file tracking the IP address in use, add ifname to the line after ContainerID
Update host-local tests to use ifname along with ContainerID in storage file

Fixes #164 
