### PR TITLE
Add missing error checks

### DIFF
--- a/pkg/ip/ipforward_linux_test.go
+++ b/pkg/ip/ipforward_linux_test.go
@@ -12,6 +12,7 @@ import (
 var _ = Describe("IpforwardLinux", func() {
 	It("echo1 must not write the file if content is 1", func() {
 		file, err := ioutil.TempFile(os.TempDir(), "containernetworking")
+		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(file.Name())
 		err = echo1(file.Name())
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ns/ns_linux_test.go
+++ b/pkg/ns/ns_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CNI authors
+// Copyright 2016-2018 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ var _ = Describe("Linux namespace operations", func() {
 					Expect(hostNSInode).To(Equal(origNSInode))
 					return nil
 				})
+				Expect(err).NotTo(HaveOccurred())
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -224,6 +225,7 @@ var _ = Describe("Linux namespace operations", func() {
 	Describe("IsNSorErr", func() {
 		It("should detect a namespace", func() {
 			createdNetNS, err := testutils.NewNS()
+			Expect(err).NotTo(HaveOccurred())
 			defer testutils.UnmountNS(createdNetNS)
 			err = ns.IsNSorErr(createdNetNS.Path())
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CNI authors
+// Copyright 2015-2018 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,6 +157,7 @@ var _ = Describe("DHCP Operations", func() {
 					Mask: net.IPv4Mask(0, 0, 0, 0),
 				},
 			})
+			Expect(err).NotTo(HaveOccurred())
 
 			cont, err := netlink.LinkByName(contVethName)
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CNI authors
+// Copyright 2015-2018 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -431,6 +431,7 @@ func (tester *testerV03x) cmdDelTest(tc testCase) {
 		Expect(link).To(BeNil())
 		return nil
 	})
+	Expect(err).NotTo(HaveOccurred())
 }
 
 type testerV01xOr02x struct {
@@ -939,6 +940,7 @@ var _ = Describe("bridge Operations", func() {
 		for _, tc := range testCases {
 			tc.cniVersion = "0.3.1"
 			_, _, err := setupBridge(tc.netConf())
+			Expect(err).NotTo(HaveOccurred())
 			link, err := netlink.LinkByName(BRNAME)
 			Expect(err).NotTo(HaveOccurred())
 			origMac := link.Attrs().HardwareAddr

--- a/plugins/meta/bandwidth/bandwidth_suite_test.go
+++ b/plugins/meta/bandwidth/bandwidth_suite_test.go
@@ -167,6 +167,7 @@ func createVeth(hostNamespace string, hostVethIfName string, containerNamespace 
 	Expect(err).NotTo(HaveOccurred())
 
 	containerNs, err := ns.GetNS(containerNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	err = containerNs.Do(func(_ ns.NetNS) error {
 		peerAddr := &net.IPNet{
 			IP:   hostIP,

--- a/plugins/meta/portmap/chain_test.go
+++ b/plugins/meta/portmap/chain_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 CNI authors
+// Copyright 2017-2018 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -178,6 +178,7 @@ var _ = Describe("chain tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		chains, err := ipt.ListChains(TABLE)
+		Expect(err).NotTo(HaveOccurred())
 		for _, chain := range chains {
 			if chain == testChain.name {
 				Fail("Chain was not deleted")
@@ -187,6 +188,7 @@ var _ = Describe("chain tests", func() {
 		err = testChain.teardown(ipt)
 		Expect(err).NotTo(HaveOccurred())
 		chains, err = ipt.ListChains(TABLE)
+		Expect(err).NotTo(HaveOccurred())
 		for _, chain := range chains {
 			if chain == testChain.name {
 				Fail("Chain was not deleted")


### PR DESCRIPTION
Fix all ineffectual assignments to `err` variables which are not followed by error check.