### PR TITLE
Handle empty netns in DEL for `loopback` and `host-device`.

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -85,6 +85,9 @@ func cmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	if args.Netns == "" {
+		return nil
+	}
 	containerNs, err := ns.GetNS(args.Netns)
 	if err != nil {
 		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)

--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -48,6 +48,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
+	if args.Netns == "" {
+		return nil
+	}
 	args.IfName = "lo" // ignore config, this only works for loopback
 	err := ns.WithNetNSPath(args.Netns, func(ns.NetNS) error {
 		link, err := netlink.LinkByName(args.IfName)


### PR DESCRIPTION
Fixes https://github.com/containernetworking/plugins/issues/210.

Conform to new CNI spec https://github.com/containernetworking/cni/commit/23a5d8e617027c87a84605426c3b228931c69826.

Signed-off-by: Lantao Liu <lantaol@google.com>