### PR TITLE
fix the typo of macvlan and also modify documents to meet the current plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
 * `macvlan`: Creates a new MAC address, forwards all traffic to that to the container.
 * `ptp`: Creates a veth pair.
 * `vlan`: Allocates a vlan device.
+* `host-device`: Move an already-existing device into a container.
 #### Windows: windows specific
 * `win-bridge`: Creates a bridge, adds the host and the container to it.
 * `win-overlay`: Creates an overlay interface to the container.
 ### IPAM: IP address allocation
 * `dhcp`: Runs a daemon on the host to make DHCP requests on behalf of the container
 * `host-local`: Maintains a local database of allocated IPs
+* `static`:  Allocate a static IPv4/IPv6 addresses to container and it's userful in debugging purpose.
 
 ### Meta: other plugins
 * `flannel`: Generates an interface corresponding to a flannel config file

--- a/plugins/main/host-device/README.md
+++ b/plugins/main/host-device/README.md
@@ -1,5 +1,5 @@
 # host-device
-Move an already-existing device in to a container.
+Move an already-existing device into a container.
 
 This simple plugin will move the requested device from the host's network namespace
 to the container's. Nothing else will be done - no IPAM, no addresses.

--- a/plugins/main/macvlan/README.md
+++ b/plugins/main/macvlan/README.md
@@ -24,7 +24,7 @@ Since each macvlan interface has its own MAC address, it makes it easy to use wi
 * `name` (string, required): the name of the network
 * `type` (string, required): "macvlan"
 * `master` (string, required): name of the host interface to enslave
-* `mode` (string, optional): one of "bridge", "private", "vepa", "passthrough". Defaults to "bridge".
+* `mode` (string, optional): one of "bridge", "private", "vepa", "passthru". Defaults to "bridge".
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.
 


### PR DESCRIPTION
Refer to issue #178 