### PR TITLE
Added CONTRIBUTORS.md for Windows and CNI plugins OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,8 @@
+# Owners
+This is the official list of the CNI network plugins owners:
+- Bryan Boreham <bryan@weave.works> (@bboreham)
+- Casey Callendrello <casey.callendrello@coreos.com> (@squeed)
+- Dan Williams <dcbw@redhat.com> (@dcbw)
+- Gabe Rosenhouse <grosenhouse@pivotal.io> (@rosenhouse)
+- Matt Dupre <matt@tigera.io> (@matthewdupre)
+- Stefan Junker <stefan.junker@coreos.com> (@steveeJ)

--- a/plugins/main/windows/CONTRIBUTORS.md
+++ b/plugins/main/windows/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+This is the official list of the Windows CNI network plugins contributors:
+ - @rakelkar
+ - @madhanrm
+ - @thxCode
+ - @nagiesek


### PR DESCRIPTION
Adding contributors.md for historical credit of Windows plugins and ownership for CNI plugins (copied from [MAINTAINERS](https://github.com/containernetworking/cni/blob/master/MAINTAINERS) file).

If there is a desired format or I missed/included anyone that I shouldn't have, let me know.