### PR TITLE
some DHCP servers expect to request for explicit router options

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -130,6 +130,7 @@ func (l *DHCPLease) acquire() error {
 
 	opts := make(dhcp4.Options)
 	opts[dhcp4.OptionClientIdentifier] = []byte(l.clientID)
+	opts[dhcp4.OptionParameterRequestList] = []byte{byte(dhcp4.OptionRouter)}
 
 	pkt, err := backoffRetry(func() (*dhcp4.Packet, error) {
 		ok, ack, err := DhcpRequest(c, opts)


### PR DESCRIPTION
Without setting this, the default route is missing in the containers. This is related to #192 