### PR TITLE
Fix host-device README.md

### DIFF
--- a/plugins/main/host-device/README.md
+++ b/plugins/main/host-device/README.md
@@ -16,6 +16,7 @@ A sample configuration might look like:
 ```json
 {
 	"cniVersion": "0.3.1",
+	"type": "host-device",
 	"device": "enp0s1"
 }
 ```


### PR DESCRIPTION
host-device's README.md missing 'type' field, so this change
just adds 'type' in config example.