### PR TITLE
Change http to https for security links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This is a rough outline of how to prepare a contribution:
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - If you changed code:
-   - add automated tests to cover your changes, using the [Ginkgo](http://onsi.github.io/ginkgo/) & [Gomega](http://onsi.github.io/gomega/) style
+   - add automated tests to cover your changes, using the [Ginkgo](https://onsi.github.io/ginkgo/) & [Gomega](https://onsi.github.io/gomega/) style
    - if the package did not previously have any test coverage, add it to the list
    of `TESTABLE` packages in the `test.sh` script.
    - run the full test script and ensure it passes

--- a/plugins/main/macvlan/README.md
+++ b/plugins/main/macvlan/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[macvlan](http://backreference.org/2014/03/20/some-notes-on-macvlanmacvtap/) functions like a switch that is already connected to the host interface.
+[macvlan](https://backreference.org/2014/03/20/some-notes-on-macvlanmacvtap/) functions like a switch that is already connected to the host interface.
 A host interface gets "enslaved" with the virtual interfaces sharing the physical device but having distinct MAC addresses.
 Since each macvlan interface has its own MAC address, it makes it easy to use with existing DHCP servers already present on the network.
 


### PR DESCRIPTION
For security, we should change http into https links.