### PR TITLE
Fix redundant import alias

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -20,7 +20,7 @@ import (
 	"net"
 
 	"github.com/containernetworking/cni/pkg/types"
-	types020 "github.com/containernetworking/cni/pkg/types/020"
+	"github.com/containernetworking/cni/pkg/types/020"
 )
 
 // The top-level network config - IPAM plugins are passed the full configuration

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 
-	types020 "github.com/containernetworking/cni/pkg/types/020"
+	"github.com/containernetworking/cni/pkg/types/020"
 )
 
 // The top-level network config - IPAM plugins are passed the full configuration

--- a/plugins/meta/portmap/chain.go
+++ b/plugins/meta/portmap/chain.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
-	shellwords "github.com/mattn/go-shellwords"
+	"github.com/mattn/go-shellwords"
 )
 
 type chain struct {


### PR DESCRIPTION
Because these package names are short and they are unique, it can not conflict. So the import aliases that can be omitted and we should remove them.