### PR TITLE
Windows: Add runtime DNS and del bug fix

### DIFF
--- a/pkg/hns/endpoint_windows.go
+++ b/pkg/hns/endpoint_windows.go
@@ -32,12 +32,11 @@ const (
 
 type EndpointInfo struct {
 	EndpointName string
-	DnsSearch    []string
+	DNS          types.DNS
 	NetworkName  string
 	NetworkId    string
 	Gateway      net.IP
 	IpAddress    net.IP
-	Nameservers  []string
 }
 
 // GetSandboxContainerID returns the sandbox ID of this pod
@@ -82,8 +81,8 @@ func GenerateHnsEndpoint(epInfo *EndpointInfo, n *NetConf) (*hcsshim.HNSEndpoint
 		hnsEndpoint = &hcsshim.HNSEndpoint{
 			Name:           epInfo.EndpointName,
 			VirtualNetwork: epInfo.NetworkId,
-			DNSServerList:  strings.Join(epInfo.Nameservers, ","),
-			DNSSuffix:      strings.Join(epInfo.DnsSearch, ","),
+			DNSServerList:  strings.Join(epInfo.DNS.Nameservers, ","),
+			DNSSuffix:      strings.Join(epInfo.DNS.Search, ","),
 			GatewayAddress: GetIpString(&epInfo.Gateway),
 			IPAddress:      epInfo.IpAddress,
 			Policies:       n.MarshalPolicies(),
@@ -130,8 +129,8 @@ func GenerateHcnEndpoint(epInfo *EndpointInfo, n *NetConf) (*hcn.HostComputeEndp
 		}
 
 		hcnDns := hcn.Dns{
-			Search:     epInfo.DnsSearch,
-			ServerList: epInfo.Nameservers,
+			Search:     epInfo.DNS.Search,
+			ServerList: epInfo.DNS.Nameservers,
 		}
 
 		hcnIpConfig := hcn.IpConfig{

--- a/pkg/hns/netconf_windows.go
+++ b/pkg/hns/netconf_windows.go
@@ -28,11 +28,33 @@ type NetConf struct {
 	types.NetConf
 	HcnPolicyArgs []hcn.EndpointPolicy `json:"HcnPolicyArgs,omitempty"`
 	Policies      []policy             `json:"policies,omitempty"`
+	RuntimeConfig RuntimeConfig        `json:"runtimeConfig"`
+}
+
+type RuntimeDNS struct {
+	Nameservers []string `json:"servers,omitempty"`
+	Search      []string `json:"searches,omitempty"`
+}
+
+type RuntimeConfig struct {
+	DNS RuntimeDNS `json:"dns"`
 }
 
 type policy struct {
 	Name  string          `json:"name"`
 	Value json.RawMessage `json:"value"`
+}
+
+// If runtime dns values are there use that else use cni conf supplied dns
+func (n *NetConf) GetDNS() types.DNS {
+	dnsResult := n.DNS
+	if len(n.RuntimeConfig.DNS.Nameservers) > 0 {
+		dnsResult.Nameservers = n.RuntimeConfig.DNS.Nameservers
+	}
+	if len(n.RuntimeConfig.DNS.Search) > 0 {
+		dnsResult.Search = n.RuntimeConfig.DNS.Search
+	}
+	return dnsResult
 }
 
 // MarshalPolicies converts the Endpoint policies in Policies

--- a/plugins/main/windows/win-bridge/README.md
+++ b/plugins/main/windows/win-bridge/README.md
@@ -13,13 +13,43 @@ With win-bridge plugin, all containers (on the same host) are plugged into an L2
 	"ipam": {
 		"type": "host-local",
 		"subnet": "10.10.0.0/16"
-	}
+	},
+    "policies":[
+        {
+            "name":"EndpointPolicy",
+            "value":{
+                "Type":"ROUTE",
+                "DestinationPrefix":"10.137.198.27/32",
+                "NeedEncap":true
+            }
+        } 
+    ],
+    "HcnPolicyArgs": [
+        {
+            "Type": "SDNRoute"
+            "Settings": {
+                "DestinationPrefix": "11.0.0.0/8",
+                "NeedEncap": true
+            }
+        }
+    ].          
+    "capabilities": {
+        "dns": true
+    }
 }
 ```
 
 ## Network configuration reference
 
+* `ApiVersion` (integer, optional): ApiVersion to use, will default to hns. If set to "2" will try to use hcn APIs.
 * `name` (string, required): the name of the network.
 * `type` (string, required): "win-bridge".
 * `ipMasqNetwork` (string, optional): setup NAT if not empty.
-* `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `dns` (dictionary, optional): dns config to be used.
+ * `Nameservers` (list, optional): list of strings to be used for dns nameservers.
+ * `Search` (list, optional): list of stings to be used for dns search.
+* `ipam` (dictionary, optional): IPAM configuration to be used for this network.
+* `Policies` (list, optional): List of hns policies to be used (only used when ApiVersion is < 2).
+* `HcnPolicyArgs` (list, optional): List of hcn policies to be used (only used when ApiVersion is 2).
+* `capabilities` (dictionary, optional): runtime capabilities to enable.
+ * `dns` (boolean, optional): if true will take the dns config supplied by the runtime and override other settings.

--- a/plugins/main/windows/win-bridge/win-bridge_windows.go
+++ b/plugins/main/windows/win-bridge/win-bridge_windows.go
@@ -84,8 +84,7 @@ func ProcessEndpointArgs(args *skel.CmdArgs, n *NetConf) (*hns.EndpointInfo, err
 		n.ApplyOutboundNatPolicy(n.IPMasqNetwork)
 	}
 
-	epInfo.DnsSearch = n.DNS.Search	
-	epInfo.Nameservers = n.DNS.Nameservers
+	epInfo.DNS = n.GetDNS()
 
 	return epInfo, nil
 }
@@ -195,8 +194,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
-		return err
+	if n.IPAM.Type != "" {
+		if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
+			return err
+		}
 	}
 	epName := hns.ConstructEndpointName(args.ContainerID, args.Netns, n.Name)
 	
@@ -213,5 +214,5 @@ func cmdGet(_ *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), "TODO")
 }

--- a/plugins/main/windows/win-overlay/README.md
+++ b/plugins/main/windows/win-overlay/README.md
@@ -15,6 +15,10 @@ With win-overlay plugin, all containers (on the same host) are plugged into an O
 		"type": "host-local",
 		"subnet": "10.10.0.0/16"
 	}
+    "capabilites": {
+        "dns": true
+    }
+
 }
 ```
 
@@ -23,5 +27,11 @@ With win-overlay plugin, all containers (on the same host) are plugged into an O
 * `name` (string, required): the name of the network.
 * `type` (string, required): "win-overlay".
 * `ipMasq` (bool, optional): the inverse of `$FLANNEL_IPMASQ`, setup NAT for the hnsNetwork subnet.
-* `endpointMacPrefix` (string, optional): set to the MAC prefix configured for Flannel  
+* `dns` (dictionary, optional): dns config to be used.
+ * `Nameservers` (list, optional): list of strings to be used for dns nameservers.
+ * `Search` (list, optional): list of stings to be used for dns search.
+* `endpointMacPrefix` (string, optional): set to the MAC prefix configured for Flannel.
+* `Policies` (list, optional): List of hns policies to be used.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `capabilities` (dictionary, optional): runtime capabilities to be parsed and injected by runtime.
+ * `dns` (boolean, optional): if true will take the dns config supplied by the runtime and override other settings.

--- a/plugins/main/windows/win-overlay/win-overlay_windows.go
+++ b/plugins/main/windows/win-overlay/win-overlay_windows.go
@@ -114,7 +114,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			n.ApplyOutboundNatPolicy(hnsNetwork.Subnets[0].AddressPrefix)
 		}
 
-		result.DNS = n.DNS
+		result.DNS = n.GetDNS()
 
 		hnsEndpoint := &hcsshim.HNSEndpoint{
 			Name:           epName,
@@ -162,5 +162,5 @@ func cmdGet(_ *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), "TODO")
 }


### PR DESCRIPTION
This adds the dns capability for supplying a runtime dnsConfig from a CRI. It also includes a bug fix for removing an endpoint when no IPAM is supplied.