### PR TITLE
[DO NOT MERGE] Use k8s env variables for dns

### DIFF
--- a/pkg/hns/endpoint_windows.go
+++ b/pkg/hns/endpoint_windows.go
@@ -23,12 +23,40 @@ import (
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/juju/errors"
 )
 
 const (
 	pauseContainerNetNS = "none"
 )
+
+type K8sCniEnvArgs struct {
+	types.CommonArgs
+	K8S_POD_NAMESPACE          types.UnmarshallableString `json:"K8S_POD_NAMESPACE,omitempty"`
+	K8S_POD_NAME               types.UnmarshallableString `json:"K8S_POD_NAME,omitempty"`
+	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString `json:"K8S_POD_INFRA_CONTAINER_ID,omitempty"`
+}
+
+func parseCniArgs(args string) (*K8sCniEnvArgs, error) {
+	podConfig := K8sCniEnvArgs{}
+	err := types.LoadArgs(args, &podConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &podConfig, nil
+}
+
+func ModifyDnsForK8s(dnsInfo *types.DNS, args *skel.CmdArgs) {
+	cniArgs, err := parseCniArgs(args.Args)
+	if err != nil {
+		errors.Annotatef(err, "k8s Namespace not found")
+	} else {
+		if len(dnsInfo.Search) > 0 {
+			dnsInfo.Search[0] = string(cniArgs.K8S_POD_NAMESPACE) + "." + dnsInfo.Search[0]
+		}
+	}
+}
 
 type EndpointInfo struct {
 	EndpointName string

--- a/plugins/main/windows/win-bridge/win-bridge_windows.go
+++ b/plugins/main/windows/win-bridge/win-bridge_windows.go
@@ -83,9 +83,11 @@ func ProcessEndpointArgs(args *skel.CmdArgs, n *NetConf) (*hns.EndpointInfo, err
 	if len(n.IPMasqNetwork) != 0 {
 		n.ApplyOutboundNatPolicy(n.IPMasqNetwork)
 	}
-
-	epInfo.DnsSearch = n.DNS.Search	
-	epInfo.Nameservers = n.DNS.Nameservers
+	
+	dnsInfo := n.DNS
+	hns.ModifyDnsForK8s(&dnsInfo, args)
+	epInfo.DnsSearch = dnsInfo.Search	
+	epInfo.Nameservers = dnsInfo.Nameservers
 
 	return epInfo, nil
 }

--- a/plugins/main/windows/win-overlay/win-overlay_windows.go
+++ b/plugins/main/windows/win-overlay/win-overlay_windows.go
@@ -114,13 +114,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 			n.ApplyOutboundNatPolicy(hnsNetwork.Subnets[0].AddressPrefix)
 		}
 
-		result.DNS = n.DNS
-
+		dnsInfo := n.DNS
+		hns.ModifyDnsForK8s(&dnsInfo, args)
 		hnsEndpoint := &hcsshim.HNSEndpoint{
 			Name:           epName,
 			VirtualNetwork: hnsNetwork.Id,
-			DNSServerList:  strings.Join(result.DNS.Nameservers, ","),
-			DNSSuffix:      strings.Join(result.DNS.Search, ","),
+			DNSServerList:  strings.Join(dnsInfo.Nameservers, ","),
+			DNSSuffix:      strings.Join(dnsInfo.Search, ","),
 			GatewayAddress: gw,
 			IPAddress:      ipAddr,
 			MacAddress:     macAddr,


### PR DESCRIPTION
This is place holder that uses K8S env variables for dns which refers to what is published in the [Microsoft SDN repo](https://github.com/Microsoft/SDN/tree/master/Kubernetes/flannel/l2bridge/cni). As discussed previously this is not the correct approach and is not intended for review or for merge