### PR TITLE
Portmap: append, rather than prepend, entry rules

### DIFF
--- a/plugins/meta/portmap/chain_test.go
+++ b/plugins/meta/portmap/chain_test.go
@@ -117,8 +117,8 @@ var _ = Describe("chain tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(haveRules).To(Equal([]string{
 			"-N " + tlChainName,
-			"-A " + tlChainName + " -d 203.0.113.1/32 -j " + testChain.name,
 			"-A " + tlChainName + ` -m comment --comment "canary value" -j ACCEPT`,
+			"-A " + tlChainName + " -d 203.0.113.1/32 -j " + testChain.name,
 		}))
 
 		// Check that the chain and rule was created

--- a/plugins/meta/portmap/portmap.go
+++ b/plugins/meta/portmap/portmap.go
@@ -255,6 +255,10 @@ func genMarkMasqChain(markBit int) chain {
 		table:       "nat",
 		name:        MarkMasqChainName,
 		entryChains: []string{"POSTROUTING"},
+		// Only this entry chain needs to be prepended, because otherwise it is
+		// stomped on by the masquerading rules created by the CNI ptp and bridge
+		// plugins.
+		prependEntry: true,
 		entryRules: [][]string{{
 			"-m", "comment",
 			"--comment", "CNI portfwd requiring masquerade",

--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -165,6 +165,12 @@ var _ = Describe("portmap integration tests", func() {
 		fmt.Fprintf(GinkgoWriter, "hostIP: %s:%d, contIP: %s:%d\n",
 			hostIP, hostPort, contIP, containerPort)
 
+		// dump iptables-save output for debugging
+		cmd = exec.Command("iptables-save")
+		cmd.Stderr = GinkgoWriter
+		cmd.Stdout = GinkgoWriter
+		Expect(cmd.Run()).To(Succeed())
+
 		// Sanity check: verify that the container is reachable directly
 		contOK := testEchoServer(contIP.String(), containerPort, "")
 

--- a/plugins/meta/portmap/portmap_test.go
+++ b/plugins/meta/portmap/portmap_test.go
@@ -323,6 +323,7 @@ var _ = Describe("portmapping configuration", func() {
 						"--mark", "0x20/0x20",
 						"-j", "MASQUERADE",
 					}},
+					prependEntry: true,
 				}))
 			})
 		})


### PR DESCRIPTION
This means that portmapped connections can be more easily controlled /
firewalled.

Cherry pick of https://github.com/containernetworking/plugins/pull/269 into master.

@containernetworking/cni-maintainers @bboreham @matthewdupre 

(Casey is out for a few weeks on vacation...)