### PR TITLE
IPAM/DHCP: include Subnet Mask option parameter in DHCPREQUEST

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -130,7 +130,7 @@ func (l *DHCPLease) acquire() error {
 
 	opts := make(dhcp4.Options)
 	opts[dhcp4.OptionClientIdentifier] = []byte(l.clientID)
-	opts[dhcp4.OptionParameterRequestList] = []byte{byte(dhcp4.OptionRouter)}
+	opts[dhcp4.OptionParameterRequestList] = []byte{byte(dhcp4.OptionRouter), byte(dhcp4.OptionSubnetMask)}
 
 	pkt, err := backoffRetry(func() (*dhcp4.Packet, error) {
 		ok, ack, err := DhcpRequest(c, opts)


### PR DESCRIPTION
**Problem**: DHCP REQUEST from DHCP plugin does not include Subnet Mask option parameter (1). Some DHCP servers need that option to be explicit in order to return it in a DHCPACK message. 
If not, DHCP plugin returns "DHCP option Subnet Mask not found in DHCPACK" error msg in this type of scenario.

**Proposed Solution**: include Subnet Mask option parameter as part of the OptionParameterRequestList array.

DHCPREQUEST generated using current master code =>
```
TIME: 2019-03-25 15:41:21.070
    IP: 0.0.0.0 (4a:75:c0:17:e4:91) > 255.255.255.255 (ff:ff:ff:ff:ff:ff)
    OP: 1 (BOOTPREQUEST)
 HTYPE: 1 (Ethernet)
  HLEN: 6
  HOPS: 0
   XID: 65aa0f90
  SECS: 0
 FLAGS: 0
CIADDR: 0.0.0.0
YIADDR: 0.0.0.0
SIADDR: 0.0.0.0
GIADDR: 0.0.0.0
CHADDR: 4a:75:c0:17:e4:91:00:00:00:00:00:00:00:00:00:00
 SNAME: .
 FNAME: .
OPTION:  53 (  1) DHCP message type         3 (DHCPREQUEST)
OPTION:  50 (  4) Request IP address        10.0.2.117
OPTION:  54 (  4) Server identifier         10.0.2.3
OPTION:  61 ( 82) Client-identifier         33:65:62:35:66:32:62:65:66:32:32:65:30:63:37:64:62:39:33:35:37:30:65:64:34:62:32:39:35:30:35:39:65:38:39:66:65:30:34:35:32:34:36:65:64:65:30:35:32:34:37:32:36:35:31:65:64:32:39:64:33:39:35:31:2f:6d:61:63:76:6c:61:6e:2d:63:6f:6e:66:2f:65:74:68:30
OPTION:  55 (  1) Parameter Request List      3 (Routers)
```

DHCPREQUEST generated using current master code with this change =>
```
  TIME: 2019-03-25 15:49:42.258
    IP: 0.0.0.0 (52:bd:71:7:af:8b) > 255.255.255.255 (ff:ff:ff:ff:ff:ff)
    OP: 1 (BOOTPREQUEST)
 HTYPE: 1 (Ethernet)
  HLEN: 6
  HOPS: 0
   XID: 54eed6cb
  SECS: 0
 FLAGS: 0
CIADDR: 0.0.0.0
YIADDR: 0.0.0.0
SIADDR: 0.0.0.0
GIADDR: 0.0.0.0
CHADDR: 52:bd:71:07:af:8b:00:00:00:00:00:00:00:00:00:00
 SNAME: .
 FNAME: .
OPTION:  53 (  1) DHCP message type         3 (DHCPREQUEST)
OPTION:  50 (  4) Request IP address        10.0.2.118
OPTION:  54 (  4) Server identifier         10.0.2.3
OPTION:  61 ( 82) Client-identifier         34:61:39:64:33:38:64:37:38:64:37:64:35:37:33:39:30:65:63:32:36:63:63:32:39:36:39:30:36:37:37:37:38:35:33:62:36:66:63:65:37:31:36:66:65:63:37:38:64:35:31:62:66:65:36:38:61:35:38:34:66:36:33:36:2f:6d:61:63:76:6c:61:6e:2d:63:6f:6e:66:2f:65:74:68:30
OPTION:  55 (  2) Parameter Request List      3 (Routers)
					      1 (Subnet mask)
```