### PR TITLE
ipvlan support default route

### DIFF
--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -203,7 +203,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	result.Interfaces = []*current.Interface{ipvlanInterface}
 
-	if n.IsDefaultGW{
+	if n.IsDefaultGW {
 		dst, err := mustCIDR("0.0.0.0/0")
 		if err != nil {
 			return err

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -28,11 +28,13 @@ import (
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	"net"
+
 )
 
 type NetConf struct {
 	types.NetConf
-
+	
 	// support chaining for master interface and IP decisions
 	// occurring prior to running ipvlan plugin
 	RawPrevResult *map[string]interface{} `json:"prevResult"`
@@ -41,6 +43,7 @@ type NetConf struct {
 	Master string `json:"master"`
 	Mode   string `json:"mode"`
 	MTU    int    `json:"mtu"`
+	IsDefaultGW bool   `json:"isDefaultGateway"`
 }
 
 func init() {
@@ -200,6 +203,17 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	result.Interfaces = []*current.Interface{ipvlanInterface}
 
+	if n.IsDefaultGW{
+		dst, err := mustCIDR("0.0.0.0/0")
+		if err != nil {
+			return err
+		}
+		result.Routes = append(
+			result.Routes,
+			&types.Route{Dst: *dst, GW: result.IPs[0].Address.IP},
+		)
+	}
+
 	err = netns.Do(func(_ ns.NetNS) error {
 		return ipam.ConfigureIface(args.IfName, result)
 	})
@@ -210,6 +224,16 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.DNS = n.DNS
 
 	return types.PrintResult(result, cniVersion)
+}
+
+func mustCIDR(s string) (*net.IPNet, error) {
+	ip, n, err := net.ParseCIDR(s)
+	n.IP = ip
+	if err != nil {
+		return nil, err
+	}
+
+	return n, nil
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -29,20 +29,19 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"net"
-
 )
 
 type NetConf struct {
 	types.NetConf
-	
+
 	// support chaining for master interface and IP decisions
 	// occurring prior to running ipvlan plugin
 	RawPrevResult *map[string]interface{} `json:"prevResult"`
 	PrevResult    *current.Result         `json:"-"`
 
-	Master string `json:"master"`
-	Mode   string `json:"mode"`
-	MTU    int    `json:"mtu"`
+	Master      string `json:"master"`
+	Mode        string `json:"mode"`
+	MTU         int    `json:"mtu"`
 	IsDefaultGW bool   `json:"isDefaultGateway"`
 }
 

--- a/plugins/meta/flannel/README.md
+++ b/plugins/meta/flannel/README.md
@@ -63,7 +63,8 @@ To use `ipvlan` instead of `bridge`, the following configuration can be specifie
 	"type": "flannel",
 	"delegate": {
 		"type": "ipvlan",
-		"master": "eth0"
+		"master": "eth0",
+		"isDefaultGateway": true
 	}
 }
 ```


### PR DESCRIPTION
When I use flannel with ipVlan, I need the default route in container.
Add "isDefaultGateway" in ipVlan,  ipVlan can work  in Kubernetes with 'l3s' mode.