### PR TITLE
plugins: correctly output build version, cosmetic cleanups

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -20,7 +20,7 @@ export GO="${GO:-go}"
 mkdir -p "${PWD}/bin"
 
 echo "Building plugins ${GOOS}"
-PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/* plugins/sample"
+PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/*"
 for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"

--- a/pkg/utils/buildversion/buildversion.go
+++ b/pkg/utils/buildversion/buildversion.go
@@ -1,0 +1,26 @@
+// Copyright 2019 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Buildversion is a destination for the linker trickery so we can auto
+// set the build-version
+package buildversion
+
+import "fmt"
+
+// This is overridden in the linker script
+var BuildVersion = "version unknown"
+
+func BuildString(pluginName string) string {
+	return fmt.Sprintf("CNI %s plugin %s", pluginName, BuildVersion)
+}

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 const defaultSocketPath = "/run/cni/dhcp.sock"
@@ -51,8 +52,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		// TODO: implement plugin version
-		skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+		skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("dhcp"))
 	}
 }
 

--- a/plugins/ipam/dhcp/options.go
+++ b/plugins/ipam/dhcp/options.go
@@ -98,7 +98,7 @@ func parseCIDRRoutes(opts dhcp4.Options) []*types.Route {
 			}
 			routes = append(routes, rt)
 
-			opt = opt[octets+5 : len(opt)]
+			opt = opt[octets+5:]
 		}
 	}
 	return routes

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -24,14 +24,14 @@ import (
 
 func validateRoutes(t *testing.T, routes []*types.Route) {
 	expected := []*types.Route{
-		&types.Route{
+		{
 			Dst: net.IPNet{
 				IP:   net.IPv4(10, 0, 0, 0),
 				Mask: net.CIDRMask(8, 32),
 			},
 			GW: net.IPv4(10, 1, 2, 3),
 		},
-		&types.Route{
+		{
 			Dst: net.IPNet{
 				IP:   net.IPv4(192, 168, 1, 0),
 				Mask: net.CIDRMask(24, 32),

--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -97,7 +97,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		n.IPAM.IPArgs = append(n.IPAM.IPArgs, n.Args.A.IPs...)
 	}
 
-	for idx, _ := range n.IPAM.IPArgs {
+	for idx := range n.IPAM.IPArgs {
 		if err := canonicalizeIP(&n.IPAM.IPArgs[idx]); err != nil {
 			return nil, "", fmt.Errorf("cannot understand ip: %v", err)
 		}
@@ -122,7 +122,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 	// Validate all ranges
 	numV4 := 0
 	numV6 := 0
-	for i, _ := range n.IPAM.Ranges {
+	for i := range n.IPAM.Ranges {
 		if err := n.IPAM.Ranges[i].Canonicalize(); err != nil {
 			return nil, "", fmt.Errorf("invalid range set %d: %s", i, err)
 		}

--- a/plugins/ipam/host-local/backend/allocator/config_test.go
+++ b/plugins/ipam/host-local/backend/allocator/config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("IPAM config", func() {
 			Name: "mynet",
 			Type: "host-local",
 			Ranges: []RangeSet{
-				RangeSet{
+				{
 					{
 						RangeStart: net.IP{10, 1, 2, 9},
 						RangeEnd:   net.IP{10, 1, 2, 20},

--- a/plugins/ipam/host-local/backend/allocator/range_set.go
+++ b/plugins/ipam/host-local/backend/allocator/range_set.go
@@ -61,7 +61,7 @@ func (s *RangeSet) Canonicalize() error {
 	}
 
 	fam := 0
-	for i, _ := range *s {
+	for i := range *s {
 		if err := (*s)[i].Canonicalize(); err != nil {
 			return err
 		}

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strings"
 
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk"
 
@@ -30,8 +31,7 @@ import (
 )
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("host-local"))
 }
 
 func loadNetConf(bytes []byte) (*types.NetConf, string, error) {

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-
-	"github.com/containernetworking/cni/pkg/types/020"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // The top-level network config - IPAM plugins are passed the full configuration
@@ -58,8 +58,7 @@ type Address struct {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("static"))
 }
 
 func loadNetConf(bytes []byte) (*types.NetConf, string, error) {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -18,12 +18,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
 	"syscall"
 
-	"io/ioutil"
+	"github.com/j-keck/arping"
+	"github.com/vishvananda/netlink"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -33,8 +35,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/utils"
-	"github.com/j-keck/arping"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // For testcases to force an error after IPAM has been performed
@@ -595,8 +596,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("bridge"))
 }
 
 type cniBridgeIf struct {

--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -25,14 +25,17 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 //NetConf for host-device config, look the README to learn how to use those parameters
@@ -281,8 +284,7 @@ func getLink(devname, hwaddr, kernelpath string) (netlink.Link, error) {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("host-device"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 type NetConf struct {
@@ -262,8 +265,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("ipvlan"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -15,11 +15,14 @@
 package main
 
 import (
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 func cmdAdd(args *skel.CmdArgs) error {
@@ -71,8 +74,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("loopback"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -21,16 +21,19 @@ import (
 	"net"
 	"runtime"
 
+	"github.com/j-keck/arping"
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
-	"github.com/j-keck/arping"
-	"github.com/vishvananda/netlink"
 )
 
 const (
@@ -270,8 +273,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("macvlan"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -22,16 +22,19 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/j-keck/arping"
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/utils"
-	"github.com/j-keck/arping"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 func init() {
@@ -110,7 +113,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 			}
 
 			for _, r := range []netlink.Route{
-				netlink.Route{
+				{
 					LinkIndex: contVeth.Index,
 					Dst: &net.IPNet{
 						IP:   ipc.Gateway,
@@ -119,7 +122,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 					Scope: netlink.SCOPE_LINK,
 					Src:   ipc.Address.IP,
 				},
-				netlink.Route{
+				{
 					LinkIndex: contVeth.Index,
 					Dst: &net.IPNet{
 						IP:   ipc.Address.IP.Mask(ipc.Address.Mask),
@@ -285,8 +288,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("ptp"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 type NetConf struct {
@@ -192,8 +195,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("vlan"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/main/windows/win-overlay/win-overlay_windows.go
+++ b/plugins/main/windows/win-overlay/win-overlay_windows.go
@@ -20,15 +20,17 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Microsoft/hcsshim"
 	"github.com/juju/errors"
 
-	"github.com/Microsoft/hcsshim"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/hns"
 	"github.com/containernetworking/plugins/pkg/ipam"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 type NetConf struct {
@@ -162,5 +164,5 @@ func cmdGet(_ *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), "TODO")
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), bv.BuildString("win-overlay"))
 }

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -20,13 +20,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-	"github.com/containernetworking/plugins/pkg/ip"
 
-	"github.com/vishvananda/netlink"
+	"github.com/containernetworking/plugins/pkg/ip"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // BandwidthEntry corresponds to a single entry in the bandwidth argument,
@@ -229,8 +231,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.3.0", "0.3.1", version.Current()), "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.3.0", "0.3.1", version.Current()), bv.BuildString("bandwidth"))
 }
 
 func SafeQdiscList(link netlink.Link) ([]netlink.Qdisc, error) {

--- a/plugins/meta/firewall/firewall.go
+++ b/plugins/meta/firewall/firewall.go
@@ -26,7 +26,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ns"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // FirewallNetConf represents the firewall configuration.
@@ -155,7 +157,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.4.0"), "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.4.0"), bv.BuildString("firewall"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -34,6 +34,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/version"
+
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 const (
@@ -217,7 +219,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, bv.BuildString("flannel"))
 }
 
 func cmdGet(args *skel.CmdArgs) error {

--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -34,6 +34,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // PortMapEntry corresponds to a single entry in the port_mappings argument,
@@ -116,8 +118,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("portmap"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/meta/sbr/main.go
+++ b/plugins/meta/sbr/main.go
@@ -22,13 +22,15 @@ import (
 	"net"
 
 	"github.com/alexflint/go-filemutex"
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-	"github.com/containernetworking/plugins/pkg/ns"
 
-	"github.com/vishvananda/netlink"
+	"github.com/containernetworking/plugins/pkg/ns"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 const firstTableID = 100
@@ -370,7 +372,7 @@ RULE_LOOP:
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, bv.BuildString("sbr"))
 }
 
 func cmdGet(args *skel.CmdArgs) error {

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -25,12 +25,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/vishvananda/netlink"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // TuningConf represents the network tuning configuration.
@@ -202,8 +205,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("tuning"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/sample/main.go
+++ b/plugins/sample/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
+
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
 // PluginConf is whatever you expect your configuration json to be. This is whatever
@@ -92,13 +94,22 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// Remove this if this is an "originating" plugin
 	if conf.PrevResult == nil {
 		return fmt.Errorf("must be called as chained plugin")
 	}
 
+	// Uncomment if this is an "originating" plugin
+
+	//if conf.PrevResult != nil {
+	//		return fmt.Errorf("must be called as the first plugin")
+	//	}
+
 	// This is some sample code to generate the list of container-side IPs.
 	// We're casting the prevResult to a 0.3.0 response, which can also include
 	// host-side IPs (but doesn't when converted from a 0.2.0 response).
+	//
+	// You don't need this if you are writing an "originating" plugin.
 	containerIPs := make([]net.IP, 0, len(conf.PrevResult.IPs))
 	if conf.CNIVersion != "0.3.0" {
 		for _, ip := range conf.PrevResult.IPs {
@@ -123,6 +134,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("got no container IPs")
 	}
 
+	// Implement your plugin here
+
 	// Pass through the result for the next plugin
 	return types.PrintResult(conf.PrevResult, conf.CNIVersion)
 }
@@ -141,11 +154,11 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	// TODO: implement plugin version
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, "TODO")
+	// replace TODO with your plugin name
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("TODO"))
 }
 
-func cmdGet(args *skel.CmdArgs) error {
+func cmdCheck(args *skel.CmdArgs) error {
 	// TODO: implement
 	return fmt.Errorf("not implemented")
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,11 +2,12 @@
 set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"
+DOCKER="${DOCKER:-docker}"
 
 TAG=$(git describe --tags --dirty)
 RELEASE_DIR=release-${TAG}
 
-BUILDFLAGS="-ldflags '-extldflags -static -X main._buildVersion=${TAG}'"
+BUILDFLAGS="-ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG}'"
 
 OUTPUT_DIR=bin
 
@@ -15,7 +16,7 @@ rm -Rf ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${OUTPUT_DIR}
 
-docker run -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins --rm golang:1.10-alpine \
+$DOCKER run -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins --rm golang:1.10-alpine \
 /bin/sh -xe -c "\
     apk --no-cache add bash tar;
     cd /go/src/github.com/containernetworking/plugins; umask 0022;


### PR DESCRIPTION
Now that libcni has the ability to print a version message, plumb it through correctly.
    
While we're at it,
- fix import paths
- run gofmt
- add some more comments to sample
- add container runtime swappability for release

Fixes: #101 