### PR TITLE
macvlan: make master config as optional

### DIFF
--- a/plugins/main/macvlan/README.md
+++ b/plugins/main/macvlan/README.md
@@ -23,7 +23,7 @@ Since each macvlan interface has its own MAC address, it makes it easy to use wi
 
 * `name` (string, required): the name of the network
 * `type` (string, required): "macvlan"
-* `master` (string, required): name of the host interface to enslave
+* `master` (string, optional): name of the host interface to enslave. Defaults to default route interace.
 * `mode` (string, optional): one of "bridge", "private", "vepa", "passthru". Defaults to "bridge".
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.


### PR DESCRIPTION
To ease of config, make master config as optional parameter.
In default case, default route interface will be used for master.