### PR TITLE
fix bug on ip revert if cmdAdd fails on macvlan and host-device

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -96,7 +97,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 		// Invoke ipam del if err to avoid ip leak
 		defer func() {
 			if err != nil {
+				os.Setenv("CNI_COMMAND", "DEL")
 				ipam.ExecDel(cfg.IPAM.Type, args.StdinData)
+				os.Setenv("CNI_COMMAND", "ADD")
 			}
 		}()
 

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"runtime"
 
 	"github.com/j-keck/arping"
@@ -197,7 +198,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// Invoke ipam del if err to avoid ip leak
 	defer func() {
 		if err != nil {
+			os.Setenv("CNI_COMMAND", "DEL")
 			ipam.ExecDel(n.IPAM.Type, args.StdinData)
+			os.Setenv("CNI_COMMAND", "ADD")
 		}
 	}()
 


### PR DESCRIPTION
This PR try to fix bug on IP revert if cmdAdd fails on macvlan and host-device plugin.
Function **ipam.ExecDel** will check whether CNI_COMMAND environment variable is **ADD**, if not, it will not work as expected. So when we want to revert IP allocation in cmdAdd with environment variable CNI_COMMAND equals to ADD, we have to change CNI_COMMAND to DEL temporarily, otherwise IP release will not succeed.