### PR TITLE
Don't return error for cmdCheck() when support is not implemented

### DIFF
--- a/plugins/meta/sbr/main.go
+++ b/plugins/meta/sbr/main.go
@@ -372,9 +372,9 @@ RULE_LOOP:
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.All, bv.BuildString("sbr"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("sbr"))
 }
 
-func cmdGet(args *skel.CmdArgs) error {
-	return fmt.Errorf("not implemented")
+func cmdCheck(args *skel.CmdArgs) error {
+	return nil
 }


### PR DESCRIPTION

Return nil instead of error for cmdCheck until support is added.

Fixes [296](https://github.com/containernetworking/plugins/issues/296)
