### PR TITLE
bridge: fix ipMasq setup to use correct source address

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -517,7 +517,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			chain := utils.FormatChainName(n.Name, args.ContainerID)
 			comment := utils.FormatComment(n.Name, args.ContainerID)
 			for _, ipc := range result.IPs {
-				if err = ip.SetupIPMasq(ip.Network(&ipc.Address), chain, comment); err != nil {
+				if err = ip.SetupIPMasq(&ipc.Address, chain, comment); err != nil {
 					return err
 				}
 			}

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -1609,7 +1609,7 @@ var _ = Describe("bridge Operations", func() {
 		}
 	})
 
-	FIt("configures a bridge and ipMasq rules for 0.4.0 config", func() {
+	It("configures a bridge and ipMasq rules for 0.4.0 config", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 			tc := testCase{


### PR DESCRIPTION
It looks like a change in #279 which seems to expect the exact address be passed into `SetupIPMasq` broke ip masquerading for the bridge plugin. See discussion [in that PR](https://github.com/containernetworking/plugins/pull/279#issuecomment-495828664) for more details.

This PR adds a ginkgo spec that reproduces the issue and a change to fix it.