### PR TITLE
bump containernetworking/cni to v0.7.1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -81,38 +81,38 @@
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/libcni",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/invoke",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/skel",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/020",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/types/current",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/containernetworking/cni/pkg/version",
-			"Comment": "v0.7.0",
-			"Rev": "7d76556571b6cf1ab90d7026a73092ac8d5e0c23"
+			"Comment": "v0.7.1",
+			"Rev": "4cfb7b568922a3c79a23e438dc52fe537fc9687e"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-iptables/iptables",

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -16,10 +16,8 @@ package ipam
 
 import (
 	"context"
-	"fmt"
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/types"
-	"os"
 )
 
 func ExecAdd(plugin string, netconf []byte) (types.Result, error) {
@@ -31,13 +29,5 @@ func ExecCheck(plugin string, netconf []byte) error {
 }
 
 func ExecDel(plugin string, netconf []byte) error {
-	cmd := os.Getenv("CNI_COMMAND")
-	if cmd == "" {
-		return fmt.Errorf("environment variable CNI_COMMAND must be specified.")
-	}
-	// Set CNI_COMMAND to DEL explicity.  We might be deleting due to an ADD gone wrong.
-	// restore CNI_COMMAND to original value upon return.
-	os.Setenv("CNI_COMMAND", "DEL")
-	defer os.Setenv("CNI_COMMAND", cmd)
 	return invoke.DelegateDel(context.TODO(), plugin, netconf, nil)
 }

--- a/plugins/main/windows/win-bridge/win-bridge_windows.go
+++ b/plugins/main/windows/win-bridge/win-bridge_windows.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"os"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
@@ -146,7 +145,7 @@ func cmdHcnAdd(args *skel.CmdArgs, n *NetConf) (*current.Result, error) {
 		return nil, fmt.Errorf("network %v not found", networkName)
 	}
 
-	if  hcnNetwork.Type != hcn.L2Bridge {
+	if hcnNetwork.Type != hcn.L2Bridge {
 		return nil, fmt.Errorf("network %v is of unexpected type: %v", networkName, hcnNetwork.Type)
 	}
 
@@ -191,13 +190,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if err != nil {
-		os.Setenv("CNI_COMMAND", "DEL")
 		ipam.ExecDel(n.IPAM.Type, args.StdinData)
-		os.Setenv("CNI_COMMAND", "ADD")
 		return errors.Annotate(err, "error while executing ADD command")
 	}
 
-	if (result == nil) {
+	if result == nil {
 		return errors.New("result for ADD not populated correctly")
 	}
 	return types.PrintResult(result, cniVersion)

--- a/plugins/main/windows/win-overlay/win-overlay_windows.go
+++ b/plugins/main/windows/win-overlay/win-overlay_windows.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"os"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/juju/errors"
@@ -135,9 +134,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 	defer func() {
 		if !success {
-			os.Setenv("CNI_COMMAND", "DEL")
 			ipam.ExecDel(n.IPAM.Type, args.StdinData)
-			os.Setenv("CNI_COMMAND", "ADD")
 		}
 	}()
 	if err != nil {

--- a/vendor/github.com/containernetworking/cni/libcni/api.go
+++ b/vendor/github.com/containernetworking/cni/libcni/api.go
@@ -69,6 +69,7 @@ type CNI interface {
 	AddNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
 	CheckNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
 	DelNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
+	GetNetworkListCachedResult(net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
 
 	AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
 	CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error


### PR DESCRIPTION
ref to [https://github.com/containernetworking/plugins/issues/340](https://github.com/containernetworking/plugins/issues/340) and [https://github.com/containernetworking/plugins/issues/303](https://github.com/containernetworking/plugins/issues/303)

1. bump containernetworking/cni to v0.7.1
2. use delegateArgs in `ipam.ExecDel` instead of setting/unsetting environment