### PR TITLE
Fix: failed to set bridge addr: could not add IP address to \"cni0\": file exists

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -175,7 +175,7 @@ func ensureAddr(br netlink.Link, family int, ipn *net.IPNet, forceAddress bool) 
 	}
 
 	addr := &netlink.Addr{IPNet: ipn, Label: ""}
-	if err := netlink.AddrAdd(br, addr); err != nil {
+	if err := netlink.AddrAdd(br, addr); err != nil && err != syscall.EEXIST {
 		return fmt.Errorf("could not add IP address to %q: %v", br.Attrs().Name, err)
 	}
 


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/3507.

When multiple pods are started at the same time at the node startup, the `cni0` bridge may be attempted to create by multiple goroutines.

The bridge creation [handled `syscall.EEXIST`](https://github.com/containernetworking/plugins/blob/v0.7.5/plugins/main/bridge/bridge.go#L222), thus no problem there. However, the bridge address assignment doesn't handle this concurrency properly. https://github.com/containernetworking/plugins/blob/v0.7.5/plugins/main/bridge/bridge.go#L143

This can cause pod start failure with error `failed to set bridge addr: could not add IP address to \"cni0\": file exists`.

This PR handles `syscall.EEXIST` for address assignment, which should fix the problem.

/cc @cadmuxe 

Signed-off-by: Lantao Liu <lantaol@google.com>