### PR TITLE
[Backport v0.7] Fix: failed to set bridge addr: could not add IP address to \"cni0\": file exists

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -170,7 +170,7 @@ func ensureBridgeAddr(br *netlink.Bridge, family int, ipn *net.IPNet, forceAddre
 	}
 
 	addr := &netlink.Addr{IPNet: ipn, Label: ""}
-	if err := netlink.AddrAdd(br, addr); err != nil {
+	if err := netlink.AddrAdd(br, addr); err != nil && err != syscall.EEXIST {
 		return fmt.Errorf("could not add IP address to %q: %v", br.Name, err)
 	}
 


### PR DESCRIPTION
Backport https://github.com/containernetworking/plugins/pull/366 to 0.7 branch.