### PR TITLE
When prevResults are not supplied to loopback plugin, create results to return

### DIFF
--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Loopback", func() {
 			fmt.Sprintf("CNI_ARGS=%s", "none"),
 			fmt.Sprintf("CNI_PATH=%s", "/some/test/path"),
 		}
-		command.Stdin = strings.NewReader(`{ "cniVersion": "0.1.0" }`)
+		command.Stdin = strings.NewReader(`{ "name": "loopback-test", "cniVersion": "0.1.0" }`)
 	})
 
 	AfterEach(func() {
@@ -59,8 +59,6 @@ var _ = Describe("Loopback", func() {
 
 	Context("when given a network namespace", func() {
 		It("sets the lo device to UP", func() {
-
-			Skip("TODO: add network name")
 			command.Env = append(environ, fmt.Sprintf("CNI_COMMAND=%s", "ADD"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -81,8 +79,6 @@ var _ = Describe("Loopback", func() {
 		})
 
 		It("sets the lo device to DOWN", func() {
-
-			Skip("TODO: add network name")
 			command.Env = append(environ, fmt.Sprintf("CNI_COMMAND=%s", "DEL"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION

When prevResults are not returned to loopback plugin, create results to return based on the lo interface and IP address assigned inside container. 

Fixes [381](https://github.com/containernetworking/plugins/issues/381)