### PR TITLE
ptp: only override DNS conf if DNS settings provided

### DIFF
--- a/pkg/testutils/dns.go
+++ b/pkg/testutils/dns.go
@@ -1,0 +1,60 @@
+// Copyright 2019 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// TmpResolvConf will create a temporary file and write the provided DNS settings to
+// it in the resolv.conf format. It returns the path of the created temporary file or
+// an error if any occurs while creating/writing the file. It is the caller's
+// responsibility to remove the file.
+func TmpResolvConf(dnsConf types.DNS) (string, error) {
+	f, err := ioutil.TempFile("", "cni_test_resolv.conf")
+	if err != nil {
+		return "", fmt.Errorf("failed to get temp file for CNI test resolv.conf: %v", err)
+	}
+	defer f.Close()
+
+	path := f.Name()
+	defer func() {
+		if err != nil {
+			os.RemoveAll(path)
+		}
+	}()
+
+	// see "man 5 resolv.conf" for the format of resolv.conf
+	var resolvConfLines []string
+	for _, nameserver := range dnsConf.Nameservers {
+		resolvConfLines = append(resolvConfLines, fmt.Sprintf("nameserver %s", nameserver))
+	}
+	resolvConfLines = append(resolvConfLines, fmt.Sprintf("domain %s", dnsConf.Domain))
+	resolvConfLines = append(resolvConfLines, fmt.Sprintf("search %s", strings.Join(dnsConf.Search, " ")))
+	resolvConfLines = append(resolvConfLines, fmt.Sprintf("options %s", strings.Join(dnsConf.Options, " ")))
+
+	resolvConf := strings.Join(resolvConfLines, "\n")
+	_, err = f.Write([]byte(resolvConf))
+	if err != nil {
+		return "", fmt.Errorf("failed to write temp resolv.conf for CNI test: %v", err)
+	}
+
+	return path, err
+}

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -247,10 +247,23 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	result.DNS = conf.DNS
+	// Only override the DNS settings in the previous result if any DNS fields
+	// were provided to the ptp plugin. This allows, for example, IPAM plugins
+	// to specify the DNS settings instead of the ptp plugin.
+	if dnsConfSet(conf.DNS) {
+		result.DNS = conf.DNS
+	}
+
 	result.Interfaces = []*current.Interface{hostInterface, containerInterface}
 
 	return types.PrintResult(result, conf.CNIVersion)
+}
+
+func dnsConfSet(dnsConf types.DNS) bool {
+	return dnsConf.Nameservers != nil ||
+		dnsConf.Search != nil ||
+		dnsConf.Options != nil ||
+		dnsConf.Domain != ""
 }
 
 func cmdDel(args *skel.CmdArgs) error {


### PR DESCRIPTION
Previously, if an IPAM plugin provided DNS settings in the result to the PTP
plugin, those settings were always lost because the PTP plugin would always
provide its own DNS settings in the result even if the PTP plugin was not
configured with any DNS settings.

This was especially problematic when trying to use, for example, the host-local
IPAM plugin's support for retrieving DNS settings from a resolv.conf file on
the host. Before this change, those DNS settings were always lost when using the
PTP plugin and couldn't be specified as part of PTP instead because PTP does not
support parsing a resolv.conf file.

This change checks to see if any fields were actually set in the PTP plugin's
DNS settings and only overrides any previous DNS results from an IPAM plugin in
the case that settings actually were provided to PTP. In the case where no
DNS settings are provided to PTP, the DNS results of the IPAM plugin (if any)
are used instead.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>