### PR TITLE
Use uint64 for Bandwidth plugin

### DIFF
--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -621,6 +621,21 @@ var _ = Describe("bandwidth test", func() {
 		})
 	})
 
+	Describe("Validating input", func() {
+		It("Should allow only 4GB burst rate", func() {
+			err := validateRateAndBurst(5000, 4*1024*1024*1024*8-16) // 2 bytes less than the max should pass
+			Expect(err).NotTo(HaveOccurred())
+			err = validateRateAndBurst(5000, 4*1024*1024*1024*8) // we're 1 bit above MaxUint32
+			Expect(err).To(HaveOccurred())
+			err = validateRateAndBurst(0, 1)
+			Expect(err).To(HaveOccurred())
+			err = validateRateAndBurst(1, 0)
+			Expect(err).To(HaveOccurred())
+			err = validateRateAndBurst(0, 0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Describe("Getting the host interface which plugin should work on from veth peer of container interface", func() {
 		It("Should work with multiple host veth interfaces", func() {
 			conf := `{
@@ -874,8 +889,8 @@ var _ = Describe("bandwidth test", func() {
 
 	Context("when chaining bandwidth plugin with PTP using 0.3.0 config", func() {
 		var ptpConf string
-		var rateInBits int
-		var burstInBits int
+		var rateInBits uint64
+		var burstInBits uint64
 		var packetInBytes int
 		var containerWithoutTbfNS ns.NetNS
 		var containerWithTbfNS ns.NetNS
@@ -889,7 +904,7 @@ var _ = Describe("bandwidth test", func() {
 
 		BeforeEach(func() {
 			rateInBytes := 1000
-			rateInBits = rateInBytes * 8
+			rateInBits = uint64(rateInBytes * 8)
 			burstInBits = rateInBits * 2
 			packetInBytes = rateInBytes * 25
 
@@ -1019,8 +1034,8 @@ var _ = Describe("bandwidth test", func() {
 
 	Context("when chaining bandwidth plugin with PTP using 0.4.0 config", func() {
 		var ptpConf string
-		var rateInBits int
-		var burstInBits int
+		var rateInBits uint64
+		var burstInBits uint64
 		var packetInBytes int
 		var containerWithoutTbfNS ns.NetNS
 		var containerWithTbfNS ns.NetNS
@@ -1034,7 +1049,7 @@ var _ = Describe("bandwidth test", func() {
 
 		BeforeEach(func() {
 			rateInBytes := 1000
-			rateInBits = rateInBytes * 8
+			rateInBits = uint64(rateInBytes * 8)
 			burstInBits = rateInBits * 2
 			packetInBytes = rateInBytes * 25
 

--- a/plugins/meta/bandwidth/ifb_creator.go
+++ b/plugins/meta/bandwidth/ifb_creator.go
@@ -50,7 +50,7 @@ func TeardownIfb(deviceName string) error {
 	return err
 }
 
-func CreateIngressQdisc(rateInBits, burstInBits int, hostDeviceName string) error {
+func CreateIngressQdisc(rateInBits, burstInBits uint64, hostDeviceName string) error {
 	hostDevice, err := netlink.LinkByName(hostDeviceName)
 	if err != nil {
 		return fmt.Errorf("get host device: %s", err)
@@ -58,7 +58,7 @@ func CreateIngressQdisc(rateInBits, burstInBits int, hostDeviceName string) erro
 	return createTBF(rateInBits, burstInBits, hostDevice.Attrs().Index)
 }
 
-func CreateEgressQdisc(rateInBits, burstInBits int, hostDeviceName string, ifbDeviceName string) error {
+func CreateEgressQdisc(rateInBits, burstInBits uint64, hostDeviceName string, ifbDeviceName string) error {
 	ifbDevice, err := netlink.LinkByName(ifbDeviceName)
 	if err != nil {
 		return fmt.Errorf("get ifb device: %s", err)
@@ -113,7 +113,7 @@ func CreateEgressQdisc(rateInBits, burstInBits int, hostDeviceName string, ifbDe
 	return nil
 }
 
-func createTBF(rateInBits, burstInBits, linkIndex int) error {
+func createTBF(rateInBits, burstInBits uint64, linkIndex int) error {
 	// Equivalent to
 	// tc qdisc add dev link root tbf
 	//		rate netConf.BandwidthLimits.Rate


### PR DESCRIPTION
This is the first out of several required PRs across CNI plugins, CRI-O and Kubelet.

We need to use something bigger than int as it goes only into 2Gb for rate and burst, which is not enough for 10Gbps networking anymore.
Since we use bits in JSON and can feed upto 4GByte into tbf (at least per current implementation), we need to use uint64 even for burst and then number check it for uint32 max * 8.

Thanks for looking into this
Ashley