### PR TITLE
firewall: don't return error in DEL if prevResult is not found.

### DIFF
--- a/plugins/meta/firewall/firewall.go
+++ b/plugins/meta/firewall/firewall.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 
-	"github.com/containernetworking/plugins/pkg/ns"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 )
 
@@ -145,12 +144,6 @@ func cmdDel(args *skel.CmdArgs) error {
 	backend, err := getBackend(conf)
 	if err != nil {
 		return err
-	}
-
-	// Tolerate errors if the container namespace has been torn down already
-	containerNS, err := ns.GetNS(args.Netns)
-	if err == nil {
-		defer containerNS.Close()
 	}
 
 	// Runtime errors are ignored


### PR DESCRIPTION
The CNI spec states that for DEL implementations, "when CNI_NETNS and/or
prevResult are not provided, the plugin should clean up as many resources as
possible (e.g. releasing IPAM allocations) and return a successful response".
This change results in the firewall plugin conforming to the spec by not
returning an error whenever the del method is not provided a prevResult.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>