### PR TITLE
bridge: check vlan id when loading net conf

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -76,7 +76,7 @@ func loadNetConf(bytes []byte) (*NetConf, string, error) {
 		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
 	}
 	if n.Vlan < 0 || n.Vlan > 4094 {
-		return nil, "", fmt.Errorf(`invalid VLAN ID %d (must be between 0 and 4094)`, n.Vlan)
+		return nil, "", fmt.Errorf("invalid VLAN ID %d (must be between 0 and 4094)", n.Vlan)
 	}
 	return n, n.CNIVersion, nil
 }

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -75,6 +75,9 @@ func loadNetConf(bytes []byte) (*NetConf, string, error) {
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
 	}
+	if n.Vlan < 0 || n.Vlan > 4094 {
+		return nil, "", fmt.Errorf(`invalid VLAN ID %d (must be between 0 and 4094)`, n.Vlan)
+	}
 	return n, n.CNIVersion, nil
 }
 

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -1645,4 +1645,48 @@ var _ = Describe("bridge Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("check vlan id when loading net conf", func() {
+		tests := []struct {
+			tc  testCase
+			err error
+		}{
+			{
+				tc: testCase{
+					cniVersion: "0.4.0",
+				},
+				err: nil,
+			},
+			{
+				tc: testCase{
+					cniVersion: "0.4.0",
+					vlan:       0,
+				},
+				err: nil,
+			},
+			{
+				tc: testCase{
+					cniVersion: "0.4.0",
+					vlan:       -100,
+				},
+				err: fmt.Errorf("invalid VLAN ID -100 (must be between 0 and 4094)"),
+			},
+			{
+				tc: testCase{
+					cniVersion: "0.4.0",
+					vlan:       5000,
+				},
+				err: fmt.Errorf("invalid VLAN ID 5000 (must be between 0 and 4094)"),
+			},
+		}
+
+		for _, test := range tests {
+			_, _, err := loadNetConf([]byte(test.tc.netConfJSON("")))
+			if test.err == nil {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).To(Equal(test.err))
+			}
+		}
+	})
 })

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -53,10 +53,10 @@ func loadConf(bytes []byte) (*NetConf, string, error) {
 		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
 	}
 	if n.Master == "" {
-		return nil, "", fmt.Errorf(`"master" field is required. It specifies the host interface name to create the VLAN for.`)
+		return nil, "", fmt.Errorf("\"master\" field is required. It specifies the host interface name to create the VLAN for.")
 	}
 	if n.VlanId < 0 || n.VlanId > 4094 {
-		return nil, "", fmt.Errorf(`invalid VLAN ID %d (must be between 0 and 4095 inclusive)`, n.VlanId)
+		return nil, "", fmt.Errorf("invalid VLAN ID %d (must be between 0 and 4095 inclusive)", n.VlanId)
 	}
 	return n, n.CNIVersion, nil
 }


### PR DESCRIPTION
Check vlan id if in [0, 4094] when loading net conf to avoid unexpected error from kernel.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>