### PR TITLE
contributing doc: revise test script name to run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ go get github.com/onsi/ginkgo/ginkgo
 cd /go/src/github.com/containernetworking/plugins
 
 # to run the full test suite
-./test.sh
+./test_linux.sh
 
 # to focus on a particular test suite
 cd plugins/main/loopback


### PR DESCRIPTION
`test.sh` mentioned in CONTRIBUTING.md doesn't exist now as it was separated into two OS-specific scripts.