### PR TITLE
testutils: newNS() works in a rootless user namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 sudo: required
-dist: trusty
+dist: xenial
 
 go:
   - 1.11.x

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -57,3 +57,7 @@ if [ -n "${vetRes}" ]; then
 	echo -e "govet checking failed:\n${vetRes}"
 	exit 255
 fi
+
+# Run the pkg/ns tests as non root user
+mkdir /tmp/cni-rootless
+(export XDG_RUNTIME_DIR=/tmp/cni-rootless; cd pkg/ns/; unshare -rmn go test)


### PR DESCRIPTION
When running in a user namespace created by an unprivileged user the
owner of /var/run will be reported as the unknown user (as defined in
/proc/sys/kernel/overflowuid) so any access to the directory will
fail.

If the XDG_RUNTIME_DIR environment variable is set, check whether the
current user is also the owner of /var/run.  If the owner is different
than the current user, use the $XDG_RUNTIME_DIR/netns directory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>