### PR TITLE
macvlan: add MTU validation to loadNetConf

### DIFF
--- a/plugins/main/macvlan/README.md
+++ b/plugins/main/macvlan/README.md
@@ -23,9 +23,9 @@ Since each macvlan interface has its own MAC address, it makes it easy to use wi
 
 * `name` (string, required): the name of the network
 * `type` (string, required): "macvlan"
-* `master` (string, optional): name of the host interface to enslave. Defaults to default route interace.
+* `master` (string, optional): name of the host interface to enslave. Defaults to default route interface.
 * `mode` (string, optional): one of "bridge", "private", "vepa", "passthru". Defaults to "bridge".
-* `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
+* `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel. The value must be \[0, master's MTU\].
 * `ipam` (dictionary, required): IPAM configuration to be used for this network. For interface only without ip address, create empty dictionary.
 
 ## Notes


### PR DESCRIPTION
Try to fix #393 

If we want to create a macvlan interface from a parent(master) interface with a greater MTU, it will fail by kernel like below. And the error message is `Invalid argument` which contains no useful information. So we should add a MTU validation before creating interface in kernel.

```
[root@test ~]# ip link show eth2
11: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether fa:f2:3b:5a:33:02 brd ff:ff:ff:ff:ff:ff
[root@test ~]# ip link add link eth2 macv1 mtu 2000 type macvlan
RTNETLINK answers: Invalid argument
[root@test ~]# ip link add link eth2 macv1 mtu 1200 type macvlan
[root@test ~]# ip link show macv1
13: macv1@eth2: <BROADCAST,MULTICAST> mtu 1200 qdisc noop state DOWN mode DEFAULT group default qlen 1000
```

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>