### PR TITLE
bring in a MAC address generator for CNI plugins

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -230,7 +230,10 @@ func SetHardwareAddress(ifName string, hwAddr net.HardwareAddr) error {
 	}
 
 	if hwAddr == nil {
-		hwAddr = hwaddr.GenerateMAC()
+		hwAddr, err = hwaddr.GenerateMAC()
+		if err != nil {
+			return fmt.Errorf("failed to generate random CNI-OUI MAC address: %v", err)
+		}
 	}
 
 	if err = netlink.LinkSetHardwareAddr(iface, hwAddr); err != nil {

--- a/pkg/ip/link_linux_test.go
+++ b/pkg/ip/link_linux_test.go
@@ -270,40 +270,46 @@ var _ = Describe("Link", func() {
 		})
 	})
 
-	It("SetHardwareAddress should set hardware address to the specified one", func() {
-		_ = containerNetNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-
-			var err error
-			hwaddrBefore := getHwAddr(containerVethName)
-
-			err = ip.SetHardwareAddress(containerVethName, specifiedHardwareAddress)
-			Expect(err).NotTo(HaveOccurred())
-			hwaddrAfter1 := getHwAddr(containerVethName)
-
-			Expect(hwaddrBefore).NotTo(Equal(hwaddrAfter1))
-			Expect(hwaddrAfter1).To(Equal(specifiedHardwareAddress.String()))
-
-			return nil
+	Context("SetHardwareAddress tests", func() {
+		BeforeEach(func() {
+			// random generator is needed in these cases
+			rand.Reader = originalRandReader
 		})
-	})
+		It("SetHardwareAddress should set hardware address to the specified one", func() {
+			_ = containerNetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
 
-	It("SetHardwareAddress should set hardware address to CNI-OUI style if not assigned", func() {
-		_ = containerNetNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
+				var err error
+				hwaddrBefore := getHwAddr(containerVethName)
 
-			err := ip.SetHardwareAddress(containerVethName, nil)
-			Expect(err).NotTo(HaveOccurred())
-			hwaddrAfter1 := getHwAddr(containerVethName)
-			Expect(hwaddrAfter1).To(HavePrefix(cniOUIPrefix))
+				err = ip.SetHardwareAddress(containerVethName, specifiedHardwareAddress)
+				Expect(err).NotTo(HaveOccurred())
+				hwaddrAfter1 := getHwAddr(containerVethName)
 
-			err = ip.SetHardwareAddress(containerVethName, nil)
-			Expect(err).NotTo(HaveOccurred())
-			hwaddrAfter2 := getHwAddr(containerVethName)
-			Expect(hwaddrAfter2).To(HavePrefix(cniOUIPrefix))
+				Expect(hwaddrBefore).NotTo(Equal(hwaddrAfter1))
+				Expect(hwaddrAfter1).To(Equal(specifiedHardwareAddress.String()))
 
-			Expect(hwaddrAfter1).NotTo(Equal(hwaddrAfter2))
-			return nil
+				return nil
+			})
+		})
+
+		It("SetHardwareAddress should set hardware address to CNI-OUI style if not assigned", func() {
+			_ = containerNetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				err := ip.SetHardwareAddress(containerVethName, nil)
+				Expect(err).NotTo(HaveOccurred())
+				hwaddrAfter1 := getHwAddr(containerVethName)
+				Expect(hwaddrAfter1).To(HavePrefix(cniOUIPrefix))
+
+				err = ip.SetHardwareAddress(containerVethName, nil)
+				Expect(err).NotTo(HaveOccurred())
+				hwaddrAfter2 := getHwAddr(containerVethName)
+				Expect(hwaddrAfter2).To(HavePrefix(cniOUIPrefix))
+
+				Expect(hwaddrAfter1).NotTo(Equal(hwaddrAfter2))
+				return nil
+			})
 		})
 	})
 })

--- a/pkg/utils/hwaddr/hwaddr.go
+++ b/pkg/utils/hwaddr/hwaddr.go
@@ -35,9 +35,9 @@ var cniOUI = []byte{0x02, 0x58, 0x00}
 // the limitation that each subnet should contain no more 1024(2^10) using IP addresses.
 // For example, a subnet whose prefix is greater or equal than 22 is safe to use this function
 // as MAC address generator.
-func GenerateMAC() net.HardwareAddr {
+func GenerateMAC() (net.HardwareAddr, error) {
 	hw := make(net.HardwareAddr, 6)
 	copy(hw[:3], cniOUI)
-	_, _ = rand.Read(hw[3:])
-	return hw
+	_, err := rand.Read(hw[3:])
+	return hw, err
 }

--- a/pkg/utils/hwaddr/hwaddr.go
+++ b/pkg/utils/hwaddr/hwaddr.go
@@ -31,8 +31,10 @@ var cniOUI = []byte{0x02, 0x58, 0x00}
 
 // GenerateMAC will generate MAC addresses with fixed first 24 bits (CNI OUI), and the last 24 bits
 // will be random, so there are at most 16777216(2^24) different addresses.
-// To avoid MAC address collision, we suggest to use this function when length of subnet masking is
-// greater or equal than 20 in IPAM.
+// To avoid MAC address collision as much as possible, this function is suggested to be used within
+// the limitation that each subnet should contain no more 1024(2^10) using IP addresses.
+// For example, a subnet whose prefix is greater or equal than 22 is safe to use this function
+// as MAC address generator.
 func GenerateMAC() net.HardwareAddr {
 	hw := make(net.HardwareAddr, 6)
 	copy(hw[:3], cniOUI)

--- a/pkg/utils/hwaddr/hwaddr_test.go
+++ b/pkg/utils/hwaddr/hwaddr_test.go
@@ -15,8 +15,6 @@
 package hwaddr_test
 
 import (
-	"net"
-
 	"github.com/containernetworking/plugins/pkg/utils/hwaddr"
 
 	. "github.com/onsi/ginkgo"
@@ -25,50 +23,14 @@ import (
 
 var _ = Describe("Hwaddr", func() {
 	Context("Generate Hardware Address", func() {
-		It("generate hardware address based on ipv4 address", func() {
-			testCases := []struct {
-				ip          net.IP
-				expectedMAC net.HardwareAddr
-			}{
-				{
-					ip:          net.ParseIP("10.0.0.2"),
-					expectedMAC: (net.HardwareAddr)(append(hwaddr.PrivateMACPrefix, 0x0a, 0x00, 0x00, 0x02)),
-				},
-				{
-					ip:          net.ParseIP("10.250.0.244"),
-					expectedMAC: (net.HardwareAddr)(append(hwaddr.PrivateMACPrefix, 0x0a, 0xfa, 0x00, 0xf4)),
-				},
-				{
-					ip:          net.ParseIP("172.17.0.2"),
-					expectedMAC: (net.HardwareAddr)(append(hwaddr.PrivateMACPrefix, 0xac, 0x11, 0x00, 0x02)),
-				},
-				{
-					ip:          net.IPv4(byte(172), byte(17), byte(0), byte(2)),
-					expectedMAC: (net.HardwareAddr)(append(hwaddr.PrivateMACPrefix, 0xac, 0x11, 0x00, 0x02)),
-				},
+		It("generate CNI MAC addresses", func() {
+			for i := 0; i < 100; i++ {
+				cniMACAddress := hwaddr.GenerateMAC()
+				Expect(len(cniMACAddress)).To(Equal(6))
+				Expect(cniMACAddress[0]).To(Equal(byte(0x02)))
+				Expect(cniMACAddress[1]).To(Equal(byte(0x58)))
+				Expect(cniMACAddress[2]).To(Equal(byte(0x00)))
 			}
-
-			for _, tc := range testCases {
-				mac, err := hwaddr.GenerateHardwareAddr4(tc.ip, hwaddr.PrivateMACPrefix)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mac).To(Equal(tc.expectedMAC))
-			}
-		})
-
-		It("return error if input is not ipv4 address", func() {
-			testCases := []net.IP{
-				net.ParseIP(""),
-				net.ParseIP("2001:db8:0:1:1:1:1:1"),
-			}
-			for _, tc := range testCases {
-				_, err := hwaddr.GenerateHardwareAddr4(tc, hwaddr.PrivateMACPrefix)
-				Expect(err).To(BeAssignableToTypeOf(hwaddr.SupportIp4OnlyErr{}))
-			}
-		})
-
-		It("return error if prefix is invalid", func() {
-			_, err := hwaddr.GenerateHardwareAddr4(net.ParseIP("10.0.0.2"), []byte{0x58})
-			Expect(err).To(BeAssignableToTypeOf(hwaddr.InvalidPrefixLengthErr{}))
 		})
 	})
 })

--- a/pkg/utils/hwaddr/hwaddr_test.go
+++ b/pkg/utils/hwaddr/hwaddr_test.go
@@ -25,7 +25,8 @@ var _ = Describe("Hwaddr", func() {
 	Context("Generate Hardware Address", func() {
 		It("generate CNI MAC addresses", func() {
 			for i := 0; i < 100; i++ {
-				cniMACAddress := hwaddr.GenerateMAC()
+				cniMACAddress, err := hwaddr.GenerateMAC()
+				Expect(err).NotTo(HaveOccurred())
 				Expect(len(cniMACAddress)).To(Equal(6))
 				Expect(cniMACAddress[0]).To(Equal(byte(0x02)))
 				Expect(cniMACAddress[1]).To(Equal(byte(0x58)))


### PR DESCRIPTION
The first PR to resolve #407  , two things have been done in this PR
1. bring a special OUI for CNI
2. deprecate old MAC generator and create a new one
    - support dual stack
    - support CNI OUI

If this PR is merged, I'll try to introduce this generator to plugins, like macvlan, ptp, bridge ...

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>