### PR TITLE
idempotent portmap teardown 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56
 	github.com/juju/errors v0.0.0-20180806074554-22422dad46e1
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 // indirect
 	github.com/juju/testing v0.0.0-20190613124551-e81189438503 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56 h1:742eGXur0715JMq73
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/juju/errors v0.0.0-20180806074554-22422dad46e1 h1:wnhMXidtb70kDZCeLt/EfsVtkXS5c8zLnE9y/6DIRAU=
 github.com/juju/errors v0.0.0-20180806074554-22422dad46e1/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b h1:FQ7+9fxhyp82ks9vAuyPzG0/vVbWwMwLJ+P6yJI5FN8=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b/go.mod h1:HMcgvsgd0Fjj4XXDkbjdmlbI505rUPBs6WBMYg2pXks=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20190613124551-e81189438503 h1:ZUgTbk8oHgP0jpMieifGC9Lv47mHn8Pb3mFX3/Ew4iY=

--- a/vendor/github.com/juju/fslock/.gitignore
+++ b/vendor/github.com/juju/fslock/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/juju/fslock/LICENSE
+++ b/vendor/github.com/juju/fslock/LICENSE
@@ -1,0 +1,191 @@
+All files in this repository are licensed as follows. If you contribute
+to this repository, it is assumed that you license your contribution
+under the same license unless you state otherwise.
+
+All files Copyright (C) 2015 Canonical Ltd. unless otherwise specified in the file.
+
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply. 
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/vendor/github.com/juju/fslock/README.md
+++ b/vendor/github.com/juju/fslock/README.md
@@ -1,0 +1,74 @@
+
+# fslock [![GoDoc](https://godoc.org/github.com/juju/fslock?status.svg)](https://godoc.org/github.com/juju/fslock)
+fslock provides a cross-process mutex based on file locks that works on windows and *nix platforms.
+
+
+![fslock](https://cloud.githubusercontent.com/assets/3185864/15507515/f3351498-2199-11e6-9f37-bc59657a9e8c.jpg)
+
+<sup><sub>image: [public domain](https://pixabay.com/en/encrypted-privacy-policy-445155/)
+(don't ask)
+</sub></sup>
+
+fslock relies on LockFileEx on Windows and flock on \*nix systems.  The timeout 
+feature uses overlapped IO on Windows, but on \*nix platforms, timing out
+requires the use of a goroutine that will run until the lock is acquired,
+regardless of timeout.  If you need to avoid this use of goroutines, poll
+TryLock in a loop. 
+
+
+
+## Variables
+``` go
+var ErrLocked error = trylockError("fslock is already locked")
+```
+ErrLocked indicates TryLock failed because the lock was already locked.
+
+``` go
+var ErrTimeout error = timeoutError("lock timeout exceeded")
+```
+ErrTimeout indicates that the lock attempt timed out.
+
+
+## type Lock
+``` go
+type Lock struct {
+    // contains filtered or unexported fields
+}
+```
+Lock implements cross-process locks using syscalls.
+
+
+### func New
+``` go
+func New(filename string) *Lock
+```
+New returns a new lock around the given file.
+
+
+### func (\*Lock) Lock
+``` go
+func (l *Lock) Lock() error
+```
+Lock locks the lock.  This call will block until the lock is available.
+
+### func (\*Lock) LockWithTimeout
+``` go
+func (l *Lock) LockWithTimeout(timeout time.Duration) error
+```
+LockWithTimeout tries to lock the lock until the timeout expires.  If the
+timeout expires, this method will return ErrTimeout.
+
+### func (\*Lock) TryLock
+``` go
+func (l *Lock) TryLock() error
+```
+TryLock attempts to lock the lock.  This method will return ErrLocked
+immediately if the lock cannot be acquired.
+
+### func (\*Lock) Unlock
+``` go
+func (l *Lock) Unlock() error
+```
+Unlock unlocks the lock.
+
+

--- a/vendor/github.com/juju/fslock/fslock.go
+++ b/vendor/github.com/juju/fslock/fslock.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Package fslock provides a cross-process mutex based on file locks.
+//
+// It is built on top of flock for linux and darwin, and LockFileEx on Windows.
+package fslock
+
+// ErrTimeout indicates that the lock attempt timed out.
+var ErrTimeout error = timeoutError("lock timeout exceeded")
+
+type timeoutError string
+
+func (t timeoutError) Error() string {
+	return string(t)
+}
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+// ErrLocked indicates TryLock failed because the lock was already locked.
+var ErrLocked error = trylockError("fslock is already locked")
+
+type trylockError string
+
+func (t trylockError) Error() string {
+	return string(t)
+}
+
+func (trylockError) Temporary() bool {
+	return true
+}

--- a/vendor/github.com/juju/fslock/fslock_nix.go
+++ b/vendor/github.com/juju/fslock/fslock_nix.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package fslock
+
+import (
+	"syscall"
+	"time"
+)
+
+// Lock implements cross-process locks using syscalls.
+// This implementation is based on flock syscall.
+type Lock struct {
+	filename string
+	fd       int
+}
+
+// New returns a new lock around the given file.
+func New(filename string) *Lock {
+	return &Lock{filename: filename}
+}
+
+// Lock locks the lock.  This call will block until the lock is available.
+func (l *Lock) Lock() error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	return syscall.Flock(l.fd, syscall.LOCK_EX)
+}
+
+// TryLock attempts to lock the lock.  This method will return ErrLocked
+// immediately if the lock cannot be acquired.
+func (l *Lock) TryLock() error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		syscall.Close(l.fd)
+	}
+	if err == syscall.EWOULDBLOCK {
+		return ErrLocked
+	}
+	return err
+}
+
+func (l *Lock) open() error {
+	fd, err := syscall.Open(l.filename, syscall.O_CREAT|syscall.O_RDONLY, 0600)
+	if err != nil {
+		return err
+	}
+	l.fd = fd
+	return nil
+}
+
+// Unlock unlocks the lock.
+func (l *Lock) Unlock() error {
+	return syscall.Close(l.fd)
+}
+
+// LockWithTimeout tries to lock the lock until the timeout expires.  If the
+// timeout expires, this method will return ErrTimeout.
+func (l *Lock) LockWithTimeout(timeout time.Duration) error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	result := make(chan error)
+	cancel := make(chan struct{})
+	go func() {
+		err := syscall.Flock(l.fd, syscall.LOCK_EX)
+		select {
+		case <-cancel:
+			// Timed out, cleanup if necessary.
+			syscall.Flock(l.fd, syscall.LOCK_UN)
+			syscall.Close(l.fd)
+		case result <- err:
+		}
+	}()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(timeout):
+		close(cancel)
+		return ErrTimeout
+	}
+}

--- a/vendor/github.com/juju/fslock/fslock_windows.go
+++ b/vendor/github.com/juju/fslock/fslock_windows.go
@@ -1,0 +1,165 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package fslock
+
+import (
+	"log"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procCreateEventW = modkernel32.NewProc("CreateEventW")
+)
+
+const (
+	lockfileExclusiveLock = 2
+	fileFlagNormal        = 0x00000080
+)
+
+func init() {
+	log.SetFlags(log.Lmicroseconds | log.Ldate)
+}
+
+// Lock implements cross-process locks using syscalls.
+// This implementation is based on LockFileEx syscall.
+type Lock struct {
+	filename string
+	handle   syscall.Handle
+}
+
+// New returns a new lock around the given file.
+func New(filename string) *Lock {
+	return &Lock{filename: filename}
+}
+
+// TryLock attempts to lock the lock.  This method will return ErrLocked
+// immediately if the lock cannot be acquired.
+func (l *Lock) TryLock() error {
+	err := l.LockWithTimeout(0)
+	if err == ErrTimeout {
+		// in our case, timing out immediately just means it was already locked.
+		return ErrLocked
+	}
+	return err
+}
+
+// Lock locks the lock.  This call will block until the lock is available.
+func (l *Lock) Lock() error {
+	return l.LockWithTimeout(-1)
+}
+
+// Unlock unlocks the lock.
+func (l *Lock) Unlock() error {
+	return syscall.Close(l.handle)
+}
+
+// LockWithTimeout tries to lock the lock until the timeout expires.  If the
+// timeout expires, this method will return ErrTimeout.
+func (l *Lock) LockWithTimeout(timeout time.Duration) (err error) {
+	name, err := syscall.UTF16PtrFromString(l.filename)
+	if err != nil {
+		return err
+	}
+
+	// Open for asynchronous I/O so that we can timeout waiting for the lock.
+	// Also open shared so that other processes can open the file (but will
+	// still need to lock it).
+	handle, err := syscall.CreateFile(
+		name,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ,
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_FLAG_OVERLAPPED|fileFlagNormal,
+		0)
+	if err != nil {
+		return err
+	}
+	l.handle = handle
+	defer func() {
+		if err != nil {
+			syscall.Close(handle)
+		}
+	}()
+
+	millis := uint32(syscall.INFINITE)
+	if timeout >= 0 {
+		millis = uint32(timeout.Nanoseconds() / 1000000)
+	}
+
+	ol, err := newOverlapped()
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(ol.HEvent)
+	err = lockFileEx(handle, lockfileExclusiveLock, 0, 1, 0, ol)
+	if err == nil {
+		return nil
+	}
+
+	// ERROR_IO_PENDING is expected when we're waiting on an asychronous event
+	// to occur.
+	if err != syscall.ERROR_IO_PENDING {
+		return err
+	}
+	s, err := syscall.WaitForSingleObject(ol.HEvent, millis)
+
+	switch s {
+	case syscall.WAIT_OBJECT_0:
+		// success!
+		return nil
+	case syscall.WAIT_TIMEOUT:
+		return ErrTimeout
+	default:
+		return err
+	}
+}
+
+// newOverlapped creates a structure used to track asynchronous
+// I/O requests that have been issued.
+func newOverlapped() (*syscall.Overlapped, error) {
+	event, err := createEvent(nil, true, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &syscall.Overlapped{HEvent: event}, nil
+}
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r1, _, e1 := syscall.Syscall6(procLockFileEx.Addr(), 6, uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func createEvent(sa *syscall.SecurityAttributes, manualReset bool, initialState bool, name *uint16) (handle syscall.Handle, err error) {
+	var _p0 uint32
+	if manualReset {
+		_p0 = 1
+	}
+	var _p1 uint32
+	if initialState {
+		_p1 = 1
+	}
+
+	r0, _, e1 := syscall.Syscall6(procCreateEventW.Addr(), 4, uintptr(unsafe.Pointer(sa)), uintptr(_p0), uintptr(_p1), uintptr(unsafe.Pointer(name)), 0, 0)
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,6 +50,8 @@ github.com/godbus/dbus
 github.com/j-keck/arping
 # github.com/juju/errors v0.0.0-20180806074554-22422dad46e1
 github.com/juju/errors
+# github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
+github.com/juju/fslock
 # github.com/mattn/go-shellwords v1.0.3
 github.com/mattn/go-shellwords
 # github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b


### PR DESCRIPTION
It turns out that the portmap plugin is not idempotent if its executed in parallel.
The errors are caused due to a race of different iptables executions deleting the chains.
This patch adds a mutex based in a file lock that solves the concurrency problems.

xref: https://github.com/containernetworking/plugins/issues/418