### PR TITLE
Portmap doesn't fail if chain doesn't exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae
 	github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44
 	github.com/containernetworking/cni v0.7.1
-	github.com/coreos/go-iptables v0.4.2
+	github.com/coreos/go-iptables v0.4.5
 	github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
 	github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c
 	github.com/d2g/dhcp4client v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/coreos/go-iptables v0.4.2 h1:KH0EwId05JwWIfb96gWvkiT2cbuOu8ygqUaB+yPAwIg=
 github.com/coreos/go-iptables v0.4.2/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.4.4 h1:5oOUvU7Fk53Hn/rkdJ0zcYGCffotqXpyi4ADCkO1TJ8=
+github.com/coreos/go-iptables v0.4.4/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.4.5 h1:DpHb9vJrZQEFMcVLFKAAGMUVX0XoRC0ptCthinRYm38=
+github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c h1:Xo2rK1pzOm0jO6abTPIQwbAmqBIOj132otexc1mmzFc=

--- a/pkg/utils/iptables_test.go
+++ b/pkg/utils/iptables_test.go
@@ -67,12 +67,31 @@ var _ = Describe("chain tests", func() {
 		cleanup()
 	})
 
-	It("creates chains idempotently", func() {
-		err := EnsureChain(ipt, TABLE, testChain)
-		Expect(err).NotTo(HaveOccurred())
+	Describe("EnsureChain", func() {
+		It("creates chains idempotently", func() {
+			err := EnsureChain(ipt, TABLE, testChain)
+			Expect(err).NotTo(HaveOccurred())
 
-		// Create it again!
-		err = EnsureChain(ipt, TABLE, testChain)
-		Expect(err).NotTo(HaveOccurred())
+			// Create it again!
+			err = EnsureChain(ipt, TABLE, testChain)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
+
+	Describe("DeleteChain", func() {
+		It("delete chains idempotently", func() {
+			// Create chain
+			err := EnsureChain(ipt, TABLE, testChain)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Delete chain
+			err = DeleteChain(ipt, TABLE, testChain)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Delete it again!
+			err = DeleteChain(ipt, TABLE, testChain)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 })

--- a/plugins/meta/portmap/chain_test.go
+++ b/plugins/meta/portmap/chain_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
+	"sync"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
@@ -32,6 +33,7 @@ const TABLE = "filter" // We'll monkey around here
 var _ = Describe("chain tests", func() {
 	var testChain chain
 	var ipt *iptables.IPTables
+	var testNs ns.NetNS
 	var cleanup func()
 
 	BeforeEach(func() {
@@ -41,7 +43,7 @@ var _ = Describe("chain tests", func() {
 		currNs, err := ns.GetCurrentNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		testNs, err := testutils.NewNS()
+		testNs, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
 		tlChainName := fmt.Sprintf("cni-test-%d", rand.Intn(10000000))
@@ -194,5 +196,39 @@ var _ = Describe("chain tests", func() {
 				Fail("Chain was not deleted")
 			}
 		}
+	})
+
+	It("deletes chains idempotently in parallel", func() {
+		defer cleanup()
+		// number of parallel executions
+		N := 10
+		var wg sync.WaitGroup
+		err := testChain.setup(ipt)
+		Expect(err).NotTo(HaveOccurred())
+		errCh := make(chan error, N)
+		for i := 0; i < N; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// teardown chain
+				errCh <- testNs.Do(func(ns.NetNS) error {
+					return testChain.teardown(ipt)
+				})
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		chains, err := ipt.ListChains(TABLE)
+		Expect(err).NotTo(HaveOccurred())
+		for _, chain := range chains {
+			if chain == testChain.name {
+				Fail("Chain was not deleted")
+			}
+		}
+
 	})
 })

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/version
 github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/libcni
-# github.com/coreos/go-iptables v0.4.2
+# github.com/coreos/go-iptables v0.4.5
 github.com/coreos/go-iptables/iptables
 # github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
 github.com/coreos/go-systemd/activation


### PR DESCRIPTION
It turns out that the portmap plugin is not idempotent if its executed in parallel.
The errors are caused due to a race of different instantiations deleting the chains.
This patch does that the portmap plugin doesn't fail if the errors are because the chain doesn't exist on teardown.

xref: https://github.com/containernetworking/plugins/issues/418

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>