### PR TITLE
bridge: add missing cniVersion in README example

### DIFF
--- a/plugins/main/bridge/README.md
+++ b/plugins/main/bridge/README.md
@@ -14,17 +14,18 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 ## Example configuration
 ```
 {
-	"name": "mynet",
-	"type": "bridge",
-	"bridge": "mynet0",
-	"isDefaultGateway": true,
-	"forceAddress": false,
-	"ipMasq": true,
-	"hairpinMode": true,
-	"ipam": {
-		"type": "host-local",
-		"subnet": "10.10.0.0/16"
-	}
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "mynet0",
+    "isDefaultGateway": true,
+    "forceAddress": false,
+    "ipMasq": true,
+    "hairpinMode": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.10.0.0/16"
+    }
 }
 ```
 
@@ -32,10 +33,10 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 ```
 {
     "cniVersion": "0.3.1",
-	"name": "mynet",
-	"type": "bridge",
-	"bridge": "mynet0",
-	"ipam": {}
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "mynet0",
+    "ipam": {}
 }
 ```
 


### PR DESCRIPTION
The `cniVersion` field was missing in the network configuration of one of the examples of the 'bridge' plugin. Also fixed the indentation.

Omitting `cniVersion` results in the following kubelet error:

```
Dec 18 10:58:30 my-k8s-master kubelet[14847]: W1218 10:58:30.629078   14847 cni.go:202] Error validating CNI config list {"cniVersion":"", ... }: [plugin bridge does not support config version ""]
```