### PR TITLE
add support for mips64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - TARGET=arm64
   - TARGET=ppc64le
   - TARGET=s390x
+  - TARGET=mips64le
 
 matrix:
   fast_finish: true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ $DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins --r
     apk --no-cache add bash tar;
     cd /go/src/github.com/containernetworking/plugins; umask 0022;
 
-    for arch in amd64 arm arm64 ppc64le s390x; do \
+    for arch in amd64 arm arm64 ppc64le s390x mips64le; do \
         rm -f ${OUTPUT_DIR}/*; \
         CGO_ENABLED=0 GOARCH=\$arch ./build_linux.sh ${BUILDFLAGS}; \
         for format in tgz; do \


### PR DESCRIPTION
Added mips64le support for releasing plugins. 
Since the golang has a native support for cross compiling for mips64le, the plugins which written in pure go should have a completely support for mips64le.