### PR TITLE
Fix for the case where kernel doesn't have CONFIG_BRIDGE_VLAN_FILTERING

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -224,7 +224,9 @@ func ensureBridge(brName string, mtu int, promiscMode, vlanFiltering bool) (*net
 			// default packet limit
 			TxQLen: -1,
 		},
-		VlanFiltering: &vlanFiltering,
+	}
+	if vlanFiltering {
+		br.VlanFiltering = &vlanFiltering
 	}
 
 	err := netlink.LinkAdd(br)


### PR DESCRIPTION
If the Linux kernel is not built with the parameter CONFIG_BRIDGE_VLAN_FILTERING, passing `vlanFiltering` in the Bridge struct returns an error creating the bridge interface. This happens even when no parameter is set on `Vlan` in the CNI config.

This change fixes the case where no `Vlan` parameter is configured on CNI config file so the flag doesn't need to be included in the struct.

Addresses problems related in issue #370 seen on the Raspberry Pi kernel.

Cc. @alexellis