### PR TITLE
loopback: Fix ipv6 address checks

### DIFF
--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -68,6 +68,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if err != nil {
 			return err // not tested
 		}
+
 		v4Addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
 		if err != nil {
 			return err // not tested
@@ -89,7 +90,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if len(v6Addrs) != 0 {
 			v6Addr = v6Addrs[0].IPNet
 			// sanity check that this is a loopback address
-			for _, addr := range v4Addrs {
+			for _, addr := range v6Addrs {
 				if !addr.IP.IsLoopback() {
 					return fmt.Errorf("loopback interface found with non-loopback address %q", addr.IP)
 				}


### PR DESCRIPTION
Fixes a minor bug in loopback plugin. The IPv6 address check loops over IPv4 addresses.

I'm not quite sure what value these address checks provide, but if we are going to do it let's at least do it right.

Test suite passes successfully.