### PR TITLE
pkg/utils: sysctl package should use black-box testing

### DIFF
--- a/pkg/utils/sysctl/sysctl_linux.go
+++ b/pkg/utils/sysctl/sysctl_linux.go
@@ -59,7 +59,7 @@ func setSysctl(name, value string) (string, error) {
 // Sysctl names can use dots or slashes as separator:
 // - if dots are used, dots and slashes are interchanged.
 // - if slashes are used, slashes and dots are left intact.
-// Separator in use is determined by firt ocurrence.
+// Separator in use is determined by first occurrence.
 func toNormalName(name string) string {
 	interchange := false
 	for _, c := range name {

--- a/pkg/utils/sysctl/sysctl_linux_test.go
+++ b/pkg/utils/sysctl/sysctl_linux_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sysctl
+package sysctl_test
 
 import (
 	"fmt"
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
@@ -77,7 +78,7 @@ var _ = Describe("Sysctl tests", func() {
 			sysctlIfaceName := strings.Replace(testIfaceName, ".", "/", -1)
 			sysctlKey := fmt.Sprintf(sysctlDotKeyTemplate, sysctlIfaceName)
 
-			_, err := Sysctl(sysctlKey)
+			_, err := sysctl.Sysctl(sysctlKey)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -86,7 +87,7 @@ var _ = Describe("Sysctl tests", func() {
 		It("reads keys with slash separators", func() {
 			sysctlKey := fmt.Sprintf(sysctlSlashKeyTemplate, testIfaceName)
 
-			_, err := Sysctl(sysctlKey)
+			_, err := sysctl.Sysctl(sysctlKey)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -96,7 +97,7 @@ var _ = Describe("Sysctl tests", func() {
 			sysctlIfaceName := strings.Replace(testIfaceName, ".", "/", -1)
 			sysctlKey := fmt.Sprintf(sysctlDotKeyTemplate, sysctlIfaceName)
 
-			_, err := Sysctl(sysctlKey, "1")
+			_, err := sysctl.Sysctl(sysctlKey, "1")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -105,7 +106,7 @@ var _ = Describe("Sysctl tests", func() {
 		It("writes keys with slash separators", func() {
 			sysctlKey := fmt.Sprintf(sysctlSlashKeyTemplate, testIfaceName)
 
-			_, err := Sysctl(sysctlKey, "1")
+			_, err := sysctl.Sysctl(sysctlKey, "1")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
A follow-up fix PR of #437 , we should use black-box testing for utility functions.

BTW, fix some typo in comments.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>