### PR TITLE
ptp: remove some redundant lines

### DIFF
--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -228,7 +228,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	hostInterface, containerInterface, err := setupContainerVeth(netns, args.IfName, conf.MTU, result)
+	hostInterface, _, err := setupContainerVeth(netns, args.IfName, conf.MTU, result)
 	if err != nil {
 		return err
 	}
@@ -253,8 +253,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if dnsConfSet(conf.DNS) {
 		result.DNS = conf.DNS
 	}
-
-	result.Interfaces = []*current.Interface{hostInterface, containerInterface}
 
 	return types.PrintResult(result, conf.CNIVersion)
 }


### PR DESCRIPTION
remove some redundant lines against [https://github.com/containernetworking/plugins/blob/832f2699c29cd6614535b91b11acdecda6d867c1/plugins/main/ptp/ptp.go#L84](https://github.com/containernetworking/plugins/blob/832f2699c29cd6614535b91b11acdecda6d867c1/plugins/main/ptp/ptp.go#L84)

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>