### PR TITLE
pkg/ip: use type cast instead of untrusty error message

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -178,7 +178,7 @@ func SetupVeth(contVethName string, mtu int, hostNS ns.NetNS) (net.Interface, ne
 func DelLinkByName(ifName string) error {
 	iface, err := netlink.LinkByName(ifName)
 	if err != nil {
-		if err.Error() == "Link not found" {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
 			return ErrLinkNotFound
 		}
 		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
@@ -195,7 +195,7 @@ func DelLinkByName(ifName string) error {
 func DelLinkByNameAddr(ifName string) ([]*net.IPNet, error) {
 	iface, err := netlink.LinkByName(ifName)
 	if err != nil {
-		if err != nil && err.Error() == "Link not found" {
+		if _, ok := err.(netlink.LinkNotFoundError); ok {
 			return nil, ErrLinkNotFound
 		}
 		return nil, fmt.Errorf("failed to lookup %q: %v", ifName, err)


### PR DESCRIPTION
Error message is untrusty.
From [https://github.com/vishvananda/netlink/commit/99091d844046e6b17e4b094e937e8e9254afbfbd](https://github.com/vishvananda/netlink/commit/99091d844046e6b17e4b094e937e8e9254afbfbd) and codes, we can see that there are three kinds of error message about **not found**
- ```Link %s not found```
- ```Link alias %s not found```
- ```Link not found```

Our judgment will obviously fail in some cases, and type cast to `LinkNotFoundError` is more proper to help distinguish **not found error** from others.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>