### PR TITLE
flannel: remove net conf file after DEL succeed

### DIFF
--- a/plugins/meta/flannel/flannel_linux.go
+++ b/plugins/meta/flannel/flannel_linux.go
@@ -68,8 +68,8 @@ func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 	return delegateAdd(args.ContainerID, n.DataDir, n.Delegate)
 }
 
-func doCmdDel(args *skel.CmdArgs, n *NetConf) error {
-	netconfBytes, err := consumeScratchNetConf(args.ContainerID, n.DataDir)
+func doCmdDel(args *skel.CmdArgs, n *NetConf) (err error) {
+	cleanup, netConfBytes, err := consumeScratchNetConf(args.ContainerID, n.DataDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Per spec should ignore error if resources are missing / already removed
@@ -78,10 +78,15 @@ func doCmdDel(args *skel.CmdArgs, n *NetConf) error {
 		return err
 	}
 
+	// cleanup will work when no error happens
+	defer func() {
+		cleanup(err)
+	}()
+
 	nc := &types.NetConf{}
-	if err = json.Unmarshal(netconfBytes, nc); err != nil {
+	if err = json.Unmarshal(netConfBytes, nc); err != nil {
 		return fmt.Errorf("failed to parse netconf: %v", err)
 	}
 
-	return invoke.DelegateDel(context.TODO(), nc.Type, netconfBytes, nil)
+	return invoke.DelegateDel(context.TODO(), nc.Type, netConfBytes, nil)
 }


### PR DESCRIPTION
`consumeScratchNetConf` will remove net conf file in defer, so if `invoke.DelegateDel` fails and CNI DEL is called again, it will always be successful because net conf file has been removed already.

So I think the better way is to remove net conf file after `invoke.DelegateDel` succeed, this will make sure the CNI DEL retry will go through `invoke.DelegateDel` every time.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>