### PR TITLE
Add route-override plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
 * `bandwidth`: Allows bandwidth-limiting through use of traffic control tbf (ingress/egress).
 * `sbr`: A plugin that configures source based routing for an interface (from which it is chained).
 * `firewall`: A firewall plugin which uses iptables or firewalld to add rules to allow traffic to/from the container.
+* `route-override`: Adds and deletes IP route in the container
 
 ### Sample
 The sample plugin provides an example for building your own plugin.

--- a/plugins/linux_only.txt
+++ b/plugins/linux_only.txt
@@ -10,3 +10,4 @@ plugins/meta/portmap
 plugins/meta/tuning
 plugins/meta/bandwidth
 plugins/meta/firewall
+plugins/meta/route-override

--- a/plugins/meta/route-override/README.md
+++ b/plugins/meta/route-override/README.md
@@ -1,0 +1,64 @@
+# route-override: Meta CNI plugin for overriding IP route
+
+## Overview
+ route-override IPAM works as meta CNI plugin to override IP route given by previous CNI plugins.
+It is useful in multiple interface case with [network-attachment-definition](https://github.com/K8sNetworkPlumbingWG/multi-net-spec) to change the destination to specific interface, not default route.
+
+## Example Configuration
+
+```
+{
+    "cniVersion": "0.3.0",
+    "name" : "mymacvlan",
+    "plugins": [
+    {
+        "type": "macvlan",
+        "master": "eth1",
+        "mode": "bridge",
+        "ipam": {
+            ...
+        }
+    },
+    {
+        "type" : "route-override",
+        "del": [
+        {
+            "dst": "192.168.0.0/24"
+        }],
+        "add": [
+        {
+            "dst": "192.168.0.0/24",
+            "gw": "10.1.254.254"
+        }]
+    }
+    ]
+}
+```
+
+## Configuration Reference
+
+* `type`: (string, required): "routing-override"
+* `flushExisting`: (bool, optional): set it `true` if you flush all routes.
+* `flushDefaultGateway`: (bool, optional): set it `true` if you flush default route (gateway).
+* `del`: (object, optional): list of routes to delete from the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, "gateway" in the previous plugin results will be used.
+* `add`: (object, optional): list of routes to add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, "gateway" in the previous plugin results will be used.
+* `skipcheck`: (bool, optional): set it to `true` if there will be any changes in routes between `add`/`del` calls of this plugin.
+
+## Process Sequence
+
+`route-override` will manipulate the routes as following sequences:
+
+1. flush routes if `flushExisting` is enabled.
+1. flush gateway if `flushDefaultGateway` is enabled.
+1. if `del` is non empty - attempt to delete all listed in this variable routes. Missing routes are ignored.
+1. add all routes listed in `add`
+
+## Supported Arguments
+
+The following ["args" conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config) are supported:
+All arguments is the same as configuration reference above.
+
+* `flushExisting`: (bool, optional)
+* `flushDefaultGateway`: (bool, optional)
+* `del`: (object, optional)
+* `add`: (object, optional)

--- a/plugins/meta/route-override/route-override.go
+++ b/plugins/meta/route-override/route-override.go
@@ -1,0 +1,418 @@
+// Copyright 2019 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a "meta-plugin". It reads in its own netconf, it does not create
+// any network interface but just changes route information given from
+// previous cni plugins
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/vishvananda/netlink"
+)
+
+// RouteOverrideConfig represents the network route-override configuration
+type RouteOverrideConfig struct {
+	types.NetConf
+
+	FlushRoutes  bool           `json:"flushExisting,omitempty"`
+	FlushGateway bool           `json:"flushDefaultGateway,omitempty"`
+	DelRoutes    []*types.Route `json:"del"`
+	AddRoutes    []*types.Route `json:"add"`
+	SkipCheck    bool           `json:"skipcheck,omitempty"`
+
+	Args *struct {
+		A *IPAMArgs `json:"cni"`
+	} `json:"args"`
+}
+
+// IPAMArgs represents CNI argument conventions for the plugin
+type IPAMArgs struct {
+	FlushRoutes  *bool          `json:"flushExisting,omitempty"`
+	FlushGateway *bool          `json:"flushDefaultGateway,omitempty"`
+	DelRoutes    []*types.Route `json:"del,omitempty"`
+	AddRoutes    []*types.Route `json:"add,omitempty"`
+	SkipCheck    *bool          `json:"skipcheck,omitempty"`
+}
+
+func parseConf(data []byte, envArgs string) (*RouteOverrideConfig, error) {
+	conf := RouteOverrideConfig{FlushRoutes: false}
+
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return nil, fmt.Errorf("failed to load netconf: %v", err)
+	}
+
+	// override values by args
+	if conf.Args != nil {
+		if conf.Args.A.FlushRoutes != nil {
+			conf.FlushRoutes = *conf.Args.A.FlushRoutes
+		}
+
+		if conf.Args.A.FlushGateway != nil {
+			conf.FlushGateway = *conf.Args.A.FlushGateway
+		}
+
+		if conf.Args.A.DelRoutes != nil {
+			conf.DelRoutes = conf.Args.A.DelRoutes
+		}
+
+		if conf.Args.A.AddRoutes != nil {
+			conf.AddRoutes = conf.Args.A.AddRoutes
+		}
+
+		if conf.Args.A.SkipCheck != nil {
+			conf.SkipCheck = *conf.Args.A.SkipCheck
+		}
+
+	}
+
+	// Parse previous result
+	if conf.RawPrevResult != nil {
+		resultBytes, err := json.Marshal(conf.RawPrevResult)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize prevResult: %v", err)
+		}
+
+		res, err := version.NewResult(conf.CNIVersion, resultBytes)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse prevResult: %v", err)
+		}
+
+		conf.RawPrevResult = nil
+		conf.PrevResult, err = current.NewResultFromResult(res)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert result to current version: %v", err)
+		}
+	}
+
+	return &conf, nil
+}
+
+func deleteAllRoutes(res *current.Result) error {
+	for _, netif := range res.Interfaces {
+		if netif.Sandbox != "" {
+			link, _ := netlink.LinkByName(netif.Name)
+			routes, _ := netlink.RouteList(link, netlink.FAMILY_ALL)
+			for _, route := range routes {
+				if route.Scope != netlink.SCOPE_LINK {
+					if route.Dst != nil {
+						if route.Dst.IP.IsLinkLocalUnicast() != true && route.Gw != nil {
+							if err := netlink.RouteDel(&route); err != nil {
+								return err
+							}
+						}
+					} else {
+						if err := netlink.RouteDel(&route); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func deleteDefaulRouteOnLink(res *current.Result) error {
+	link, _ := netlink.LinkByName("eth0")
+	routes, _ := netlink.RouteList(link, netlink.FAMILY_ALL)
+	for _, nlroute := range routes {
+		if nlroute.Dst == nil {
+			if err := netlink.RouteDel(&nlroute); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func findAndDeleteDefaultRoute(res *current.Result) error {
+	// fallback to eth0 if there is no interface in result
+	if res.Interfaces == nil {
+		deleteDefaulRouteOnLink(res)
+	} else {
+		for _, netif := range res.Interfaces {
+			if netif.Sandbox != "" {
+				link, _ := netlink.LinkByName(netif.Name)
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_ALL)
+				for _, nlroute := range routes {
+					if nlroute.Dst == nil {
+						if err := netlink.RouteDel(&nlroute); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func deleteRouteOnLink(ifName string, route *types.Route, res *current.Result) error {
+	link, _ := netlink.LinkByName(ifName)
+	routes, _ := netlink.RouteList(link, netlink.FAMILY_ALL)
+	for _, nlroute := range routes {
+		if nlroute.Dst != nil &&
+			nlroute.Dst.IP.Equal(route.Dst.IP) &&
+			nlroute.Dst.Mask.String() == route.Dst.Mask.String() {
+			if err := netlink.RouteDel(&nlroute); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func deleteRoute(route *types.Route, res *current.Result) error {
+	// fallback to eth0 if there is no interface in result
+	if res.Interfaces == nil {
+		if err := deleteRouteOnLink("eth0", route, res); err != nil {
+			return err
+		}
+	} else {
+		for _, netif := range res.Interfaces {
+			if netif.Sandbox != "" {
+				if err := deleteRouteOnLink(netif.Name, route, res); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func addRoute(dev netlink.Link, route *types.Route) error {
+	return netlink.RouteAdd(&netlink.Route{
+		LinkIndex: dev.Attrs().Index,
+		Scope:     netlink.SCOPE_UNIVERSE,
+		Dst:       &route.Dst,
+		Gw:        route.GW,
+	})
+}
+
+func processRoutes(netnsname string, conf *RouteOverrideConfig) (*current.Result, error) {
+	netns, err := ns.GetNS(netnsname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open netns %q: %v", netns, err)
+	}
+	defer netns.Close()
+
+	res, err := current.NewResultFromResult(conf.PrevResult)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert result to current version: %v", err)
+	}
+
+	if conf.FlushGateway {
+		// add "0.0.0.0/0" into delRoute to remove it from routing table/result
+		_, gwRoute, _ := net.ParseCIDR("0.0.0.0/0")
+		conf.DelRoutes = append(conf.DelRoutes, &types.Route{Dst: *gwRoute})
+		_, gwRoute, _ = net.ParseCIDR("::/0")
+		conf.DelRoutes = append(conf.DelRoutes, &types.Route{Dst: *gwRoute})
+
+		// delete given gateway address
+		for _, ips := range res.IPs {
+			if ips.Version == "6" {
+				ips.Gateway = net.IPv6zero
+			} else {
+				ips.Gateway = net.IPv4zero
+			}
+		}
+	}
+
+	newRoutes := []*types.Route{}
+	err = netns.Do(func(_ ns.NetNS) error {
+		// Flush routes if required
+		if !conf.FlushRoutes {
+		NEXT:
+			for _, route := range res.Routes {
+				for _, delroute := range conf.DelRoutes {
+					if route.Dst.IP.Equal(delroute.Dst.IP) &&
+						bytes.Equal(route.Dst.Mask, delroute.Dst.Mask) {
+						err = deleteRoute(delroute, res)
+						if err != nil {
+							return fmt.Errorf("failed to delete route %v: %v", delroute, err)
+						}
+						continue NEXT
+					}
+
+				}
+				newRoutes = append(newRoutes, route)
+			}
+		} else {
+			err = deleteAllRoutes(res)
+			if err != nil {
+				return fmt.Errorf("failed to delete all routes: %v", err)
+			}
+		}
+
+		if conf.FlushGateway {
+			err = findAndDeleteDefaultRoute(res)
+			if err != nil {
+				return fmt.Errorf("failed to flush gateway: %v", err)
+			}
+		}
+
+		// Get container IF name
+		var containerIFName string
+		for _, i := range res.Interfaces {
+			if i.Sandbox != "" {
+				containerIFName = i.Name
+				break
+			}
+		}
+		// Add route
+		dev, _ := netlink.LinkByName(containerIFName)
+		for _, route := range conf.AddRoutes {
+			newRoutes = append(newRoutes, route)
+			if err := addRoute(dev, route); err != nil {
+				return fmt.Errorf("failed to add route: %v: %v", route, err)
+			}
+		}
+
+		return nil
+	})
+	res.Routes = newRoutes
+
+	return res, err
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	overrideConf, err := parseConf(args.StdinData, args.Args)
+	if err != nil {
+		return err
+	}
+
+	newResult, err := processRoutes(args.Netns, overrideConf)
+	if err != nil {
+		return fmt.Errorf("failed to override routes: %v", err)
+	}
+
+	return types.PrintResult(newResult, overrideConf.CNIVersion)
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	// The settings are not reverted to the previous values. Reverting the
+	// settings is not useful when the whole container goes away but it could be
+	// useful in scenarios where plugins are added and removed at runtime.
+	return nil
+}
+
+func cmdCheck(args *skel.CmdArgs) error {
+	// Parse previous result
+	overrideConf, err := parseConf(args.StdinData, args.Args)
+
+	if err != nil {
+		return err
+	}
+
+	// if skipcheck is true, skip it
+	if overrideConf.SkipCheck == true {
+		return nil
+	}
+
+	if overrideConf.PrevResult == nil {
+		return fmt.Errorf("Required prevResult missing")
+	}
+
+	if err := version.ParsePrevResult(&overrideConf.NetConf); err != nil {
+		return err
+	}
+
+	result, err := current.NewResultFromResult(overrideConf.PrevResult)
+	if err != nil {
+		return err
+	}
+
+	gateways := []net.IP{}
+	for _, i := range result.IPs {
+		gateways = append(gateways, i.Gateway)
+	}
+
+	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		for _, cniRoute := range overrideConf.DelRoutes {
+			_, err := netlink.RouteGet(cniRoute.Dst.IP)
+			if err == nil {
+				return fmt.Errorf("route-override: route is not removed: %v", cniRoute)
+			}
+		}
+
+		for _, cniRoute := range result.Routes {
+			var routes []netlink.Route
+			if cniRoute.Dst.IP.Equal(net.ParseIP("0.0.0.0")) == true || cniRoute.Dst.IP.Equal(net.ParseIP("::")) {
+				family := netlink.FAMILY_ALL
+				if cniRoute.Dst.IP.To4() == nil {
+					family = netlink.FAMILY_V6
+				} else {
+					family = netlink.FAMILY_V4
+				}
+				filter := &netlink.Route{
+					Dst: nil,
+				}
+				routes, err = netlink.RouteListFiltered(family, filter, netlink.RT_FILTER_DST)
+				if err != nil {
+					return err
+				}
+			} else {
+				routes, err = netlink.RouteGet(cniRoute.Dst.IP)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(routes) != 1 {
+				return fmt.Errorf("route-override: got multiple routes: %v", routes)
+			}
+
+			// if gateway in cni result is nil, then lookup gateways in interface of cni result
+			if cniRoute.GW == nil {
+				found := false
+				for _, gw := range gateways {
+					if gw.Equal(routes[0].Gw) {
+						found = true
+					}
+				}
+				if found != true {
+					return fmt.Errorf("route-override: cannot find gateway %v in result: %v", cniRoute.GW, routes[0].Gw)
+				}
+			} else {
+				if routes[0].Gw.Equal(cniRoute.GW) != true {
+					return fmt.Errorf("route-override: failed to match route: %v %v", cniRoute, routes[0].Gw)
+				}
+			}
+		}
+		return nil
+	})
+
+	return err
+}
+
+func main() {
+	// TODO: implement plugin version
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, "TODO")
+}

--- a/plugins/meta/route-override/route-override_test.go
+++ b/plugins/meta/route-override/route-override_test.go
@@ -1,0 +1,2279 @@
+// Copyright 2019 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	//"fmt"
+	//"os"
+	"net"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// ginkgo -p --randomizeAllSpecs --randomizeSuites --failOnPending --progress -r ./cmd/...
+
+func TestRouteOverride(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RouteOverride")
+}
+
+// helper function
+func testAddRoute(link netlink.Link, ip net.IP, mask net.IPMask, gw net.IP) error {
+	dst := &net.IPNet{
+		IP:   ip,
+		Mask: mask,
+	}
+	route := netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst, Gw: gw}
+	err := netlink.RouteAdd(&route)
+	return err
+}
+
+func testAddAddr(link netlink.Link, ip net.IP, mask net.IPMask) error {
+	var address = &net.IPNet{IP: ip, Mask: mask}
+	var addr = &netlink.Addr{IPNet: address}
+	err := netlink.AddrAdd(link, addr)
+	return err
+}
+
+func testHasRoute(routes []netlink.Route, dst *net.IPNet) bool {
+	for _, route := range routes {
+		// default route case
+		if dst == nil {
+			if route.Dst == nil {
+				return true
+			}
+		} else if route.Dst != nil && dst != nil &&
+			route.Dst.IP.Equal(dst.IP) && route.Dst.Mask.String() == dst.Mask.String() {
+			return true
+		}
+	}
+
+	return false
+}
+
+var _ = Describe("route-override operations by conf", func() {
+	const IFNAME string = "dummy0"
+	var originalNS ns.NetNS
+	var targetNS ns.NetNS
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		targetNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = targetNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: IFNAME,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	AfterEach(func() {
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	Context("ipv4 route manipulation", func() {
+		It("passes prevResult through unchanged", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("0.0.0.0/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+				Expect(result.Routes[1].Dst.String()).To(Equal("30.0.0.0/24"))
+				Expect(result.Routes[1].GW).To(BeNil())
+				Expect(result.Routes[2].Dst.String()).To(Equal("20.0.0.0/24"))
+				Expect(result.Routes[2].GW.String()).To(Equal("10.0.0.254"))
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(4)) // default + add2 + interface route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check flushExisting clears all routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"flushExisting": true,
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes).To(BeNil())
+
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(1)) // interface route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("check flushDefaultGateway clears gw routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"flushDefaultGateway": true,
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.1"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}
+			]
+		}
+	}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				// check no default gw
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Gateway.String()).To(Equal("0.0.0.0"))
+				Expect(result.Routes[0].Dst.String()).NotTo(Equal("0.0.0.0/0"))
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "gw routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(3)) // add2 + interface route
+				Expect(testHasRoute(routes, nil)).To(Equal(false))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check del works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"del": [ { "dst": "20.0.0.0/24" } ],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.1"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("0.0.0.0/0"))
+				Expect(result.Routes[0].GW).NotTo(BeNil())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				Expect(len(routes)).To(Equal(3))
+				_, delroute1, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testHasRoute(routes, delroute1)).To(Equal(false))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check add works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"add": [
+			{
+				"dst": "20.0.0.0/24"
+			}],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.254",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.254"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("0.0.0.0/0"))
+				Expect(result.Routes[0].GW.String()).To(Equal("10.0.0.254"))
+				Expect(result.Routes[1].Dst.String()).To(Equal("30.0.0.0/24"))
+				Expect(result.Routes[1].GW).To(BeNil())
+				Expect(result.Routes[2].Dst.String()).To(Equal("20.0.0.0/24"))
+				Expect(result.Routes[2].GW).To(BeNil())
+
+				return nil
+			})
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "XXX routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(4))
+				_, route1, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testHasRoute(routes, route1)).To(Equal(true))
+				_, route2, _ := net.ParseCIDR("10.0.0.0/24")
+				Expect(testHasRoute(routes, route2)).To(Equal(true))
+				_, route3, _ := net.ParseCIDR("30.0.0.0/24")
+				Expect(testHasRoute(routes, route3)).To(Equal(true))
+				Expect(testHasRoute(routes, nil)).To(Equal(true))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+
+	Context("ipv6 route manipulation", func() {
+		It("passes prevResult through unchanged", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("::/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+				Expect(result.Routes[1].Dst.String()).To(Equal("2001:db8:2::/64"))
+				Expect(result.Routes[1].GW.String()).To(Equal("2001:db8:1::ffff"))
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(4)) // default + add + interface route + link-local route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check flushExisting clears all routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"flushExisting": true,
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(result.Routes).To(BeNil())
+
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(2)) // interface route + link local route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("check flushDefaultGateway clears gw routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"flushDefaultGateway": true,
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}
+			]
+		}
+	}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				// check no default gw
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Gateway.String()).To(Equal("::"))
+				Expect(result.Routes[0].Dst.String()).NotTo(Equal("0.0.0.0/0"))
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v6 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				Expect(len(routes)).To(Equal(3)) // add + interface route + link-local
+				Expect(testHasRoute(routes, nil)).To(Equal(false))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check del works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"del": [ { "dst": "2001:DB8:2::/64" } ],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(len(result.Routes)).To(Equal(1))
+				Expect(result.Routes[0].Dst.String()).To(Equal("::/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v6 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(3))
+				_, delroute1, _ := net.ParseCIDR("2001:DB8:2::/64")
+				Expect(testHasRoute(routes, delroute1)).To(Equal(false))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check add works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"add": [
+			{
+				"dst": "2001:DB8:2::/64",
+				"gw": "2001:DB8:1::fffe"
+			}],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("::/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+				Expect(result.Routes[1].Dst.String()).To(Equal("2001:db8:2::/64"))
+				Expect(result.Routes[1].GW.String()).To(Equal("2001:db8:1::fffe"))
+
+				return nil
+			})
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v6 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "XXX routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(4))
+				_, route1, _ := net.ParseCIDR("2001:db8:2::/64")
+				Expect(testHasRoute(routes, route1)).To(Equal(true))
+				Expect(testHasRoute(routes, nil)).To(Equal(true))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("ipv4/v6 mixed route manipulation", func() {
+		It("pass cni's check command", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"add": [
+			{
+				"dst": "20.0.0.0/24"
+			}],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.254",
+					"interface": 0
+				},
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.254"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = testutils.CmdCheckWithArgs(args, func() error {
+					return cmdCheck(args)
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+		})
+
+		It("check cni's check command with error", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"add": [
+			{
+				"dst": "20.0.0.0/24"
+			}],
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.254",
+					"interface": 0
+				},
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.254"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME with different gw
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24" with different gw
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = testutils.CmdCheckWithArgs(args, func() error {
+					return cmdCheck(args)
+				})
+
+				Expect(err).To(HaveOccurred())
+				return nil
+			})
+		})
+
+		It("skip cni's check command", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"add": [
+			{
+				"dst": "20.0.0.0/24"
+			}],
+			"skipcheck": true,
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.254",
+					"interface": 0
+				},
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.254"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME with different gw
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24" with different gw
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = testutils.CmdCheckWithArgs(args, func() error {
+					return cmdCheck(args)
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+		})
+	})
+})
+
+var _ = Describe("route-override operations by args", func() {
+	const IFNAME string = "dummy0"
+
+	var originalNS ns.NetNS
+	var targetNS ns.NetNS
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		targetNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = targetNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: IFNAME,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	AfterEach(func() {
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	Context("ipv4 route manipulation", func() {
+		It("check flushExisting clears all routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"flushExisting": true
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.1"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes).To(BeNil())
+
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(1)) // interface route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check del works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"del": [
+					{
+						"dst": "20.0.0.0/24"
+					}]
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.1"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				},
+				{
+					"dst": "20.0.0.0/24",
+					"gw": "10.0.0.254"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "20.0.0.0/24", "gw": "10.0.0.254"
+				err = testAddRoute(link,
+					net.IPv4(20, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 254))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("0.0.0.0/0"))
+				Expect(result.Routes[0].GW).NotTo(BeNil())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(3))
+				_, delroute1, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testHasRoute(routes, delroute1)).To(Equal(false))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check add works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"add": [
+					{
+						"dst": "20.0.0.0/24"
+					}]
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "4",
+					"address": "10.0.0.2/24",
+					"gateway": "10.0.0.254",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "0.0.0.0/0",
+					"gw": "10.0.0.254"
+				},
+				{
+					"dst": "30.0.0.0/24"
+				}]
+			}
+		}`)
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 10.0.0.2/24
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				//"dst": "30.0.0.0/24"
+				err = testAddRoute(link,
+					net.IPv4(30, 0, 0, 0), net.CIDRMask(24, 32),
+					net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("0.0.0.0/0"))
+				Expect(result.Routes[0].GW.String()).To(Equal("10.0.0.254"))
+				Expect(result.Routes[1].Dst.String()).To(Equal("30.0.0.0/24"))
+				Expect(result.Routes[1].GW).To(BeNil())
+				Expect(result.Routes[2].Dst.String()).To(Equal("20.0.0.0/24"))
+				Expect(result.Routes[2].GW).To(BeNil())
+
+				return nil
+			})
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V4)
+				Expect(len(routes)).To(Equal(4))
+				_, delroute1, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testHasRoute(routes, delroute1)).To(Equal(true))
+				_, delroute2, _ := net.ParseCIDR("10.0.0.0/24")
+				Expect(testHasRoute(routes, delroute2)).To(Equal(true))
+				_, delroute3, _ := net.ParseCIDR("30.0.0.0/24")
+				Expect(testHasRoute(routes, delroute3)).To(Equal(true))
+				Expect(testHasRoute(routes, nil)).To(Equal(true))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("ipv6 route manipulation", func() {
+		It("check flushExisting clears all routes", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"flushExisting": true
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(result.Routes).To(BeNil())
+
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v4 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(2)) // interface route + link local route
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("check del works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"del": [
+					{
+						"dst": "2001:DB8:2::/64"
+					}]
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0",
+					"sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				},
+				{
+					"dst": "2001:DB8:2::/64",
+					"gw": "2001:DB8:1::ffff"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				// "dst": "2001:DB8:2::/64", "gw": "2001:DB8:1::ffff"
+				err = testAddRoute(link,
+					net.ParseIP("2001:DB8:2::"), net.CIDRMask(64, 128),
+					net.ParseIP("2001:DB8:1::ffff"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(len(result.Routes)).To(Equal(1))
+				Expect(result.Routes[0].Dst.String()).To(Equal("::/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+
+				return nil
+			})
+
+			// check route info
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v6 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(3))
+				_, delroute1, _ := net.ParseCIDR("2001:DB8:2::/64")
+				Expect(testHasRoute(routes, delroute1)).To(Equal(false))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check add works", func() {
+			conf := []byte(`{
+			"name": "test",
+			"type": "route-override",
+			"cniVersion": "0.3.1",
+			"args": {
+				"cni": {
+					"add": [
+					{
+						"dst": "2001:DB8:2::/64",
+						"gw": "2001:DB8:1::fffe"
+					}]
+				}
+			},
+			"prevResult": {
+				"interfaces": [
+				{
+					"name": "dummy0", "sandbox":"netns"
+				}],
+				"ips": [
+				{
+					"version": "6",
+					"address": "2001:DB8:1::2/64",
+					"gateway": "2001:DB8:1::1",
+					"interface": 0
+				}],
+				"routes": [
+				{
+					"dst": "::/0"
+				}]
+			}
+		}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			// set address/route as fakeCNI plugin
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+
+				// addr 2001:DB8:1::2/64
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+
+				// add default gateway into IFNAME
+				err = testAddRoute(link,
+					net.ParseIP("::"), net.CIDRMask(0, 0),
+					net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				var result *current.Result
+
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err = current.GetResult(r)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(result.Interfaces)).To(Equal(1))
+				Expect(result.Interfaces[0].Name).To(Equal(IFNAME))
+				Expect(len(result.IPs)).To(Equal(1))
+				Expect(result.IPs[0].Address.String()).To(Equal("2001:db8:1::2/64"))
+				Expect(result.Routes[0].Dst.String()).To(Equal("::/0"))
+				Expect(result.Routes[0].GW).To(BeNil())
+				Expect(result.Routes[1].Dst.String()).To(Equal("2001:db8:2::/64"))
+				Expect(result.Routes[1].GW.String()).To(Equal("2001:db8:1::fffe"))
+
+				return nil
+			})
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				// FAMILY_ALL for all, but use v6 for its simplicity
+				routes, _ := netlink.RouteList(link, netlink.FAMILY_V6)
+				//fmt.Fprintf(os.Stderr, "XXX routes: %v\n", routes) // XXX
+				Expect(len(routes)).To(Equal(4))
+				_, route1, _ := net.ParseCIDR("2001:db8:2::/64")
+				Expect(testHasRoute(routes, route1)).To(Equal(true))
+				Expect(testHasRoute(routes, nil)).To(Equal(true))
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This changes to add 'route-overide' meta CNI plugin, which
overrides (i.e. add/del) ip route for the interface.