### PR TITLE
Make host-device to work with virtio net device

### DIFF
--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -296,7 +296,12 @@ func getLink(devname, hwaddr, kernelpath, pciaddr string) (netlink.Link, error) 
 	} else if len(pciaddr) > 0 {
 		netDir := filepath.Join(sysBusPCI, pciaddr, "net")
 		if _, err := os.Lstat(netDir); err != nil {
-			return nil, fmt.Errorf("no net directory under pci device %s: %q", pciaddr, err)
+			virtioNetDir := filepath.Join(sysBusPCI, pciaddr, "virtio*", "net")
+			matches, err := filepath.Glob(virtioNetDir)
+			if matches == nil || err != nil {
+				return nil, fmt.Errorf("no net directory under pci device %s", pciaddr)
+			}
+			netDir = matches[0]
 		}
 		fInfo, err := ioutil.ReadDir(netDir)
 		if err != nil {


### PR DESCRIPTION
In case pciBusID contains pci address of the virtio device, then lookup `ip link` under `{sysBusPCIDir}/virtio{id}/net` directory.

Issue: https://github.com/containernetworking/plugins/issues/320

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>