### PR TITLE
win-bridge: add support for portMappings capability

### DIFF
--- a/plugins/main/windows/win-bridge/README.md
+++ b/plugins/main/windows/win-bridge/README.md
@@ -35,7 +35,8 @@ With win-bridge plugin, all containers (on the same host) are plugged into an L2
     ],
     "loopbackDSR": true,
     "capabilities": {
-        "dns": true
+        "dns": true,
+        "portMappings":  true
     }
 }
 ```
@@ -55,3 +56,4 @@ With win-bridge plugin, all containers (on the same host) are plugged into an L2
 * `loopbackDSR` (bool, optional): If true, will add a policy to allow the interface to support loopback direct server return.
 * `capabilities` (dictionary, optional): Runtime capabilities to enable.
  * `dns` (boolean, optional): If true, will take the dns config supplied by the runtime and override other settings.
+ * `portMappings` (boolean, optional): If true, will handle HostPort<>ContainerPort mapping using NAT HNS Policies

--- a/plugins/main/windows/win-bridge/win-bridge_windows.go
+++ b/plugins/main/windows/win-bridge/win-bridge_windows.go
@@ -86,6 +86,9 @@ func ProcessEndpointArgs(args *skel.CmdArgs, n *NetConf) (*hns.EndpointInfo, err
 		n.ApplyOutboundNatPolicy(n.IPMasqNetwork)
 	}
 
+	// Add HostPort mapping if any present
+	n.ApplyPortMappingPolicy(n.RuntimeConfig.PortMaps)
+
 	epInfo.DNS = n.GetDNS()
 
 	return epInfo, nil
@@ -107,7 +110,6 @@ func cmdHnsAdd(args *skel.CmdArgs, n *NetConf) (*current.Result, error) {
 	}
 
 	epName := hns.ConstructEndpointName(args.ContainerID, args.Netns, n.Name)
-
 	hnsEndpoint, err := hns.ProvisionEndpoint(epName, hnsNetwork.Id, args.ContainerID, args.Netns, func() (*hcsshim.HNSEndpoint, error) {
 		epInfo, err := ProcessEndpointArgs(args, n)
 		epInfo.NetworkId = hnsNetwork.Id
@@ -130,7 +132,6 @@ func cmdHnsAdd(args *skel.CmdArgs, n *NetConf) (*current.Result, error) {
 	}
 
 	return result, nil
-
 }
 
 func cmdHcnAdd(args *skel.CmdArgs, n *NetConf) (*current.Result, error) {


### PR DESCRIPTION
If the pluging receives portMappings in runtimeConfig, the pluing will add a NAT policy for each port mapping on the generated endpoints.

It enables HostPort usage on Windows with win-bridge (currently silently ignored).
Requires Windows >=1903 for containers to reach their own node through NodeIP + HostPort.