### PR TITLE
plugins/meta/sbr: Adjusted ipv6 address mask to /128

### DIFF
--- a/plugins/meta/sbr/main.go
+++ b/plugins/meta/sbr/main.go
@@ -237,7 +237,7 @@ func doRoutes(ipCfgs []*current.IPConfig, origRoutes []*types.Route, iface strin
 		if ipCfg.Version == "4" {
 			src.Mask = net.CIDRMask(32, 32)
 		} else {
-			src.Mask = net.CIDRMask(64, 64)
+			src.Mask = net.CIDRMask(128, 128)
 		}
 
 		log.Printf("Source to use %s", src.String())
@@ -258,7 +258,7 @@ func doRoutes(ipCfgs []*current.IPConfig, origRoutes []*types.Route, iface strin
 				dest.Mask = net.CIDRMask(0, 32)
 			} else {
 				dest.IP = net.IPv6zero
-				dest.Mask = net.CIDRMask(0, 64)
+				dest.Mask = net.CIDRMask(0, 128)
 			}
 
 			route := netlink.Route{


### PR DESCRIPTION
A /64 mask was used which routed an entire cidr based on source, not only the bound address.

Fixes #478

