### PR TITLE
ptp, bridge: disable accept_ra on the host-side interface

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -21,10 +21,12 @@ import (
 	"net"
 	"os"
 
-	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/containernetworking/plugins/pkg/utils/hwaddr"
 	"github.com/safchain/ethtool"
 	"github.com/vishvananda/netlink"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/utils/hwaddr"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 )
 
 var (
@@ -158,6 +160,9 @@ func SetupVethWithName(contVethName, hostVethName string, mtu int, hostNS ns.Net
 		if err = netlink.LinkSetUp(hostVeth); err != nil {
 			return fmt.Errorf("failed to set %q up: %v", hostVethName, err)
 		}
+
+		// we want to own the routes for this interface
+		_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", hostVethName), "0")
 		return nil
 	})
 	if err != nil {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/utils"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 )
 
 // For testcases to force an error after IPAM has been performed
@@ -247,6 +248,9 @@ func ensureBridge(brName string, mtu int, promiscMode, vlanFiltering bool) (*net
 	if err != nil {
 		return nil, err
 	}
+
+	// we want to own the routes for this interface
+	_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", brName), "0")
 
 	if err := netlink.LinkSetUp(br); err != nil {
 		return nil, err


### PR DESCRIPTION
The interface plugins should have absolute control over their addressing and routing.