### PR TITLE
Use another thread to process time.Sleep, so even if time.Sleep hangs…

### DIFF
--- a/pkg/ip/addr_linux.go
+++ b/pkg/ip/addr_linux.go
@@ -38,7 +38,7 @@ func SettleAddresses(ifName string, timeout int) error {
 		return fmt.Errorf("failed to retrieve link: %v", err)
 	}
 
-	cxt, cancel := context.WithTimeout(context.Background(), time.Duration(timeout) * time.Second)
+	cxt, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 	timeEventChan := make(chan readOnlyTimeChan, 1)
 
@@ -69,8 +69,8 @@ func SettleAddresses(ifName string, timeout int) error {
 		}()
 
 		select {
-		case <- <-timeEventChan:
-		case <- cxt.Done():
+		case <-<-timeEventChan:
+		case <-cxt.Done():
 			return fmt.Errorf("link %s still has tentative addresses after %d seconds",
 				ifName,
 				timeout)


### PR DESCRIPTION
…, we can also use context.timeout to ensure that the program runs normally

Signed-off-by: Xiaoning Tan <txiaoning@casachina.com.cn>