### PR TITLE
portmap should not perform deletions if not portMapping config received

### DIFF
--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -107,6 +107,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to parse config: %v", err)
 	}
 
+	if len(netConf.RuntimeConfig.PortMaps) == 0 {
+		return nil
+	}
+
 	netConf.ContainerID = args.ContainerID
 
 	// We don't need to parse out whether or not we're using v6 or snat,


### PR DESCRIPTION
The portmap plugin, once receives a DEL, tries to delete as much as possible.

This causes issues on busy environment, because all DEL command are going to be processed by the portmap plugin, that will perform iptables operations holding the lock despite it doesn't have anything to delete.

portmap should only try to delete if it receives portMap parameters from the runtimeConfig.

xref: https://github.com/kubernetes/kubernetes/pull/92811#issuecomment-657426111

Fixes: https://github.com/containernetworking/plugins/issues/510

Signed-off-by: Antonio Ojea <aojea@redhat.com>