### PR TITLE
firewall: fix some typos in docs

### DIFF
--- a/plugins/meta/firewall/README.md
+++ b/plugins/meta/firewall/README.md
@@ -28,7 +28,7 @@ The following network configuration file
         }
       },
       {
-        "type": "firewall",
+        "type": "firewall"
       }
     ]
 }
@@ -72,7 +72,7 @@ look like:
       },
       {
         "type": "firewall",
-	"backend": "firewalld"
+        "backend": "firewalld"
       }
     ]
 }
@@ -111,7 +111,7 @@ look like:
       },
       {
         "type": "firewall",
-	"backend": "iptables"
+        "backend": "iptables"
       }
     ]
 }
@@ -129,7 +129,7 @@ when containers are created and from where rules will be removed when containers
 CNI-FORWARD will have a pair of rules added, one for each direction, using the IPAM assigned IP address
 of the container as shown:
 
-`CNI_FORWARD` chain:
-- `-s 10.88.0.2 -m conntrack --ctstate RELATED,ESTABLISHED -j CNI-FORWARD`
-- `-d 10.88.0.2 -j CNI-FORWARD`
+`CNI-FORWARD` chain:
+- `-s 10.88.0.2 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT`
+- `-d 10.88.0.2 -j ACCEPT`
 


### PR DESCRIPTION
When preparing the slides of CNI Deep Dive, found these typos in firewall plugin docs.
Most of them are just small typos, but the last two lines are fatal I think.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>