### PR TITLE
Add contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Read [CONTRIBUTING](CONTRIBUTING.md) for build and test instructions.
 
 ### Sample
 The sample plugin provides an example for building your own plugin.
+
+## Contact
+
+For any questions about CNI, please reach out via:
+- Email: [cni-dev](https://groups.google.com/forum/#!forum/cni-dev)
+- Slack: #cni on the [CNCF slack](https://slack.cncf.io/).
+
+If you have a _security_ issue to report, please do so privately to the email addresses listed in the [OWNERS](OWNERS.md) file.


### PR DESCRIPTION
Inspired by https://github.com/containernetworking/cni/pull/780, but I had to add the non-security info too.

Interesting the maintainers file has a different name here.
