### PR TITLE
Fix race condition in GetCurrentNS

### DIFF
--- a/pkg/ns/ns_linux.go
+++ b/pkg/ns/ns_linux.go
@@ -26,6 +26,11 @@ import (
 
 // Returns an object representing the current OS thread's network namespace
 func GetCurrentNS() (NetNS, error) {
+	// Lock the thread in case other goroutine executes in it and changes its
+	// network namespace after getCurrentThreadNetNSPath(), otherwise it might
+	// return an unexpected network namespace.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	return GetNS(getCurrentThreadNetNSPath())
 }
 


### PR DESCRIPTION
In GetCurrentNS, If there is a context-switch between
getCurrentThreadNetNSPath and GetNS, another goroutine may execute in
the original thread and change its network namespace, then the original
goroutine would get the updated network namespace, which could lead to
unexpected behavior, especially when GetCurrentNS is used to get the
host network namespace in netNS.Do.

The added test has a chance to reproduce it with "-count=50".

The patch fixes it by locking the thread in GetCurrentNS.

Fixes #524