### PR TITLE
Flannel log

### DIFF
--- a/plugins/meta/flannel/flannel_linux.go
+++ b/plugins/meta/flannel/flannel_linux.go
@@ -85,6 +85,8 @@ func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 	}
 	n.Delegate["ipam"] = ipam
 
+	Log(DebugLevel, "flannel CNI doCmdAdd() Delegate: %v", n.Delegate)
+
 	return delegateAdd(args.ContainerID, n.DataDir, n.Delegate)
 }
 


### PR DESCRIPTION
Logging level can be set using the "LogLevel" field of the NetConf:
```
  {
    "name": "cbr0",
    "cniVersion": "0.3.1",
    "type": "flannel",
    "logLevel": "debug",
    ...
  }
```
It can be set to "panic", "error", "verbose" or "debug", and defaults to "panic".