### PR TITLE
flannel: allow input ipam parameters as basis for delegate

### DIFF
--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -46,6 +46,8 @@ const (
 type NetConf struct {
 	types.NetConf
 
+	// IPAM field "replaces" that of types.NetConf which is incomplete
+	IPAM          map[string]interface{} `json:"ipam,omitempty"`
 	SubnetFile    string                 `json:"subnetFile"`
 	DataDir       string                 `json:"dataDir"`
 	Delegate      map[string]interface{} `json:"delegate"`
@@ -87,6 +89,18 @@ func loadFlannelNetConf(bytes []byte) (*NetConf, error) {
 	}
 
 	return n, nil
+}
+
+func getIPAMRoutes(n *NetConf) ([]types.Route, error) {
+	rtes := []types.Route{}
+
+	if n.IPAM != nil && hasKey(n.IPAM, "routes") {
+		buf, _ := json.Marshal(n.IPAM["routes"])
+		if err := json.Unmarshal(buf, &rtes); err != nil {
+			return rtes, fmt.Errorf("failed to parse ipam.routes: %w", err)
+		}
+	}
+	return rtes, nil
 }
 
 func loadFlannelSubnetEnv(fn string) (*subnetEnv, error) {

--- a/plugins/meta/flannel/flannel_linux.go
+++ b/plugins/meta/flannel/flannel_linux.go
@@ -22,11 +22,35 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"os"
 )
+
+// Return IPAM section for Delegate using input IPAM if present and replacing
+// or complementing as needed.
+func getDelegateIPAM(n *NetConf, fenv *subnetEnv) (map[string]interface{}, error) {
+	ipam := n.IPAM
+	if ipam == nil {
+		ipam = map[string]interface{}{}
+	}
+
+	if !hasKey(ipam, "type") {
+		ipam["type"] = "host-local"
+	}
+	ipam["subnet"] = fenv.sn.String()
+
+	rtes, err := getIPAMRoutes(n)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read IPAM routes: %w", err)
+	}
+	rtes = append(rtes, types.Route{Dst: *fenv.nw})
+	ipam["routes"] = rtes
+
+	return ipam, nil
+}
 
 func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 	n.Delegate["name"] = n.Name
@@ -55,15 +79,11 @@ func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 		n.Delegate["cniVersion"] = n.CNIVersion
 	}
 
-	n.Delegate["ipam"] = map[string]interface{}{
-		"type":   "host-local",
-		"subnet": fenv.sn.String(),
-		"routes": []types.Route{
-			{
-				Dst: *fenv.nw,
-			},
-		},
+	ipam, err := getDelegateIPAM(n, fenv)
+	if err != nil {
+		return fmt.Errorf("failed to assemble Delegate IPAM: %w", err)
 	}
+	n.Delegate["ipam"] = ipam
 
 	return delegateAdd(args.ContainerID, n.DataDir, n.Delegate)
 }


### PR DESCRIPTION
(NOTE: This work started under PR #527 which was a combination of this and the addition of logging; now split into 2 PRs)

This change allows providing an 'ipam' section as part of the input network configuration for flannel. It is then used as basis to construct the ipam parameters provided to the delegate.

All parameters from the input ipam are preserved except:
* 'subnet' which is set to the flannel host subnet
* 'routes' which is complemented by a route to the flannel network.

One use case of this feature is to allow adding back the routes to the cluster services and/or to the hosts (HostPort) when using isDefaultGateway=false. In that case, the bridge plugin does not install a default route and, as a result, only pod-to-pod connectivity would be available.

Example:
```
  {
    "name": "cbr0",
    "cniVersion": "0.3.1",
    "type": "flannel",
    "ipam": {
      "routes": [
        {
          "dst": "192.168.242.0/24"
        },
        {
          "dst": "10.96.0.0/12"
        }
      ],
      "unknown-param": "value"
    },
    "delegate": {
      "hairpinMode": true,
      "isDefaultGateway": false
    }
    ...
  }
```

This results in the following 'ipam' being provided to the delegate:
```
    {
      "routes" : [
        {
          "dst": "192.168.242.0/24"
        },
        {
          "dst": "10.96.0.0/12"
        },
        {
          "dst" : "10.1.0.0/16"
        }
      ],
      "subnet" : "10.1.17.0/24",
      "type" : "host-local"
      "unknown-param": "value"
    }
```

where "10.1.0.0/16" is the flannel network and "10.1.17.0/24" is the host flannel subnet.

Note that this also allows setting a different ipam 'type' than "host-local".