### PR TITLE
VRF CNI: Add an optional table parameter.

### DIFF
--- a/plugins/meta/vrf/README.md
+++ b/plugins/meta/vrf/README.md
@@ -4,7 +4,7 @@
 
 This plugin creates a [VRF](https://www.kernel.org/doc/Documentation/networking/vrf.txt) in the network namespace and assigns it the interface passed in the arguments. If the VRF is already present in the namespace, it only adds the interface to it.
 
-As a table id is mandatory, the plugin generates a new one for each different VRF that is added to the namespace.
+The table id is mandatory for VRF but optional in the CNI configuration. If not specified, the plugin generates a new one for each different VRF that is added to the namespace.
 
 It does not create any network interfaces and therefore does not bring connectivity by itself.
 It is only useful when used in addition to other plugins.
@@ -50,4 +50,5 @@ The only configuration is the name of the VRF, as per the following example:
 
 The following [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config) are supported:
 
-* `vrfname` (string, optional): The name of the VRF to be created and to be set as master of the interface
+* `vrfname` (string): The name of the VRF to be created and to be set as master of the interface
+* `table` (int, optional): The route table to be associated to the created VRF.

--- a/plugins/meta/vrf/vrf.go
+++ b/plugins/meta/vrf/vrf.go
@@ -35,15 +35,19 @@ func findVRF(name string) (*netlink.Vrf, error) {
 }
 
 // createVRF creates a new VRF and sets it up.
-func createVRF(name string) (*netlink.Vrf, error) {
+func createVRF(name string, tableID uint32) (*netlink.Vrf, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return nil, fmt.Errorf("createVRF: Failed to find links %v", err)
 	}
-	tableID, err := findFreeRoutingTableID(links)
-	if err != nil {
-		return nil, err
+
+	if tableID == 0 {
+		tableID, err = findFreeRoutingTableID(links)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	vrf := &netlink.Vrf{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: name,


### PR DESCRIPTION
When specified from the user, the VRF will get assigned to the given tableid instead of having the CNI to choose for a free one.

This is based on https://github.com/containernetworking/plugins/pull/535 and https://github.com/containernetworking/plugins/pull/525