### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 sudo: required
 dist: bionic
-
+arch:
+  - AMD64
+  - ppc64le
 go:
   - 1.13.x
   - 1.14.x
@@ -36,7 +38,15 @@ matrix:
       env: TARGET=arm64
       go: 1.14.x
       arch: arm64
-
+#power jobs
+    - os: linux
+      env: TARGET=arm64
+      go: 1.13.x
+      arch: ppc64le
+    - os: linux
+      env: TARGET=arm64
+      go: 1.14.x
+      arch: ppc64le
 install:
   - go get github.com/onsi/ginkgo/ginkgo
   - go get github.com/containernetworking/cni/cnitool


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.