### PR TITLE
VRF: extend supported version to 0.3.1 too

### DIFF
--- a/plugins/meta/vrf/main.go
+++ b/plugins/meta/vrf/main.go
@@ -38,7 +38,7 @@ type VRFNetConf struct {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.4.0"), bv.BuildString("vrf"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.3.1", "0.4.0"), bv.BuildString("vrf"))
 }
 
 func cmdAdd(args *skel.CmdArgs) error {


### PR DESCRIPTION
The e2e tests already covers both versions, and since the plugin is meant to be used in chains, this will augment the scope of the plugins it can be used with.
