### PR TITLE
dhcp: fix example configuration

### DIFF
--- a/plugins/ipam/dhcp/README.md
+++ b/plugins/ipam/dhcp/README.md
@@ -30,7 +30,7 @@ With the daemon running, containers using the dhcp plugin can be launched.
 ```
 {
 	"ipam": {
-		"type": "dhcp",
+		"type": "dhcp"
 	}
 }
 


### PR DESCRIPTION
The current cni config has an extra comma and cannot be parsed normally, the kubelet will report an error as follows:
"Error loading CNI config file: error parsing configuration: invalid character '}' looking for beginning of object key string"