### PR TITLE
fix a bug in ifb link teardown with ip addr

### DIFF
--- a/plugins/meta/bandwidth/ifb_creator.go
+++ b/plugins/meta/bandwidth/ifb_creator.go
@@ -43,7 +43,7 @@ func CreateIfb(ifbDeviceName string, mtu int) error {
 }
 
 func TeardownIfb(deviceName string) error {
-	_, err := ip.DelLinkByNameAddr(deviceName)
+	err := ip.DelLinkByName(deviceName)
 	if err != nil && err == ip.ErrLinkNotFound {
 		return nil
 	}


### PR DESCRIPTION
In brandwidth plugin scenario, ifb link(bwpxxx) has no ip address, so an error `failed to get IP addresses for ...` always returned when cmdDel called and this link device won't be removed.