### PR TITLE
DHCP timeout is configurable

### DIFF
--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -63,7 +64,7 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 
 	clientID := generateClientID(args.ContainerID, conf.Name, args.IfName)
 	hostNetns := d.hostNetnsPrefix + args.Netns
-	l, err := AcquireLease(clientID, hostNetns, args.IfName)
+	l, err := AcquireLease(clientID, hostNetns, args.IfName, 5*time.Second)
 	if err != nil {
 		return err
 	}

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -22,6 +22,7 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -37,17 +38,19 @@ func main() {
 		var pidfilePath string
 		var hostPrefix string
 		var socketPath string
+		var timeout time.Duration
 		daemonFlags := flag.NewFlagSet("daemon", flag.ExitOnError)
 		daemonFlags.StringVar(&pidfilePath, "pidfile", "", "optional path to write daemon PID to")
 		daemonFlags.StringVar(&hostPrefix, "hostprefix", "", "optional prefix to host root")
 		daemonFlags.StringVar(&socketPath, "socketpath", "", "optional dhcp server socketpath")
+		daemonFlags.DurationVar(&timeout, "timeout", 5*time.Second, "optional dhcp client timeout duration")
 		daemonFlags.Parse(os.Args[2:])
 
 		if socketPath == "" {
 			socketPath = defaultSocketPath
 		}
 
-		if err := runDaemon(pidfilePath, hostPrefix, socketPath); err != nil {
+		if err := runDaemon(pidfilePath, hostPrefix, socketPath, timeout); err != nil {
 			log.Printf(err.Error())
 			os.Exit(1)
 		}

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -43,7 +43,7 @@ func main() {
 		daemonFlags.StringVar(&pidfilePath, "pidfile", "", "optional path to write daemon PID to")
 		daemonFlags.StringVar(&hostPrefix, "hostprefix", "", "optional prefix to host root")
 		daemonFlags.StringVar(&socketPath, "socketpath", "", "optional dhcp server socketpath")
-		daemonFlags.DurationVar(&timeout, "timeout", 5*time.Second, "optional dhcp client timeout duration")
+		daemonFlags.DurationVar(&timeout, "timeout", 10*time.Second, "optional dhcp client timeout duration")
 		daemonFlags.Parse(os.Args[2:])
 
 		if socketPath == "" {


### PR DESCRIPTION
What
----

Addresses #470, albeit quite naively. Building on the existing daemon configuration code

A user would deploy the daemon (using the systemd example):

```
[Service]
ExecStart=/opt/cni/bin/dhcp daemon -timeout 15s
```

to configure the DHCP client timeout to 15s. The default timeout remains 5s unchanged.

Why
---

If a user configures their DHCP daemon, because they are in an environment where DHCP responses may take a long time, an IP address will still be allocated for their container

Why not
---

It is arguable that a simpler solution would be to arbitrarily increase the default timeout to 15s. I can redo this PR to do that instead

Further work
------------

If this is merged I will make a cni.dev PR to document the CLI option, consistent with `hostprefix` and friends