### PR TITLE
[main/vlan] Fix error handling for delegate IPAM plugin

### DIFF
--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -152,7 +152,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// run the IPAM plugin and get back the config to apply
 	r, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute IPAM delegate: %v", err)
 	}
 
 	// Invoke ipam del if err to avoid ip leak


### PR DESCRIPTION
At the moment error messages generated during execution of delegate IPAM plugin are indistinguishable from main `vlan` messages leading to cryptic messages like `no plugin name provided` which IS hard to debug from a human operator level.
This PR fixes that behavior.