### PR TITLE
Add plugins/meta/isolation (Bridge Isolation Plugin)

### DIFF
--- a/plugins/linux_only.txt
+++ b/plugins/linux_only.txt
@@ -11,3 +11,4 @@ plugins/meta/tuning
 plugins/meta/bandwidth
 plugins/meta/firewall
 plugins/meta/vrf
+plugins/meta/isolation

--- a/plugins/meta/isolation/chain.go
+++ b/plugins/meta/isolation/chain.go
@@ -1,0 +1,141 @@
+// Copyright 2021 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/utils"
+	"github.com/coreos/go-iptables/iptables"
+)
+
+const (
+	filterTableName        = "filter"  // built-in
+	forwardChainName       = "FORWARD" // built-in
+	defaultStage1ChainName = "CNI-ISOLATION-STAGE-1"
+	defaultStage2ChainName = "CNI-ISOLATION-STAGE-2"
+)
+
+// setupChain executes the following iptables commands:
+// ```
+// iptables -N CNI-ISOLATION-STAGE-1
+// iptables -N CNI-ISOLATION-STAGE-2
+// # NOTE: "-j CNI-ISOLATION-STAGE-1" needs to be before "CNI-FORWARD" created by CNI firewall plugin. So we use -I here.
+// iptables -I FORWARD -j CNI-ISOLATION-STAGE-1
+// iptables -A CNI-ISOLATION-STAGE-1 -i ${bridgeName} ! -o ${bridgeName} -j CNI-ISOLATION-STAGE-2
+// iptables -A CNI-ISOLATION-STAGE-1 -j RETURN
+// iptables -A CNI-ISOLATION-STAGE-2 -o ${bridgeName} -j DROP
+// iptables -A CNI-ISOLATION-STAGE-2 -j RETURN
+// ```
+func setupChain(ipt *iptables.IPTables, bridgeName string) error {
+	const (
+		// Future version may support custom chain names
+		stage1Chain = defaultStage1ChainName
+		stage2Chain = defaultStage2ChainName
+	)
+	// Commands:
+	// ```
+	// iptables -N CNI-ISOLATION-STAGE-1
+	// iptables -N CNI-ISOLATION-STAGE-2
+	// ```
+	for _, chain := range []string{stage1Chain, stage2Chain} {
+		if err := utils.EnsureChain(ipt, filterTableName, chain); err != nil {
+			return err
+		}
+	}
+
+	// Commands:
+	// ```
+	// iptables -I FORWARD -j CNI-ISOLATION-STAGE-1
+	// ```
+	jumpToStage1 := withDefaultComment([]string{"-j", stage1Chain})
+	//  NOTE: "-j CNI-ISOLATION-STAGE-1" needs to be before "CNI-FORWARD" created by CNI firewall plugin.
+	// So we specify prepend = true .
+	const jumpToStage1Prepend = true
+	if err := insertUnique(ipt, filterTableName, forwardChainName, jumpToStage1Prepend, jumpToStage1); err != nil {
+		return err
+	}
+
+	// Commands:
+	// ```
+	// iptables -A CNI-ISOLATION-STAGE-1 -i ${bridgeName} ! -o ${bridgeName} -j CNI-ISOLATION-STAGE-2
+	// iptables -A CNI-ISOLATION-STAGE-1 -j RETURN
+	// ```
+	stage1Bridge := withDefaultComment(stage1BridgeRule(bridgeName, stage2Chain))
+	// prepend = true because this needs to be before "-j RETURN"
+	const stage1BridgePrepend = true
+	if err := insertUnique(ipt, filterTableName, stage1Chain, stage1BridgePrepend, stage1Bridge); err != nil {
+		return err
+	}
+	stage1Return := withDefaultComment([]string{"-j", "RETURN"})
+	if err := insertUnique(ipt, filterTableName, stage1Chain, false, stage1Return); err != nil {
+		return err
+	}
+
+	// Commands:
+	// ```
+	// iptables -A CNI-ISOLATION-STAGE-2 -o ${bridgeName} -j DROP
+	// iptables -A CNI-ISOLATION-STAGE-2 -j RETURN
+	// ```
+	stage2Bridge := withDefaultComment(stage2BridgeRule(bridgeName))
+	// prepend = true because this needs to be before "-j RETURN"
+	const stage2BridgePrepend = true
+	if err := insertUnique(ipt, filterTableName, stage2Chain, stage2BridgePrepend, stage2Bridge); err != nil {
+		return err
+	}
+	stage2Return := withDefaultComment([]string{"-j", "RETURN"})
+	if err := insertUnique(ipt, filterTableName, stage2Chain, false, stage2Return); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func stage1BridgeRule(bridgeName, stage2Chain string) []string {
+	return []string{"-i", bridgeName, "!", "-o", bridgeName, "-j", stage2Chain}
+}
+
+func stage2BridgeRule(bridgeName string) []string {
+	return []string{"-o", bridgeName, "-j", "DROP"}
+}
+
+func withDefaultComment(rule []string) []string {
+	defaultComment := fmt.Sprintf("CNI %s plugin rules", PluginName)
+	return withComment(rule, defaultComment)
+}
+
+func withComment(rule []string, comment string) []string {
+	return append(rule, []string{"-m", "comment", "--comment", comment}...)
+}
+
+// insertUnique will add a rule to a chain if it does not already exist.
+// By default the rule is appended, unless prepend is true.
+//
+// insertUnique was taken from https://github.com/containernetworking/plugins/blob/v0.9.0/plugins/meta/portmap/chain.go#L104-L120
+func insertUnique(ipt *iptables.IPTables, table, chain string, prepend bool, rule []string) error {
+	exists, err := ipt.Exists(table, chain, rule...)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	if prepend {
+		return ipt.Insert(table, chain, 1, rule...)
+	} else {
+		return ipt.Append(table, chain, rule...)
+	}
+}

--- a/plugins/meta/isolation/isolation_integ_test.go
+++ b/plugins/meta/isolation/isolation_integ_test.go
@@ -1,0 +1,206 @@
+// Copyright 2021 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// To run test: go test -c . && sudo PATH=/opt/cni/bin:$PATH ./isolation.test -test.v -ginkgo.v
+//
+// The test is roughly based on https://github.com/containernetworking/plugins/blob/v0.9.0/plugins/meta/portmap/portmap_integ_test.go
+var _ = Describe("isolation integration tests", func() {
+	// ns0: foo (10.88.3.0/24)
+	// ns1: foo (10.88.3.0/24)
+	// ns2: bar (10.88.4.0/24)
+	//
+	// ns0@foo can talk to ns1@foo, but cannot talk to ns2@bar
+	const nsCount = 3
+	var (
+		configListFoo *libcni.NetworkConfigList // "foo", 10.88.3.0/24
+		configListBar *libcni.NetworkConfigList // "bar", 10.88.4.0/24
+		cniConf       *libcni.CNIConfig
+		namespaces    [nsCount]ns.NetNS
+	)
+
+	BeforeEach(func() {
+		var err error
+		rawConfigFoo := `
+{
+   "cniVersion": "0.4.0",
+   "name": "foo",
+   "plugins": [
+      {
+         "type": "bridge",
+         "bridge": "foo",
+         "isGateway": true,
+         "ipMasq": true,
+         "hairpinMode": true,
+         "ipam": {
+            "type": "host-local",
+            "routes": [
+               {
+                  "dst": "0.0.0.0/0"
+               }
+            ],
+            "ranges": [
+               [
+                  {
+                     "subnet": "10.88.3.0/24",
+                     "gateway": "10.88.3.1"
+                  }
+               ]
+            ]
+         }
+      },
+      {
+         "type": "firewall"
+      },
+      {
+         "type": "isolation"
+      }
+   ]
+}
+`
+		configListFoo, err = libcni.ConfListFromBytes([]byte(rawConfigFoo))
+		Expect(err).NotTo(HaveOccurred())
+
+		rawConfigBar := strings.ReplaceAll(rawConfigFoo, "foo", "bar")
+		rawConfigBar = strings.ReplaceAll(rawConfigBar, "10.88.3.", "10.88.4.")
+
+		configListBar, err = libcni.ConfListFromBytes([]byte(rawConfigBar))
+		Expect(err).NotTo(HaveOccurred())
+
+		// turn PATH in to CNI_PATH.
+		_, err = exec.LookPath("isolation")
+		Expect(err).NotTo(HaveOccurred())
+		dirs := filepath.SplitList(os.Getenv("PATH"))
+		cniConf = &libcni.CNIConfig{Path: dirs}
+
+		for i := 0; i < nsCount; i++ {
+			targetNS, err := testutils.NewNS()
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "namespace %d:%s\n", i, targetNS.Path())
+			namespaces[i] = targetNS
+		}
+	})
+
+	AfterEach(func() {
+		for _, targetNS := range namespaces {
+			if targetNS != nil {
+				targetNS.Close()
+			}
+		}
+	})
+
+	Describe("Testing with network foo and bar", func() {
+		It("should isolate foo from bar", func() {
+			var results [nsCount]*current.Result
+			for i := 0; i < nsCount; i++ {
+				runtimeConfig := libcni.RuntimeConf{
+					ContainerID: fmt.Sprintf("test-cni-isolation-%d", i),
+					NetNS:       namespaces[i].Path(),
+					IfName:      "eth0",
+				}
+
+				configList := configListFoo
+				switch i {
+				case 0, 1:
+				// leave foo
+				default:
+					configList = configListBar
+				}
+
+				// Clean up garbages produced during past failed executions
+				_ = cniConf.DelNetworkList(context.TODO(), configList, &runtimeConfig)
+
+				// Make delete idempotent, so we can clean up on failure
+				netDeleted := false
+				deleteNetwork := func() error {
+					if netDeleted {
+						return nil
+					}
+					netDeleted = true
+					return cniConf.DelNetworkList(context.TODO(), configList, &runtimeConfig)
+				}
+				// Create the network
+				res, err := cniConf.AddNetworkList(context.TODO(), configList, &runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+				// nolint: errcheck
+				defer deleteNetwork()
+
+				results[i], err = current.NewResultFromResult(res)
+				Expect(err).NotTo(HaveOccurred())
+				fmt.Fprintf(GinkgoWriter, "results[%d]: %+v\n", i, results[i])
+			}
+			ping := func(src, dst int) error {
+				return namespaces[src].Do(func(ns.NetNS) error {
+					defer GinkgoRecover()
+					saddr := results[src].IPs[0].Address.IP.String()
+					daddr := results[dst].IPs[0].Address.IP.String()
+					srcNetName := results[src].Interfaces[0].Name
+					dstNetName := results[dst].Interfaces[0].Name
+
+					fmt.Fprintf(GinkgoWriter, "ping %s (ns%d@%s) -> %s (ns%d@%s)...",
+						saddr, src, srcNetName, daddr, dst, dstNetName)
+					v6 := results[dst].IPs[0].Version == "6"
+					timeoutSec := 1
+					if err := testutils.Ping(saddr, daddr, v6, timeoutSec); err != nil {
+						fmt.Fprintln(GinkgoWriter, "unpingable")
+						return err
+					}
+					fmt.Fprintln(GinkgoWriter, "pingable")
+					return nil
+				})
+			}
+
+			// ns0@foo can ping to ns1@foo
+			err := ping(0, 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			// ns1@foo can ping to ns0@foo
+			err = ping(1, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			// ns0@foo cannot ping to ns2@bar
+			err = ping(0, 2)
+			Expect(err).To(HaveOccurred())
+
+			// ns1@foo cannot ping to ns2@bar
+			err = ping(1, 2)
+			Expect(err).To(HaveOccurred())
+
+			// ns2@bar cannot ping to ns0@foo
+			err = ping(2, 0)
+			Expect(err).To(HaveOccurred())
+
+			// ns2@bar cannot ping to ns1@foo
+			err = ping(2, 1)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/plugins/meta/isolation/isolation_suite_test.go
+++ b/plugins/meta/isolation/isolation_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIsolation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "plugins/meta/isolation")
+}

--- a/plugins/meta/isolation/main.go
+++ b/plugins/meta/isolation/main.go
@@ -1,0 +1,153 @@
+// Copyright 2021 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/coreos/go-iptables/iptables"
+
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
+)
+
+// PluginName
+const PluginName = "isolation"
+
+// PluginConf
+type PluginConf struct {
+	types.NetConf
+
+	// Chained prev results
+	RawPrevResult *map[string]interface{} `json:"prevResult"`
+	PrevResult    *current.Result         `json:"-"`
+
+	// Internal states
+	bridgeName string
+}
+
+// parseConfig parses the supplied configuration (and prevResult) from stdin.
+func parseConfig(stdin []byte) (*PluginConf, error) {
+	conf := PluginConf{}
+
+	if err := json.Unmarshal(stdin, &conf); err != nil {
+		return nil, fmt.Errorf("failed to parse network configuration: %v", err)
+	}
+
+	if conf.RawPrevResult != nil {
+		resultBytes, err := json.Marshal(conf.RawPrevResult)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize prevResult: %v", err)
+		}
+		res, err := version.NewResult(conf.CNIVersion, resultBytes)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse prevResult: %v", err)
+		}
+		conf.RawPrevResult = nil
+		conf.PrevResult, err = current.NewResultFromResult(res)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert result to current version: %v", err)
+		}
+	} else {
+		return nil, fmt.Errorf("needs to be chained with \"bridge\" plugin")
+	}
+
+	if len(conf.PrevResult.Interfaces) == 0 {
+		return nil, fmt.Errorf("interface needs to be set, make sure to chain %q plugin with \"bridge\"", PluginName)
+	}
+	intf := conf.PrevResult.Interfaces[0]
+	if intf == nil {
+		return nil, fmt.Errorf("got nil interface")
+	}
+	conf.bridgeName = intf.Name
+
+	if conf.bridgeName == "" {
+		return nil, fmt.Errorf("got empty bridge name")
+	}
+	return &conf, nil
+}
+
+func hasV6(conf *PluginConf) bool {
+	for _, f := range conf.PrevResult.IPs {
+		if f != nil && f.Version == "6" {
+			return true
+		}
+	}
+	return false
+}
+
+func getIPTables(withV6 bool) ([]*iptables.IPTables, error) {
+	ipt4, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+	res := []*iptables.IPTables{ipt4}
+
+	if withV6 {
+		ipt6, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, ipt6)
+	}
+	return res, nil
+}
+
+// cmdAdd is called for ADD requests
+func cmdAdd(args *skel.CmdArgs) error {
+	conf, err := parseConfig(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	ipts, err := getIPTables(hasV6(conf))
+	if err != nil {
+		return err
+	}
+
+	for _, ipt := range ipts {
+		if err := setupChain(ipt, conf.bridgeName); err != nil {
+			return err
+		}
+	}
+
+	// Pass through the result for the next plugin
+	return types.PrintResult(conf.PrevResult, conf.CNIVersion)
+}
+
+// cmdDel is called for DELETE requests
+func cmdDel(args *skel.CmdArgs) error {
+	conf, err := parseConfig(args.StdinData)
+	if err != nil {
+		return err
+	}
+	_ = conf
+
+	// We can't be sure whether conf.bridgeName is still in use by other containers.
+	// So we do not remove the iptable rules that are created per bridge.
+	return nil
+}
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString(PluginName))
+}
+
+func cmdCheck(args *skel.CmdArgs) error {
+	return nil
+}


### PR DESCRIPTION
The `isolation` plugin isolates CNI bridge networks as in Docker bridge networks.

e.g., when `ns1` and `ns2` are connected to bridge `cni1`, and `ns3` is connected to bridge `cni2`, `isolation` plugins disallows communications between `ns1` and `ns3`, while allowing communications between `ns1` and `ns2`.

To enable `isolation` plugin, `{"type":"isolation"}` needs to be inserted after `{"type":"bridge"}` (and `{"type":"firewall"}`if present) .

This plugin is mostly made for single-node CNI projects, including, but not limited to, containerd ([nerdctl](https://github.com/AkihiroSuda/nerdctl)), BuildKit, and Podman.

For the further information (including why this plugin needs to be merged into this repo rather than 3rd party repo), please see the proposal document: https://github.com/containernetworking/plugins/issues/573

 - - -
Close #573 