### PR TITLE
[macvlan] Stop setting proxy-arp on macvlan interface

### DIFF
--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -33,11 +33,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
-	"github.com/containernetworking/plugins/pkg/utils/sysctl"
-)
-
-const (
-	IPv4InterfaceArpProxySysctlTemplate = "net.ipv4.conf.%s.proxy_arp"
 )
 
 type NetConf struct {
@@ -208,14 +203,6 @@ func createMacvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Inter
 	}
 
 	err = netns.Do(func(_ ns.NetNS) error {
-		// TODO: duplicate following lines for ipv6 support, when it will be added in other places
-		ipv4SysctlValueName := fmt.Sprintf(IPv4InterfaceArpProxySysctlTemplate, tmpName)
-		if _, err := sysctl.Sysctl(ipv4SysctlValueName, "1"); err != nil {
-			// remove the newly added link and ignore errors, because we already are in a failed state
-			_ = netlink.LinkDel(mv)
-			return fmt.Errorf("failed to set proxy_arp on newly added interface %q: %v", tmpName, err)
-		}
-
 		err := ip.RenameLink(tmpName, ifName)
 		if err != nil {
 			_ = netlink.LinkDel(mv)


### PR DESCRIPTION
The original issue was: https://github.com/containernetworking/cni/issues/84
I've added "a fix" for it in
https://github.com/containernetworking/cni/pull/149 which then was
merged in https://github.com/containernetworking/cni/pull/177

The thing is that "the fix" was incorrect as it was setting 1 on
arp_proxy (I really don't recall why) instead of setting it on
arp_notify - which was my original suggestion in:
https://github.com/rkt/rkt/issues/1765#issuecomment-188776317
Setting apr_proxy can be harmfull and we have already support for
sending GratuitousArpOverIface after setting an IP address, so setting
any sysctl should not be needed.

Signed-off-by: Piotr Skamruk <piotr.skamruk@gmail.com>