### PR TITLE
portmap: use slashes in sysctl template to support interface names which separated by dots

### DIFF
--- a/plugins/meta/portmap/portmap.go
+++ b/plugins/meta/portmap/portmap.go
@@ -337,7 +337,7 @@ func genMarkMasqChain(markBit int) chain {
 // enableLocalnetRouting tells the kernel not to treat 127/8 as a martian,
 // so that connections with a source ip of 127/8 can cross a routing boundary.
 func enableLocalnetRouting(ifName string) error {
-	routeLocalnetPath := "net.ipv4.conf." + ifName + ".route_localnet"
+	routeLocalnetPath := "net/ipv4/conf/" + ifName + "/route_localnet"
 	_, err := sysctl.Sysctl(routeLocalnetPath, "1")
 	return err
 }


### PR DESCRIPTION
Scanned the whole project based on #585  and found this left behind.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>