### PR TITLE
Fix nil-pointer check

### DIFF
--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -143,6 +143,9 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 	if err := json.Unmarshal(bytes, &n); err != nil {
 		return nil, "", err
 	}
+	if n.IPAM == nil {
+		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
+	}
 
 	// load IP from CNI_ARGS
 	if envArgs != "" {
@@ -201,10 +204,6 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		for _, addr := range n.RuntimeConfig.IPs {
 			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
 		}
-	}
-
-	if n.IPAM == nil {
-		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
 	}
 
 	// Validate all ranges


### PR DESCRIPTION
I am writing my own ipam plugin for a little project I am working on and stumbled across this nil check that looked out of place.
Omitting the `"ipam"` key from the config, while still supplying args or `runtimeConfig` would resulting in a nil pointer panic.

Signed-off-by: Nico Schieder <nschieder@redhat.com>