### PR TITLE
gha: update actions/setup-go@v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2


### PR DESCRIPTION
The V2 offers: https://github.com/actions/setup-go#v2

- Adds GOBIN to the PATH
- Proxy Support
- stable input
- Bug Fixes (including issues around version matching and semver)
