### PR TITLE
bridge: update a URL in plugin README.md file

### DIFF
--- a/plugins/main/bridge/README.md
+++ b/plugins/main/bridge/README.md
@@ -1,5 +1,5 @@
 
 This document has moved to the [containernetworking/cni.dev](https://github.com/containernetworking/cni.dev) repo.
 
-You can find it online here: https://cni.dev/plugins/main/bridge/
+You can find it online here: https://www.cni.dev/plugins/current/main/bridge
 


### PR DESCRIPTION
The original URL shows "Page Not Found."