### PR TITLE
win-bridge/win-overlay: skip dsr if not supported

### DIFF
--- a/pkg/hns/netconf_windows.go
+++ b/pkg/hns/netconf_windows.go
@@ -73,6 +73,9 @@ func GetDefaultDestinationPrefix(ip *net.IP) string {
 }
 
 func (n *NetConf) ApplyLoopbackDSR(ip *net.IP) {
+	if err := hcn.DSRSupported(); err != nil {
+		return
+	}
 	value := fmt.Sprintf(`"Destinations" : ["%s"]`, ip.String())
 	if n.ApiVersion == 2 {
 		hcnLoopbackRoute := hcn.EndpointPolicy{


### PR DESCRIPTION
just skip the DSR configuration(`loopbackDSR: true`) if the host is not supported.