### PR TITLE
tuning: always update MAC in CNI result

### DIFF
--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -145,7 +145,7 @@ func changeMacAddr(ifName string, newMacAddr string) error {
 	return netlink.LinkSetHardwareAddr(link, addr)
 }
 
-func updateResultsMacAddr(config TuningConf, ifName string, newMacAddr string) {
+func updateResultsMacAddr(config *TuningConf, ifName string, newMacAddr string) {
 	// Parse previous result.
 	if config.PrevResult == nil {
 		return
@@ -159,6 +159,7 @@ func updateResultsMacAddr(config TuningConf, ifName string, newMacAddr string) {
 			i.Mac = newMacAddr
 		}
 	}
+	config.PrevResult = result
 }
 
 func changePromisc(ifName string, val bool) error {
@@ -327,7 +328,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				}
 			}
 
-			updateResultsMacAddr(*tuningConf, args.IfName, tuningConf.Mac)
+			updateResultsMacAddr(tuningConf, args.IfName, tuningConf.Mac)
 		}
 
 		if tuningConf.Promisc != false {

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -465,11 +465,12 @@ var _ = Describe("tuning plugin", func() {
 		})
 
 		It(fmt.Sprintf("[%s] configures and deconfigures mac address (from conf file) with ADD/DEL", ver), func() {
+			mac := "c2:11:22:33:44:55"
 			conf := []byte(fmt.Sprintf(`{
 				"name": "test",
 				"type": "iplink",
 				"cniVersion": "%s",
-				"mac": "c2:11:22:33:44:55",
+				"mac": "%s",
 				"prevResult": {
 					"interfaces": [
 						{"name": "dummy0", "sandbox":"netns"}
@@ -483,7 +484,7 @@ var _ = Describe("tuning plugin", func() {
 						}
 					]
 				}
-			}`, ver))
+			}`, ver, mac))
 
 			args := &skel.CmdArgs{
 				ContainerID: "dummy",
@@ -508,9 +509,10 @@ var _ = Describe("tuning plugin", func() {
 				Expect(len(result.IPs)).To(Equal(1))
 				Expect(result.IPs[0].Address.String()).To(Equal("10.0.0.2/24"))
 
+				Expect(result.Interfaces[0].Mac).To(Equal(mac))
 				link, err := netlink.LinkByName(IFNAME)
 				Expect(err).NotTo(HaveOccurred())
-				hw, err := net.ParseMAC("c2:11:22:33:44:55")
+				hw, err := net.ParseMAC(mac)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(link.Attrs().HardwareAddr).To(Equal(hw))
 


### PR DESCRIPTION
Since the CNI Spec bump to v1.0 the tuning plugin no longer updates the
mac address in the cni result for 0.4.0 or below configs. I don't think
this ever worked when the cni result was converted to a different version.

A test has been added to ensure it is working for all spec versions.

Fixes #605 