### PR TITLE
bridge: Add mac field to specify container iface mac

### DIFF
--- a/pkg/ip/link_linux_test.go
+++ b/pkg/ip/link_linux_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Link", func() {
 		_ = containerNetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			hostVeth, containerVeth, err = ip.SetupVeth(fmt.Sprintf(ifaceFormatString, ifaceCounter), mtu, hostNetNS)
+			hostVeth, containerVeth, err = ip.SetupVeth(fmt.Sprintf(ifaceFormatString, ifaceCounter), mtu, "", hostNetNS)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ var _ = Describe("Link", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, _, err := ip.SetupVeth(containerVethName, mtu, hostNetNS)
+				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
 				Expect(err.Error()).To(Equal(fmt.Sprintf("container veth name provided (%s) already exists", containerVethName)))
 
 				return nil
@@ -189,7 +189,7 @@ var _ = Describe("Link", func() {
 		It("returns useful error", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
-				_, _, err := ip.SetupVeth(containerVethName, mtu, hostNetNS)
+				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
 				Expect(err.Error()).To(HavePrefix("failed to move veth to host netns: "))
 
 				return nil
@@ -207,7 +207,7 @@ var _ = Describe("Link", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, hostNetNS)
+				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
 				Expect(err).NotTo(HaveOccurred())
 				hostVethName = hostVeth.Name
 				return nil
@@ -233,6 +233,32 @@ var _ = Describe("Link", func() {
 			})
 		})
 
+		It("successfully creates a veth pair with an explicit mac", func() {
+			const mac = "02:00:00:00:01:23"
+			_ = containerNetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, mac, hostNetNS)
+				Expect(err).NotTo(HaveOccurred())
+				hostVethName = hostVeth.Name
+
+				link, err := netlink.LinkByName(containerVethName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(link.Attrs().HardwareAddr.String()).To(Equal(mac))
+
+				return nil
+			})
+
+			_ = hostNetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(hostVethName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(link.Attrs().HardwareAddr.String()).NotTo(Equal(mac))
+
+				return nil
+			})
+		})
 	})
 
 	It("DelLinkByName must delete the veth endpoints", func() {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -55,6 +55,25 @@ type NetConf struct {
 	HairpinMode  bool   `json:"hairpinMode"`
 	PromiscMode  bool   `json:"promiscMode"`
 	Vlan         int    `json:"vlan"`
+
+	Args struct {
+		Cni BridgeArgs `json:"cni,omitempty"`
+	} `json:"args,omitempty"`
+	RuntimeConfig struct {
+		Mac string `json:"mac,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
+
+	mac string
+}
+
+type BridgeArgs struct {
+	Mac string `json:"mac,omitempty"`
+}
+
+// MacEnvArgs represents CNI_ARGS
+type MacEnvArgs struct {
+	types.CommonArgs
+	MAC types.UnmarshallableString `json:"mac,omitempty"`
 }
 
 type gwInfo struct {
@@ -70,7 +89,7 @@ func init() {
 	runtime.LockOSThread()
 }
 
-func loadNetConf(bytes []byte) (*NetConf, string, error) {
+func loadNetConf(bytes []byte, envArgs string) (*NetConf, string, error) {
 	n := &NetConf{
 		BrName: defaultBrName,
 	}
@@ -80,6 +99,26 @@ func loadNetConf(bytes []byte) (*NetConf, string, error) {
 	if n.Vlan < 0 || n.Vlan > 4094 {
 		return nil, "", fmt.Errorf("invalid VLAN ID %d (must be between 0 and 4094)", n.Vlan)
 	}
+
+	if envArgs != "" {
+		e := MacEnvArgs{}
+		if err := types.LoadArgs(envArgs, &e); err != nil {
+			return nil, "", err
+		}
+
+		if e.MAC != "" {
+			n.mac = string(e.MAC)
+		}
+	}
+
+	if mac := n.Args.Cni.Mac; mac != "" {
+		n.mac = mac
+	}
+
+	if mac := n.RuntimeConfig.Mac; mac != "" {
+		n.mac = mac
+	}
+
 	return n, n.CNIVersion, nil
 }
 
@@ -273,7 +312,7 @@ func ensureVlanInterface(br *netlink.Bridge, vlanId int) (netlink.Link, error) {
 			return nil, fmt.Errorf("faild to find host namespace: %v", err)
 		}
 
-		_, brGatewayIface, err := setupVeth(hostNS, br, name, br.MTU, false, vlanId)
+		_, brGatewayIface, err := setupVeth(hostNS, br, name, br.MTU, false, vlanId, "")
 		if err != nil {
 			return nil, fmt.Errorf("faild to create vlan gateway %q: %v", name, err)
 		}
@@ -287,13 +326,13 @@ func ensureVlanInterface(br *netlink.Bridge, vlanId int) (netlink.Link, error) {
 	return brGatewayVeth, nil
 }
 
-func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool, vlanID int) (*current.Interface, *current.Interface, error) {
+func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool, vlanID int, mac string) (*current.Interface, *current.Interface, error) {
 	contIface := &current.Interface{}
 	hostIface := &current.Interface{}
 
 	err := netns.Do(func(hostNS ns.NetNS) error {
 		// create the veth pair in the container and move host end into host netns
-		hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, hostNS)
+		hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, mac, hostNS)
 		if err != nil {
 			return err
 		}
@@ -380,7 +419,7 @@ func enableIPForward(family int) error {
 func cmdAdd(args *skel.CmdArgs) error {
 	var success bool = false
 
-	n, cniVersion, err := loadNetConf(args.StdinData)
+	n, cniVersion, err := loadNetConf(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}
@@ -406,7 +445,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode, n.Vlan)
+	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode, n.Vlan, n.mac)
 	if err != nil {
 		return err
 	}
@@ -585,7 +624,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	n, _, err := loadNetConf(args.StdinData)
+	n, _, err := loadNetConf(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}
@@ -776,7 +815,7 @@ func validateCniContainerInterface(intf current.Interface) (cniBridgeIf, error) 
 
 func cmdCheck(args *skel.CmdArgs) error {
 
-	n, _, err := loadNetConf(args.StdinData)
+	n, _, err := loadNetConf(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -66,7 +66,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 	containerInterface := &current.Interface{}
 
 	err := netns.Do(func(hostNS ns.NetNS) error {
-		hostVeth, contVeth0, err := ip.SetupVeth(ifName, mtu, hostNS)
+		hostVeth, contVeth0, err := ip.SetupVeth(ifName, mtu, "", hostNS)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


Controlling the mac address of the interface (veth peer) in the
container is useful for functionalities that depend on the mac address.
Examples range from dynamic IP allocations based on an identifier (the
mac) and up to firewall rules (e.g. no-mac-spoofing).

Enforcing a mac address at an early stage and not through a chained
plugin assures the configuration does not have wrong intermediate
configuration. This is especially critical when a dynamic IP may be
provided already in this period.
But it also has implications for future abilities that may land on the
bridge plugin, e.g. supporting no-mac-spoofing.

The field name used (`mac`) fits with other plugins which control the
mac address of the container interface.

The mac address may be specified through the following methods:
- CNI_ARGS
- Args
- RuntimeConfig [1]

The list is ordered by priority, from lowest to higher. The higher
priority method overrides any previous settings.
(e.g. if the mac is specified in RuntimeConfig, it will override any
specifications of the mac mentioned in CNI_ARGS or Args)

[1] To use RuntimeConfig, the network configuration should include the
`capabilities` field with `mac` specified (`"capabilities": {"mac": true}`).