### PR TITLE
Fix confusing error msg invalid cidr

### DIFF
--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -193,6 +193,10 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		// args IP overwrites IP, so clear IPAM Config
 		n.IPAM.Addresses = make([]Address, 0, len(n.Args.A.IPs))
 		for _, addr := range n.Args.A.IPs {
+			_, _, err := net.ParseCIDR(addr)
+			if err != nil {
+				return nil, "", fmt.Errorf("an entry in the 'ips' field is NOT in CIDR notation, got: '%s'", addr)
+			}
 			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
 		}
 	}
@@ -202,6 +206,10 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 		// runtimeConfig IP overwrites IP, so clear IPAM Config
 		n.IPAM.Addresses = make([]Address, 0, len(n.RuntimeConfig.IPs))
 		for _, addr := range n.RuntimeConfig.IPs {
+			_, _, err := net.ParseCIDR(addr)
+			if err != nil {
+				return nil, "", fmt.Errorf("an entry in the 'ips' field is NOT in CIDR notation, got: '%s'", addr)
+			}
 			n.IPAM.Addresses = append(n.IPAM.Addresses, Address{AddressStr: addr})
 		}
 	}

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -161,7 +161,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 
 				ip, subnet, err := net.ParseCIDR(ipstr)
 				if err != nil {
-					return nil, "", err
+					return nil, "", fmt.Errorf("the 'ip' field is expected to be in CIDR notation, got: '%s'", ipstr)
 				}
 
 				addr := Address{
@@ -213,7 +213,8 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 	for i := range n.IPAM.Addresses {
 		ip, addr, err := net.ParseCIDR(n.IPAM.Addresses[i].AddressStr)
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf(
+				"the 'address' field is expected to be in CIDR notation, got: '%s'", n.IPAM.Addresses[i].AddressStr)
 		}
 		n.IPAM.Addresses[i].Address = *addr
 		n.IPAM.Addresses[i].Address.IP = ip

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -161,7 +161,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 
 				ip, subnet, err := net.ParseCIDR(ipstr)
 				if err != nil {
-					return nil, "", fmt.Errorf("invalid CIDR %s: %s", ipstr, err)
+					return nil, "", err
 				}
 
 				addr := Address{
@@ -213,7 +213,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 	for i := range n.IPAM.Addresses {
 		ip, addr, err := net.ParseCIDR(n.IPAM.Addresses[i].AddressStr)
 		if err != nil {
-			return nil, "", fmt.Errorf("invalid CIDR %s: %s", n.IPAM.Addresses[i].AddressStr, err)
+			return nil, "", err
 		}
 		n.IPAM.Addresses[i].Address = *addr
 		n.IPAM.Addresses[i].Address.IP = ip

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -575,8 +575,8 @@ var _ = Describe("static Operations", func() {
 			_, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)
 			})
-			Expect(err).Should(
-				MatchError(fmt.Sprintf("invalid CIDR address: %s", ipStr)))
+			Expect(err).Should(MatchError(
+				fmt.Sprintf("the 'address' field is expected to be in CIDR notation, got: '%s'", ipStr)))
 		})
 	}
 })

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -576,7 +576,7 @@ var _ = Describe("static Operations", func() {
 				return cmdAdd(args)
 			})
 			Expect(err).Should(
-				MatchError(fmt.Sprintf("invalid CIDR %s: invalid CIDR address: %s", ipStr, ipStr)))
+				MatchError(fmt.Sprintf("invalid CIDR address: %s", ipStr)))
 		})
 	}
 })

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -547,7 +547,7 @@ var _ = Describe("static Operations", func() {
 			Expect(err).Should(MatchError("IPAM config missing 'ipam' key"))
 		})
 
-		It(fmt.Sprintf("[%s] errors when passed an invalid CIDR", ver), func() {
+		It(fmt.Sprintf("[%s] errors when passed an invalid CIDR via ipam config", ver), func() {
 			const ifname string = "eth0"
 			const nspath string = "/some/where"
 			const ipStr string = "10.10.0.1"
@@ -577,6 +577,105 @@ var _ = Describe("static Operations", func() {
 			})
 			Expect(err).Should(MatchError(
 				fmt.Sprintf("the 'address' field is expected to be in CIDR notation, got: '%s'", ipStr)))
+		})
+
+		It(fmt.Sprintf("[%s] errors when passed an invalid CIDR via Args", ver), func() {
+			const ifname string = "eth0"
+			const nspath string = "/some/where"
+			const ipStr string = "10.10.0.1"
+
+			conf := fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"name": "mynet",
+				"type": "bridge",
+				"ipam": {
+					"type": "static",
+					"routes": [{ "dst": "0.0.0.0/0" }]
+				}
+			}`, ver)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       nspath,
+				IfName:      ifname,
+				StdinData:   []byte(conf),
+				Args:        fmt.Sprintf("IP=%s", ipStr),
+			}
+
+			// Allocate the IP
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).Should(MatchError(
+				fmt.Sprintf("the 'ip' field is expected to be in CIDR notation, got: '%s'", ipStr)))
+		})
+
+		It(fmt.Sprintf("[%s] errors when passed an invalid CIDR via CNI_ARGS", ver), func() {
+			const ifname string = "eth0"
+			const nspath string = "/some/where"
+			const ipStr string = "10.10.0.1"
+
+			conf := fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"name": "mynet",
+				"type": "bridge",
+				"ipam": {
+					"type": "static",
+					"routes": [{ "dst": "0.0.0.0/0" }]
+				},
+				"args": {
+					"cni": {
+						"ips" : ["%s"]
+					}
+				}
+			}`, ver, ipStr)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       nspath,
+				IfName:      ifname,
+				StdinData:   []byte(conf),
+			}
+
+			// Allocate the IP
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).Should(MatchError(
+				fmt.Sprintf("an entry in the 'ips' field is NOT in CIDR notation, got: '%s'", ipStr)))
+		})
+
+		It(fmt.Sprintf("[%s] errors when passed an invalid CIDR via RuntimeConfig", ver), func() {
+			const ifname string = "eth0"
+			const nspath string = "/some/where"
+			const ipStr string = "10.10.0.1"
+
+			conf := fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"name": "mynet",
+				"type": "bridge",
+				"ipam": {
+					"type": "static",
+					"routes": [{ "dst": "0.0.0.0/0" }]
+				},
+				"RuntimeConfig": {
+					"ips" : ["%s"]
+				}
+			}`, ver, ipStr)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       nspath,
+				IfName:      ifname,
+				StdinData:   []byte(conf),
+			}
+
+			// Allocate the IP
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).Should(MatchError(
+				fmt.Sprintf("an entry in the 'ips' field is NOT in CIDR notation, got: '%s'", ipStr)))
 		})
 	}
 })


### PR DESCRIPTION
By wrapping the error msg we ended up actually duplicating the exact same msg `net.ParseCIDR` replies, as seen in its implementation - [0] & [1]

This PR makes the error msg less confusing.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1897431

[0] - https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/net.go#L540
[1] - https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/ip.go#L739
