### PR TITLE
Update the CI badge from Travis CI to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/containernetworking/plugins.svg?branch=master)](https://travis-ci.org/containernetworking/plugins)
+[![test](https://github.com/containernetworking/plugins/actions/workflows/test.yaml/badge.svg)](https://github.com/containernetworking/plugins/actions/workflows/test.yaml?query=branch%3Amaster)
 
 # Plugins
 Some CNI network plugins, maintained by the containernetworking team. For more information, see the [CNI website](https://www.cni.dev).


### PR DESCRIPTION
Better to update the CI badge on README as #555 replaced CI infra from Travis CI to GitHub Actions.
 
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>