### PR TITLE
Fix `"config is \"1.0.0\", plugin supports [\"0.4.0\"]"`

### DIFF
--- a/plugins/main/windows/win-bridge/win-bridge_windows.go
+++ b/plugins/main/windows/win-bridge/win-bridge_windows.go
@@ -215,5 +215,5 @@ func cmdCheck(_ *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), bv.BuildString("win-bridge"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("win-bridge"))
 }

--- a/plugins/main/windows/win-overlay/win-overlay_windows.go
+++ b/plugins/main/windows/win-overlay/win-overlay_windows.go
@@ -173,5 +173,5 @@ func cmdCheck(_ *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.1.0", "0.2.0", "0.3.0"), bv.BuildString("win-overlay"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("win-overlay"))
 }

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -246,7 +246,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.3.0", "0.3.1", version.Current()), bv.BuildString("bandwidth"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("bandwidth"))
 }
 
 func SafeQdiscList(link netlink.Link) ([]netlink.Qdisc, error) {

--- a/plugins/meta/firewall/firewall.go
+++ b/plugins/meta/firewall/firewall.go
@@ -157,7 +157,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.4.0"), bv.BuildString("firewall"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("firewall"))
 }
 
 func cmdCheck(args *skel.CmdArgs) error {

--- a/plugins/meta/vrf/main.go
+++ b/plugins/meta/vrf/main.go
@@ -40,7 +40,7 @@ type VRFNetConf struct {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports("0.3.1", "0.4.0"), bv.BuildString("vrf"))
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("vrf"))
 }
 
 func cmdAdd(args *skel.CmdArgs) error {


### PR DESCRIPTION
Some plugins could not be executed with `cniVersion: "1.0.0"` JSON because `version.Current()` was not included in `version.PluginSupports()` checks.

