### PR TITLE
Use crypto/rand.Read, not crypto.Reader.Read

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -107,7 +107,7 @@ func makeVeth(name, vethPeerName string, mtu int, mac string, hostNS ns.NetNS) (
 // RandomVethName returns string "veth" with random prefix (hashed from entropy)
 func RandomVethName() (string, error) {
 	entropy := make([]byte, 4)
-	_, err := rand.Reader.Read(entropy)
+	_, err := rand.Read(entropy)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate random veth name: %v", err)
 	}

--- a/pkg/testutils/netns_linux.go
+++ b/pkg/testutils/netns_linux.go
@@ -53,7 +53,7 @@ func NewNS() (ns.NetNS, error) {
 	nsRunDir := getNsRunDir()
 
 	b := make([]byte, 16)
-	_, err := rand.Reader.Read(b)
+	_, err := rand.Read(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate random netns name: %v", err)
 	}


### PR DESCRIPTION
The current code accidentally ignores partial reads, since it doesn't
check the return value of (io.Reader).Read.

What we actually want is io.ReadFull(rand.Reader, buf), which is
conveniently provided by rand.Read(buf).