### PR TITLE
Don't redundantly filepath.Clean the output of filepath.Join

### DIFF
--- a/pkg/utils/sysctl/sysctl_linux.go
+++ b/pkg/utils/sysctl/sysctl_linux.go
@@ -36,7 +36,6 @@ func Sysctl(name string, params ...string) (string, error) {
 
 func getSysctl(name string) (string, error) {
 	fullName := filepath.Join("/proc/sys", toNormalName(name))
-	fullName = filepath.Clean(fullName)
 	data, err := ioutil.ReadFile(fullName)
 	if err != nil {
 		return "", err
@@ -47,7 +46,6 @@ func getSysctl(name string) (string, error) {
 
 func setSysctl(name, value string) (string, error) {
 	fullName := filepath.Join("/proc/sys", toNormalName(name))
-	fullName = filepath.Clean(fullName)
 	if err := ioutil.WriteFile(fullName, []byte(value), 0644); err != nil {
 		return "", err
 	}

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -326,7 +326,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		for key, value := range tuningConf.SysCtl {
 			fileName := filepath.Join("/proc/sys", strings.Replace(key, ".", "/", -1))
-			fileName = filepath.Clean(fileName)
 
 			// Refuse to modify sysctl parameters that don't belong
 			// to the network subsystem.
@@ -428,7 +427,6 @@ func cmdCheck(args *skel.CmdArgs) error {
 		// Check each configured value vs what's currently in the container
 		for key, confValue := range tuningConf.SysCtl {
 			fileName := filepath.Join("/proc/sys", strings.Replace(key, ".", "/", -1))
-			fileName = filepath.Clean(fileName)
 
 			contents, err := ioutil.ReadFile(fileName)
 			if err != nil {


### PR DESCRIPTION
filepath.Join is already specified to clean its output,
and the implementation indeed does so.