### PR TITLE
dhcp ipam: support customizing dhcp options from CNI args

### DIFF
--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -71,9 +71,16 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 		return fmt.Errorf("error parsing netconf: %v", err)
 	}
 
+	optsRequesting, optsProviding, err := prepareOptions(args.Args, conf.IPAM.ProvideOptions, conf.IPAM.RequireOptions)
+	if err != nil {
+		return err
+	}
+
 	clientID := generateClientID(args.ContainerID, conf.Name, args.IfName)
 	hostNetns := d.hostNetnsPrefix + args.Netns
-	l, err := AcquireLease(clientID, hostNetns, args.IfName, d.clientTimeout, d.clientResendMax, d.broadcast)
+	l, err := AcquireLease(clientID, hostNetns, args.IfName,
+		optsRequesting, optsProviding,
+		d.clientTimeout, d.clientResendMax, d.broadcast)
 	if err != nil {
 		return err
 	}

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/coreos/go-systemd/v22/activation"
 )
@@ -62,7 +61,7 @@ func generateClientID(containerID string, netName string, ifName string) string 
 // Allocate acquires an IP from a DHCP server for a specified container.
 // The acquired lease will be maintained until Release() is called.
 func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
-	conf := types.NetConf{}
+	conf := NetConf{}
 	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
 		return fmt.Errorf("error parsing netconf: %v", err)
 	}
@@ -94,7 +93,7 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 // Release stops maintenance of the lease acquired in Allocate()
 // and sends a release msg to the DHCP server.
 func (d *DHCP) Release(args *skel.CmdArgs, reply *struct{}) error {
-	conf := types.NetConf{}
+	conf := NetConf{}
 	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
 		return fmt.Errorf("error parsing netconf: %v", err)
 	}

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -71,7 +71,7 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 		return fmt.Errorf("error parsing netconf: %v", err)
 	}
 
-	optsRequesting, optsProviding, err := prepareOptions(args.Args, conf.IPAM.ProvideOptions, conf.IPAM.RequireOptions)
+	optsRequesting, optsProviding, err := prepareOptions(args.Args, conf.IPAM.ProvideOptions, conf.IPAM.RequestOptions)
 	if err != nil {
 		return err
 	}

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -218,6 +218,10 @@ func (l *DHCPLease) acquire() error {
 	for k, v := range l.optsProviding {
 		opts[k] = v
 	}
+	// client identifier's first byte is "type"
+	newClientID := []byte{0}
+	newClientID = append(newClientID, opts[dhcp4.OptionClientIdentifier]...)
+	opts[dhcp4.OptionClientIdentifier] = newClientID
 
 	pkt, err := backoffRetry(l.resendMax, func() (*dhcp4.Packet, error) {
 		ok, ack, err := DhcpRequest(c, opts)

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -68,12 +68,12 @@ type DHCPLease struct {
 	optsProviding  map[dhcp4.OptionCode][]byte
 }
 
-var acquireOptionsDefault = map[dhcp4.OptionCode]bool{
+var requestOptionsDefault = map[dhcp4.OptionCode]bool{
 	dhcp4.OptionRouter:     true,
 	dhcp4.OptionSubnetMask: true,
 }
 
-func prepareOptions(cniArgs string, ProvideOptions []ProvideOption, RequireOptions []RequireOption) (
+func prepareOptions(cniArgs string, ProvideOptions []ProvideOption, RequestOptions []RequestOption) (
 	optsRequesting map[dhcp4.OptionCode]bool, optsProviding map[dhcp4.OptionCode][]byte, err error) {
 
 	// parse CNI args
@@ -113,7 +113,7 @@ func prepareOptions(cniArgs string, ProvideOptions []ProvideOption, RequireOptio
 	// parse necessary options map
 	optsRequesting = make(map[dhcp4.OptionCode]bool)
 	skipRequireDefault := false
-	for _, opt := range RequireOptions {
+	for _, opt := range RequestOptions {
 		if opt.SkipDefault {
 			skipRequireDefault = true
 		}
@@ -124,7 +124,7 @@ func prepareOptions(cniArgs string, ProvideOptions []ProvideOption, RequireOptio
 		}
 		optsRequesting[optParsed] = true
 	}
-	for k, v := range acquireOptionsDefault {
+	for k, v := range requestOptionsDefault {
 		// only set if not skipping default and this value does not exists
 		if _, ok := optsRequesting[k]; !ok && !skipRequireDefault {
 			optsRequesting[k] = v

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -423,6 +423,7 @@ func jitter(span time.Duration) time.Duration {
 func backoffRetry(resendMax time.Duration, f func() (*dhcp4.Packet, error)) (*dhcp4.Packet, error) {
 	var baseDelay time.Duration = resendDelay0
 	var sleepTime time.Duration
+	var fastRetryLimit = 3 // fast retry for 3 times to speed up
 
 	for {
 		pkt, err := f()
@@ -432,7 +433,12 @@ func backoffRetry(resendMax time.Duration, f func() (*dhcp4.Packet, error)) (*dh
 
 		log.Print(err)
 
-		sleepTime = baseDelay + jitter(time.Second)
+		if fastRetryLimit == 0 {
+			sleepTime = baseDelay + jitter(time.Second)
+		} else {
+			sleepTime = jitter(time.Second)
+			fastRetryLimit--
+		}
 
 		log.Printf("retrying in %f seconds", sleepTime.Seconds())
 

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -67,7 +67,7 @@ func main() {
 		}
 
 		if err := runDaemon(pidfilePath, hostPrefix, socketPath, timeout, resendMax, broadcast); err != nil {
-			log.Printf(err.Error())
+			log.Print(err.Error())
 			os.Exit(1)
 		}
 	} else {

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -88,8 +88,6 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func cmdCheck(args *skel.CmdArgs) error {
-	// TODO: implement
-	//return fmt.Errorf("not implemented")
 	// Plugin must return result in same version as specified in netconf
 	versionDecoder := &version.ConfigDecoder{}
 	//confVersion, err := versionDecoder.Decode(args.StdinData)

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -48,9 +48,9 @@ type IPAMConfig struct {
 	ProvideOptions []ProvideOption `json:"provide"`
 	// When requesting IP from DHCP server, claiming these options are necessary. Options are necessary unless `optional`
 	// is set to `false`.
-	// To override default required fields, set `skipDefault` to `false`.
+	// To override default requesting fields, set `skipDefault` to `false`.
 	// If an field is not optional, but the server failed to provide it, error will be raised.
-	RequireOptions []RequireOption `json:"require"`
+	RequestOptions []RequestOption `json:"request"`
 }
 
 // DHCPOption represents a DHCP option. It can be a number, or a string defined in manual dhcp-options(5).
@@ -64,7 +64,7 @@ type ProvideOption struct {
 	ValueFromCNIArg string `json:"fromArg"`
 }
 
-type RequireOption struct {
+type RequestOption struct {
 	SkipDefault bool `json:"skipDefault"`
 
 	Option DHCPOption `json:"option"`

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -33,6 +33,18 @@ import (
 
 const defaultSocketPath = "/run/cni/dhcp.sock"
 
+// The top-level network config - IPAM plugins are passed the full configuration
+// of the calling plugin, not just the IPAM section.
+type NetConf struct {
+	types.NetConf
+	IPAM *IPAMConfig `json:"ipam"`
+}
+
+type IPAMConfig struct {
+	types.IPAM
+	DaemonSocketPath string `json:"daemonSocketPath,omitempty"`
+}
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "daemon" {
 		var pidfilePath string
@@ -104,16 +116,8 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-type SocketPathConf struct {
-	DaemonSocketPath string `json:"daemonSocketPath,omitempty"`
-}
-
-type TempNetConf struct {
-	IPAM SocketPathConf `json:"ipam,omitempty"`
-}
-
 func getSocketPath(stdinData []byte) (string, error) {
-	conf := TempNetConf{}
+	conf := NetConf{}
 	if err := json.Unmarshal(stdinData, &conf); err != nil {
 		return "", fmt.Errorf("error parsing socket path conf: %v", err)
 	}

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -42,7 +42,32 @@ type NetConf struct {
 
 type IPAMConfig struct {
 	types.IPAM
-	DaemonSocketPath string `json:"daemonSocketPath,omitempty"`
+	DaemonSocketPath string `json:"daemonSocketPath"`
+	// When requesting IP from DHCP server, carry these options for management purpose.
+	// Some fields have default values, and can be override by setting a new option with the same name at here.
+	ProvideOptions []ProvideOption `json:"provide"`
+	// When requesting IP from DHCP server, claiming these options are necessary. Options are necessary unless `optional`
+	// is set to `false`.
+	// To override default required fields, set `skipDefault` to `false`.
+	// If an field is not optional, but the server failed to provide it, error will be raised.
+	RequireOptions []RequireOption `json:"require"`
+}
+
+// DHCPOption represents a DHCP option. It can be a number, or a string defined in manual dhcp-options(5).
+// Note that not all DHCP options are supported at all time. Error will be raised if unsupported options are used.
+type DHCPOption string
+
+type ProvideOption struct {
+	Option DHCPOption `json:"option"`
+
+	Value           string `json:"value"`
+	ValueFromCNIArg string `json:"fromArg"`
+}
+
+type RequireOption struct {
+	SkipDefault bool `json:"skipDefault"`
+
+	Option DHCPOption `json:"option"`
 }
 
 func main() {

--- a/plugins/ipam/dhcp/options.go
+++ b/plugins/ipam/dhcp/options.go
@@ -26,10 +26,12 @@ import (
 )
 
 var optionNameToID = map[string]dhcp4.OptionCode{
-	"dhcp-client-identifier": dhcp4.OptionClientIdentifier,
-	"subnet-mask":            dhcp4.OptionSubnetMask,
-	"routers":                dhcp4.OptionRouter,
-	"host-name":              dhcp4.OptionHostName,
+	"dhcp-client-identifier":  dhcp4.OptionClientIdentifier,
+	"subnet-mask":             dhcp4.OptionSubnetMask,
+	"routers":                 dhcp4.OptionRouter,
+	"host-name":               dhcp4.OptionHostName,
+	"user-class":              dhcp4.OptionUserClass,
+	"vendor-class-identifier": dhcp4.OptionVendorClassIdentifier,
 }
 
 func parseOptionName(option string) (dhcp4.OptionCode, error) {

--- a/plugins/ipam/dhcp/options.go
+++ b/plugins/ipam/dhcp/options.go
@@ -18,11 +18,30 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/d2g/dhcp4"
 )
+
+var optionNameToID = map[string]dhcp4.OptionCode{
+	"dhcp-client-identifier": dhcp4.OptionClientIdentifier,
+	"subnet-mask":            dhcp4.OptionSubnetMask,
+	"routers":                dhcp4.OptionRouter,
+	"host-name":              dhcp4.OptionHostName,
+}
+
+func parseOptionName(option string) (dhcp4.OptionCode, error) {
+	if val, ok := optionNameToID[option]; ok {
+		return val, nil
+	}
+	i, err := strconv.ParseUint(option, 10, 8)
+	if err != nil {
+		return 0, fmt.Errorf("Can not parse option: %w", err)
+	}
+	return dhcp4.OptionCode(i), nil
+}
 
 func parseRouter(opts dhcp4.Options) net.IP {
 	if opts, ok := opts[dhcp4.OptionRouter]; ok {

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/types"
@@ -72,4 +73,35 @@ func TestParseCIDRRoutes(t *testing.T) {
 	routes := parseCIDRRoutes(opts)
 
 	validateRoutes(t, routes)
+}
+
+func TestParseOptionName(t *testing.T) {
+	tests := []struct {
+		name    string
+		option  string
+		want    dhcp4.OptionCode
+		wantErr bool
+	}{
+		{
+			"hostname", "host-name", dhcp4.OptionHostName, false,
+		},
+		{
+			"hostname in number", "12", dhcp4.OptionHostName, false,
+		},
+		{
+			"random string", "doNotparseMe", 0, true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOptionName(tt.option)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOptionName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseOptionName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Make some DHCP options sent to the server can be set from parsing CNI_ARGS.

This closes #435 and #660.