### PR TITLE
Fixed DHCP problem that broke when fast retry was added.

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -455,7 +455,7 @@ func backoffRetry(resendMax time.Duration, f func() (*dhcp4.Packet, error)) (*dh
 		// only adjust delay time if we are in normal backoff stage
 		if baseDelay < resendMax && fastRetryLimit == 0 {
 			baseDelay *= 2
-		} else if fastRetryLimit == 0 {  // only break if we are at normal delay
+		} else if fastRetryLimit == 0 { // only break if we are at normal delay
 			break
 		}
 	}

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -455,7 +455,7 @@ func backoffRetry(resendMax time.Duration, f func() (*dhcp4.Packet, error)) (*dh
 		// only adjust delay time if we are in normal backoff stage
 		if baseDelay < resendMax && fastRetryLimit == 0 {
 			baseDelay *= 2
-		} else {
+		} else if fastRetryLimit == 0 {  // only break if we are at normal delay
 			break
 		}
 	}


### PR DESCRIPTION
DHCP daemon could not get a lease when a retry was needed.  fastRetry caused backoffRetry to exit and not retry.  This change holds off the break from the retry loop until after it is back in normal delay.  This lets a retry happen and leases can be acquired.