### PR TITLE
Allow user to optionally disable IPV6 duplicate address detection via runtime configuration for bridge plugin 

### DIFF
--- a/pkg/ip/link_linux_test.go
+++ b/pkg/ip/link_linux_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Link", func() {
 		_ = containerNetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			hostVeth, containerVeth, err = ip.SetupVeth(fmt.Sprintf(ifaceFormatString, ifaceCounter), mtu, "", hostNetNS)
+			hostVeth, containerVeth, err = ip.SetupVeth(fmt.Sprintf(ifaceFormatString, ifaceCounter), mtu, "", hostNetNS, false)
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ var _ = Describe("Link", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
+				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS, false)
 				Expect(err.Error()).To(Equal(fmt.Sprintf("container veth name provided (%s) already exists", containerVethName)))
 
 				return nil
@@ -187,7 +187,7 @@ var _ = Describe("Link", func() {
 		It("returns useful error", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
-				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
+				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS, false)
 				Expect(err.Error()).To(HavePrefix("container veth name provided"))
 				Expect(err.Error()).To(HaveSuffix("already exists"))
 				return nil
@@ -205,7 +205,7 @@ var _ = Describe("Link", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
+				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS, false)
 				Expect(err).NotTo(HaveOccurred())
 				hostVethName = hostVeth.Name
 				return nil
@@ -236,7 +236,7 @@ var _ = Describe("Link", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, mac, hostNetNS)
+				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, mac, hostNetNS, false)
 				Expect(err).NotTo(HaveOccurred())
 				hostVethName = hostVeth.Name
 

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -66,7 +66,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 	containerInterface := &current.Interface{}
 
 	err := netns.Do(func(hostNS ns.NetNS) error {
-		hostVeth, contVeth0, err := ip.SetupVeth(ifName, mtu, "", hostNS)
+		hostVeth, contVeth0, err := ip.SetupVeth(ifName, mtu, "", hostNS, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hello, this PR is for #680 and more documentation exists around the motivation for this PR. An effort is underway to speed up pod creation time and the SettleAddresses method was the culprit and more specifically it was the duplicate address detection feature of IPV6. This PR allows the accept_dad setting to be set to "0" as a runtime configuration which disables that and allows the bridge setup to take less than 100 ms vs 1800-2200ms. Follow-on PR's will be submitted to go-cni,containerd and k8s as well. Look forward to hearing from you!

`{
   "cniVersion":"0.4.0",
   "name":"containerd-net",
   "plugins":[
      {
         "type":"bridge",
         "bridge":"cni0",
         "isGateway":true,
         "ipMasq":true,
         "promiscMode":true,
         "runtimeConfig":{
            "omitdad":true
         },
         "ipam":{
            "type":"host-local",
            "ranges":[
               [
                  {
                     "subnet":"10.88.0.0/16"
                  }
               ],
               [
                  {
                     "subnet":"2001:4860:4860::/64"
                  }
               ]
            ],
            "routes":[
               {
                  "dst":"0.0.0.0/0"
               },
               {
                  "dst":"::/0"
               }
            ]
         }
      },
      {
         "type":"portmap",
         "capabilities":{
            "portMappings":true
         }
      }
   ]
}`

`{
   "cniVersion":"0.4.0",
   "name":"containerd-net",
   "plugins":[
      {
         "type":"bridge",
         "bridge":"cni0",
         "isGateway":true,
         "ipMasq":true,
         "promiscMode":true,
         "omitdad":true,
         "ipam":{
            "type":"host-local",
            "ranges":[
               [
                  {
                     "subnet":"10.88.0.0/16"
                  }
               ],
               [
                  {
                     "subnet":"2001:4860:4860::/64"
                  }
               ]
            ],
            "routes":[
               {
                  "dst":"0.0.0.0/0"
               },
               {
                  "dst":"::/0"
               }
            ]
         }
      },
      {
         "type":"portmap",
         "capabilities":{
            "portMappings":true
         }
      }
   ]
}`

Related PR for Documentation: https://github.com/containernetworking/cni.dev/pull/95 Can submit another PR to update the documentation for the runtime configurations when implemented into containerd/k8s