### PR TITLE
pkg/ns: use file system magic numbers from golang.org/x/sys/unix

### DIFF
--- a/pkg/ns/ns_linux.go
+++ b/pkg/ns/ns_linux.go
@@ -106,8 +106,8 @@ var _ NetNS = &netNS{}
 
 const (
 	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
-	NSFS_MAGIC   = 0x6e736673
-	PROCFS_MAGIC = 0x9fa0
+	NSFS_MAGIC   = unix.NSFS_MAGIC
+	PROCFS_MAGIC = unix.PROC_SUPER_MAGIC
 )
 
 type NSPathNotExistErr struct{ msg string }


### PR DESCRIPTION
Use the constants already defined in the golang.org/x/sys/unix package
instead of open-coding them.