### PR TITLE
Added new option for preventing dhcp plugin to update ip table

### DIFF
--- a/plugins/ipam/dhcp/README.md
+++ b/plugins/ipam/dhcp/README.md
@@ -2,3 +2,34 @@
 This document has moved to the [containernetworking/cni.dev](https://github.com/containernetworking/cni.dev) repo.
 
 You can find it online here: https://cni.dev/plugins/current/ipam/dhcp/
+
+# Dev
+`sudo rm -f /run/cni/dhcp.sock`
+
+`sudo go run . daemon`
+
+# Building
+`go build`
+
+`sudo rm -f /run/cni/dhcp.sock`
+
+`sudo ./dhcp daemon`
+
+# New option
+`sudo nano /etc/cni/multus/net.d/sw-lan.conf`
+
+```json
+{
+    "cniVersion": "0.4.0",
+    "type": "macvlan",
+    "name": "sw-lan",
+    "master": "eno1",
+    "mode": "bridge",
+    "ipam": {
+        "type": "dhcp",
+        "discardDhcpRoutes": true
+    }
+}
+```
+
+**discardDhcpRoutes** is set to false by default. If set to true, it will prevent the dhcp plugin to update the container/pod ip route table.

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -97,7 +97,10 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 		Address: *ipn,
 		Gateway: l.Gateway(),
 	}}
-	result.Routes = l.Routes()
+
+	if !conf.IPAM.DiscardDhcpRoutes {
+		result.Routes = l.Routes()
+	}
 
 	return nil
 }

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -50,7 +50,8 @@ type IPAMConfig struct {
 	// is set to `false`.
 	// To override default requesting fields, set `skipDefault` to `false`.
 	// If an field is not optional, but the server failed to provide it, error will be raised.
-	RequestOptions []RequestOption `json:"request"`
+	RequestOptions    []RequestOption `json:"request"`
+	DiscardDhcpRoutes bool            `json:"discardDhcpRoutes"`
 }
 
 // DHCPOption represents a DHCP option. It can be a number, or a string defined in manual dhcp-options(5).


### PR DESCRIPTION
The DHCP plugin add a default route to the container. In Kubernetes, there is already a default route provided by k8s. 
The route added by the plugin make the container unable to access the network or the kubernetes intra network.

 This new option prevent the addition of the new route and mimic the host-local ipam type, but with the dhcp plugin.

# New option
`sudo nano /etc/cni/multus/net.d/sw-lan.conf`

```json
{
    "cniVersion": "0.4.0",
    "type": "macvlan",
    "name": "sw-lan",
    "master": "eno1",
    "mode": "bridge",
    "ipam": {
        "type": "dhcp",
        "discardDhcpRoutes": true
    }
}
```

**discardDhcpRoutes** is set to false by default. If set to true, it will prevent the dhcp plugin to update the container/pod ip route table.
