### PR TITLE
Fix Host Veth Mac in CNI Result (Breaks Check)

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -358,7 +358,6 @@ func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairp
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to lookup %q: %v", hostIface.Name, err)
 	}
-	hostIface.Mac = hostVeth.Attrs().HardwareAddr.String()
 
 	// connect host veth end to the bridge
 	if err := netlink.LinkSetMaster(hostVeth, br); err != nil {
@@ -610,6 +609,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 	brInterface.Mac = br.Attrs().HardwareAddr.String()
+
+	hostveth, err := netlink.LinkByName(hostInterface.Name)
+
+	if err != nil {
+		return err
+	}
+
+	hostInterface.Mac = hostveth.Attrs().HardwareAddr.String()
 
 	result.DNS = n.DNS
 


### PR DESCRIPTION
I noticed when using the cnitool and implementing the check command in containerd that the check command was constantly failing. The host side veth was always wrong. I will check the current state of the tests. 

I am not certain if this happens else, all my machines this does, however I don't know how it would work since I believe CRI-O calls CHECK right after ADD

Signed-off-by: Michael Zappa <Michael.Zappa@stateless.net>