### PR TITLE
portmap: fix bug that new udp connection deletes all existing conntrack entries

### DIFF
--- a/pkg/utils/conntrack.go
+++ b/pkg/utils/conntrack.go
@@ -62,8 +62,8 @@ func DeleteConntrackEntriesForDstIP(dstIP string, protocol uint8) error {
 // by the given destination port, protocol and IP family
 func DeleteConntrackEntriesForDstPort(port uint16, protocol uint8, family netlink.InetFamily) error {
 	filter := &netlink.ConntrackFilter{}
-	filter.AddPort(netlink.ConntrackOrigDstPort, port)
 	filter.AddProtocol(protocol)
+	filter.AddPort(netlink.ConntrackOrigDstPort, port)
 
 	_, err := netlink.ConntrackDeleteFilter(netlink.ConntrackTable, family, filter)
 	if err != nil {


### PR DESCRIPTION
Hello, I found a critical bug that new udp connection deletes all existing conntrack entries.
The `DeleteConntrackEntriesForDstPort` function intended to only delete a conntrack entry that meet the conditions, but calling AddPort before AddProtocol returns an error (`Filter attribute not available without a valid Layer 4 protocol: 0`) and the port filter remains empty.
As a result, ConntrackDeleteFilter deletes all conntrack entries without port filter.
I think this is the simplest PR to resolve this issue, but I'm totally fine if you just ignore this PR and solve this issue in better way.
Just for reference, this bug is affecting our service with latest AKS node image. I recommend someone who are suffering same issue in AKS to build your own plugin binary and inject to worker nodes.

ref: https://github.com/vishvananda/netlink/blob/main/conntrack_linux.go#L455