### PR TITLE
build: support riscv64

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on: ["push", "pull_request"]
 
 env:
   GO_VERSION: "1.18"
-  LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le"
+  LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le riscv64"
 
 jobs:
   build:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ $DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z -
     apk --no-cache add bash tar;
     cd /go/src/github.com/containernetworking/plugins; umask 0022;
 
-    for arch in amd64 arm arm64 ppc64le s390x mips64le; do \
+    for arch in amd64 arm arm64 ppc64le s390x mips64le riscv64; do \
         rm -f ${OUTPUT_DIR}/*; \
         CGO_ENABLED=0 GOARCH=\$arch ./build_linux.sh ${BUILDFLAGS}; \
         for format in tgz; do \


### PR DESCRIPTION
Containers are coming to riscv64:
- https://github.com/opencontainers/runc/pull/3463
- https://medium.com/@tonistiigi/early-look-at-docker-containers-on-risc-v-40ed43b16b09 

