### PR TITLE
Use the same options for acquiring, renewing lease

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -308,7 +308,7 @@ func (l *DHCPLease) maintain() {
 				log.Printf("%v: %v", l.clientID, err)
 
 				if time.Now().After(l.rebindingTime) {
-					log.Printf("%v: renawal time expired, rebinding", l.clientID)
+					log.Printf("%v: renewal time expired, rebinding", l.clientID)
 					state = leaseStateRebinding
 				}
 			} else {
@@ -356,7 +356,7 @@ func (l *DHCPLease) renew() error {
 	}
 	defer c.Close()
 
-	opts := l.getOptionsWithClientId()
+	opts := l.getAllOptions()
 	pkt, err := backoffRetry(l.resendMax, func() (*dhcp4.Packet, error) {
 		ok, ack, err := DhcpRenew(c, *l.ack, opts)
 		switch {


### PR DESCRIPTION
Currently, hostname is set in the original DHCPREQUEST but not the
renewal. With some DHCP server implementations (such as FreeBSD dhcpd),
this leads to the hostname being cleared in the lease table.

This behavior is inconsistent with other DHCP clients such as dhclient
which set the hostname on the renewal request as well. To fix, use the
same options for acquire and renew.

This is compatible with RFC 2131 (see table 5).