### PR TITLE
host-local: remove unused Release(ip) from type Store interface

### DIFF
--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -94,10 +94,6 @@ func (s *Store) LastReservedIP(rangeID string) (net.IP, error) {
 	return net.ParseIP(string(data)), nil
 }
 
-func (s *Store) Release(ip net.IP) error {
-	return os.Remove(GetEscapedPath(s.dataDir, ip.String()))
-}
-
 func (s *Store) FindByKey(id string, ifname string, match string) (bool, error) {
 	found := false
 

--- a/plugins/ipam/host-local/backend/store.go
+++ b/plugins/ipam/host-local/backend/store.go
@@ -22,7 +22,6 @@ type Store interface {
 	Close() error
 	Reserve(id string, ifname string, ip net.IP, rangeID string) (bool, error)
 	LastReservedIP(rangeID string) (net.IP, error)
-	Release(ip net.IP) error
 	ReleaseByID(id string, ifname string) error
 	GetByID(id string, ifname string) []net.IP
 }

--- a/plugins/ipam/host-local/backend/testing/fake_store.go
+++ b/plugins/ipam/host-local/backend/testing/fake_store.go
@@ -63,11 +63,6 @@ func (s *FakeStore) LastReservedIP(rangeID string) (net.IP, error) {
 	return ip, nil
 }
 
-func (s *FakeStore) Release(ip net.IP) error {
-	delete(s.ipMap, ip.String())
-	return nil
-}
-
 func (s *FakeStore) ReleaseByID(id string, ifname string) error {
 	toDelete := []string{}
 	for k, v := range s.ipMap {


### PR DESCRIPTION
This function seems unused and host-local compiles perfectly without it.