### PR TITLE
build: Remove dos2unix dependency

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -7,7 +7,7 @@ export GOOS=windows
 export GOFLAGS="${GOFLAGS} -mod=vendor"
 echo "$GOFLAGS"
 
-PLUGINS=$(cat plugins/windows_only.txt | dos2unix )
+PLUGINS=$(cat plugins/windows_only.txt)
 for d in $PLUGINS; do
 	plugin="$(basename "$d").exe"
 	echo "building $plugin"

--- a/test_windows.sh
+++ b/test_windows.sh
@@ -11,7 +11,7 @@ echo "Running tests"
 
 PKGS="./pkg/hns/..."
 
-PLUGINS=$(cat plugins/windows_only.txt | dos2unix )
+PLUGINS=$(cat plugins/windows_only.txt)
 for d in $PLUGINS; do
 	PKGS="$PKGS ./$d/..."
 done


### PR DESCRIPTION
Removes use of dos2unix when building and testing for Windows. This is unnecessary and is adding an additional dependency to build systems.

Signed-off-by: Sebastian Soto <ssoto@redhat.com>