### PR TITLE
Plugins: add multicast to loopback

### DIFF
--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -97,6 +97,23 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 
+		err = netlink.LinkSetMulticastOn(link)
+		if err != nil {
+			return err // not tested
+		}
+
+		err = netlink.RouteAdd(&netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Scope:     netlink.SCOPE_HOST,
+			Dst: &net.IPNet{
+				IP:   net.IPv4(224, 0, 0, 0),
+				Mask: net.IPv4Mask(240, 0, 0, 0),
+			},
+		})
+		if err != nil {
+			return err // not tested
+		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
There are scenarios when multicast is needed on lo, for example in testing. The change adds it to the main loopback plugin. 

This change works perfectly well in our environment - a workable multicast pops up on the loopback interface once the loopback plugin is replaced with the one from the change.

Not sure yet how to write an automated test for it though, so the change is lacking the test so far. But could you please have a look at it first, and let me know if the change is good on its own - if it is, then I guess test(s) can be sorted.

Here is my initial question from which I came to this PR:
https://serverfault.com/questions/1114351/is-there-a-way-to-add-multicast-to-loopback-interface-on-a-kubernetes-pod

Thanks!