### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/pkg/ip/ipforward_linux.go
+++ b/pkg/ip/ipforward_linux.go
@@ -16,7 +16,7 @@ package ip
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
 )
@@ -53,10 +53,10 @@ func EnableForward(ips []*current.IPConfig) error {
 }
 
 func echo1(f string) error {
-	if content, err := ioutil.ReadFile(f); err == nil {
+	if content, err := os.ReadFile(f); err == nil {
 		if bytes.Equal(bytes.TrimSpace(content), []byte("1")) {
 			return nil
 		}
 	}
-	return ioutil.WriteFile(f, []byte("1"), 0644)
+	return os.WriteFile(f, []byte("1"), 0644)
 }

--- a/pkg/ip/ipforward_linux_test.go
+++ b/pkg/ip/ipforward_linux_test.go
@@ -1,7 +1,6 @@
 package ip
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 
 var _ = Describe("IpforwardLinux", func() {
 	It("echo1 must not write the file if content is 1", func() {
-		file, err := ioutil.TempFile(os.TempDir(), "containernetworking")
+		file, err := os.CreateTemp("", "containernetworking")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(file.Name())
 		err = echo1(file.Name())

--- a/pkg/ns/ns_linux_test.go
+++ b/pkg/ns/ns_linux_test.go
@@ -17,7 +17,6 @@ package ns_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -208,7 +207,7 @@ var _ = Describe("Linux namespace operations", func() {
 			})
 
 			It("fails when the path is not a namespace", func() {
-				tempFile, err := ioutil.TempFile("", "nstest")
+				tempFile, err := os.CreateTemp("", "nstest")
 				Expect(err).NotTo(HaveOccurred())
 				defer tempFile.Close()
 
@@ -262,7 +261,7 @@ var _ = Describe("Linux namespace operations", func() {
 		})
 
 		It("should refuse other paths", func() {
-			tempFile, err := ioutil.TempFile("", "nstest")
+			tempFile, err := os.CreateTemp("", "nstest")
 			Expect(err).NotTo(HaveOccurred())
 			defer tempFile.Close()
 

--- a/pkg/testutils/cmd.go
+++ b/pkg/testutils/cmd.go
@@ -15,7 +15,7 @@
 package testutils
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -52,7 +52,7 @@ func CmdAdd(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() er
 
 	var out []byte
 	if err == nil {
-		out, err = ioutil.ReadAll(r)
+		out, err = io.ReadAll(r)
 	}
 	os.Stdout = oldStdout
 

--- a/pkg/testutils/dns.go
+++ b/pkg/testutils/dns.go
@@ -16,7 +16,6 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -28,7 +27,7 @@ import (
 // an error if any occurs while creating/writing the file. It is the caller's
 // responsibility to remove the file.
 func TmpResolvConf(dnsConf types.DNS) (string, error) {
-	f, err := ioutil.TempFile("", "cni_test_resolv.conf")
+	f, err := os.CreateTemp("", "cni_test_resolv.conf")
 	if err != nil {
 		return "", fmt.Errorf("failed to get temp file for CNI test resolv.conf: %v", err)
 	}

--- a/pkg/testutils/echo/echo_test.go
+++ b/pkg/testutils/echo/echo_test.go
@@ -2,7 +2,7 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os/exec"
 	"strings"
@@ -74,7 +74,7 @@ var _ = Describe("Echosvr", func() {
 			defer conn.Close()
 
 			fmt.Fprintf(conn, "hello\n")
-			Expect(ioutil.ReadAll(conn)).To(Equal([]byte("hello")))
+			Expect(io.ReadAll(conn)).To(Equal([]byte("hello")))
 		})
 	})
 

--- a/pkg/utils/sysctl/sysctl_linux.go
+++ b/pkg/utils/sysctl/sysctl_linux.go
@@ -16,7 +16,7 @@ package sysctl
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -36,7 +36,7 @@ func Sysctl(name string, params ...string) (string, error) {
 
 func getSysctl(name string) (string, error) {
 	fullName := filepath.Join("/proc/sys", toNormalName(name))
-	data, err := ioutil.ReadFile(fullName)
+	data, err := os.ReadFile(fullName)
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func getSysctl(name string) (string, error) {
 
 func setSysctl(name, value string) (string, error) {
 	fullName := filepath.Join("/proc/sys", toNormalName(name))
-	if err := ioutil.WriteFile(fullName, []byte(value), 0644); err != nil {
+	if err := os.WriteFile(fullName, []byte(value), 0644); err != nil {
 		return "", err
 	}
 

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -142,7 +141,7 @@ func (d *DHCP) setLease(clientID string, l *DHCPLease) {
 	d.leases[clientID] = l
 }
 
-//func (d *DHCP) clearLease(contID, netName, ifName string) {
+// func (d *DHCP) clearLease(contID, netName, ifName string) {
 func (d *DHCP) clearLease(clientID string) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
@@ -188,7 +187,7 @@ func runDaemon(
 		if !filepath.IsAbs(pidfilePath) {
 			return fmt.Errorf("Error writing pidfile %q: path not absolute", pidfilePath)
 		}
-		if err := ioutil.WriteFile(pidfilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		if err := os.WriteFile(pidfilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
 			return fmt.Errorf("Error writing pidfile %q: %v", pidfilePath, err)
 		}
 	}

--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -27,7 +26,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -43,7 +42,7 @@ import (
 )
 
 func getTmpDir() (string, error) {
-	tmpDir, err := ioutil.TempDir(cniDirPrefix, "dhcp")
+	tmpDir, err := os.MkdirTemp(cniDirPrefix, "dhcp")
 	if err == nil {
 		tmpDir = filepath.ToSlash(tmpDir)
 	}

--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -15,7 +15,6 @@
 package disk
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -77,7 +76,7 @@ func (s *Store) Reserve(id string, ifname string, ip net.IP, rangeID string) (bo
 	}
 	// store the reserved ip in lastIPFile
 	ipfile := GetEscapedPath(s.dataDir, lastIPFilePrefix+rangeID)
-	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0644)
+	err = os.WriteFile(ipfile, []byte(ip.String()), 0644)
 	if err != nil {
 		return false, err
 	}
@@ -87,7 +86,7 @@ func (s *Store) Reserve(id string, ifname string, ip net.IP, rangeID string) (bo
 // LastReservedIP returns the last reserved IP if exists
 func (s *Store) LastReservedIP(rangeID string) (net.IP, error) {
 	ipfile := GetEscapedPath(s.dataDir, lastIPFilePrefix+rangeID)
-	data, err := ioutil.ReadFile(ipfile)
+	data, err := os.ReadFile(ipfile)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +100,7 @@ func (s *Store) FindByKey(id string, ifname string, match string) (bool, error) 
 		if err != nil || info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
@@ -137,7 +136,7 @@ func (s *Store) ReleaseByKey(id string, ifname string, match string) (bool, erro
 		if err != nil || info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
@@ -181,7 +180,7 @@ func (s *Store) GetByID(id string, ifname string) []net.IP {
 		if err != nil || info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}

--- a/plugins/ipam/host-local/backend/disk/lock_test.go
+++ b/plugins/ipam/host-local/backend/disk/lock_test.go
@@ -15,7 +15,6 @@
 package disk
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -25,7 +24,7 @@ import (
 
 var _ = Describe("Lock Operations", func() {
 	It("locks a file path", func() {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(dir)
 
@@ -47,7 +46,7 @@ var _ = Describe("Lock Operations", func() {
 	})
 
 	It("locks a folder path", func() {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(dir)
 

--- a/plugins/ipam/host-local/dns_test.go
+++ b/plugins/ipam/host-local/dns_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/types"
@@ -64,7 +63,7 @@ options four
 })
 
 func parse(contents string) (*types.DNS, error) {
-	f, err := ioutil.TempFile("", "host_local_resolv")
+	f, err := os.CreateTemp("", "host_local_resolv")
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -24,7 +23,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk"
@@ -43,7 +42,7 @@ var _ = Describe("host-local Operations", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "host-local_test")
+		tmpDir, err = os.MkdirTemp("", "host-local_test")
 		Expect(err).NotTo(HaveOccurred())
 		tmpDir = filepath.ToSlash(tmpDir)
 	})
@@ -58,7 +57,7 @@ var _ = Describe("host-local Operations", func() {
 		ver := ver
 
 		It(fmt.Sprintf("[%s] allocates and releases addresses with ADD/DEL", ver), func() {
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf := fmt.Sprintf(`{
@@ -134,22 +133,22 @@ var _ = Describe("host-local Operations", func() {
 			}
 
 			ipFilePath1 := filepath.Join(tmpDir, "mynet", "10.1.2.2")
-			contents, err := ioutil.ReadFile(ipFilePath1)
+			contents, err := os.ReadFile(ipFilePath1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
 
 			ipFilePath2 := filepath.Join(tmpDir, disk.GetEscapedPath("mynet", "2001:db8:1::2"))
-			contents, err = ioutil.ReadFile(ipFilePath2)
+			contents, err = os.ReadFile(ipFilePath2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
 
 			lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.0")
-			contents, err = ioutil.ReadFile(lastFilePath1)
+			contents, err = os.ReadFile(lastFilePath1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal("10.1.2.2"))
 
 			lastFilePath2 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.1")
-			contents, err = ioutil.ReadFile(lastFilePath2)
+			contents, err = os.ReadFile(lastFilePath2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal("2001:db8:1::2"))
 			// Release the IP
@@ -167,7 +166,7 @@ var _ = Describe("host-local Operations", func() {
 		It(fmt.Sprintf("[%s] allocates and releases addresses on specific interface with ADD/DEL", ver), func() {
 			const ifname1 string = "eth1"
 
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf0 := fmt.Sprintf(`{
@@ -239,12 +238,12 @@ var _ = Describe("host-local Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ipFilePath0 := filepath.Join(tmpDir, "mynet0", "10.1.2.2")
-			contents, err := ioutil.ReadFile(ipFilePath0)
+			contents, err := os.ReadFile(ipFilePath0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args0.ContainerID + LineBreak + ifname))
 
 			ipFilePath1 := filepath.Join(tmpDir, "mynet1", "10.2.2.2")
-			contents, err = ioutil.ReadFile(ipFilePath1)
+			contents, err = os.ReadFile(ipFilePath1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args1.ContainerID + LineBreak + ifname1))
 
@@ -257,7 +256,7 @@ var _ = Describe("host-local Operations", func() {
 			Expect(err).To(HaveOccurred())
 
 			// reread ipFilePath1, ensure that ifname1 didn't get deleted
-			contents, err = ioutil.ReadFile(ipFilePath1)
+			contents, err = os.ReadFile(ipFilePath1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args1.ContainerID + LineBreak + ifname1))
 
@@ -357,7 +356,7 @@ var _ = Describe("host-local Operations", func() {
 		})
 
 		It(fmt.Sprintf("[%s] verify DEL works on backwards compatible allocate", ver), func() {
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf := fmt.Sprintf(`{
@@ -395,10 +394,10 @@ var _ = Describe("host-local Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
-			contents, err := ioutil.ReadFile(ipFilePath)
+			contents, err := os.ReadFile(ipFilePath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal(args.ContainerID + LineBreak + ifname))
-			err = ioutil.WriteFile(ipFilePath, []byte(strings.TrimSpace(args.ContainerID)), 0644)
+			err = os.WriteFile(ipFilePath, []byte(strings.TrimSpace(args.ContainerID)), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = testutils.CmdDelWithArgs(args, func() error {
@@ -466,7 +465,7 @@ var _ = Describe("host-local Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ipFilePath := filepath.Join(tmpDir, "mynet", result.IPs[0].Address.IP.String())
-			contents, err := ioutil.ReadFile(ipFilePath)
+			contents, err := os.ReadFile(ipFilePath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(contents)).To(Equal("dummy" + LineBreak + ifname))
 
@@ -547,7 +546,7 @@ var _ = Describe("host-local Operations", func() {
 		})
 
 		It(fmt.Sprintf("[%s] allocates custom IPs from multiple ranges", ver), func() {
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf := fmt.Sprintf(`{
@@ -595,7 +594,7 @@ var _ = Describe("host-local Operations", func() {
 		})
 
 		It(fmt.Sprintf("[%s] allocates custom IPs from multiple protocols", ver), func() {
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf := fmt.Sprintf(`{

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -266,7 +265,7 @@ func (tc testCase) resolvConfConfig() string {
 }
 
 func newResolvConf() (string, error) {
-	f, err := ioutil.TempFile("", "host_local_resolv")
+	f, err := os.CreateTemp("", "host_local_resolv")
 	if err != nil {
 		return "", err
 	}
@@ -397,16 +396,16 @@ func ipVersion(ip net.IP) string {
 
 func countIPAMIPs(path string) (int, error) {
 	count := 0
-	files, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return -1, err
 	}
-	for _, file := range files {
-		if file.IsDir() {
+	for _, entry := range entries {
+		if entry.IsDir() {
 			continue
 		}
 
-		if net.ParseIP(file.Name()) != nil {
+		if net.ParseIP(entry.Name()) != nil {
 			count++
 		}
 	}
@@ -1631,7 +1630,7 @@ var _ = Describe("bridge Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "bridge_test")
+		dataDir, err = os.MkdirTemp("", "bridge_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Do not emulate an error, each test will set this if needed

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -175,7 +174,7 @@ var _ = Describe("dummy Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "dummy_test")
+		dataDir, err = os.MkdirTemp("", "dummy_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = originalNS.Do(func(ns.NetNS) error {

--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -46,7 +45,7 @@ var (
 // Array of different linux drivers bound to network device needed for DPDK
 var userspaceDrivers = []string{"vfio-pci", "uio_pci_generic", "igb_uio"}
 
-//NetConf for host-device config, look the README to learn how to use those parameters
+// NetConf for host-device config, look the README to learn how to use those parameters
 type NetConf struct {
 	types.NetConf
 	Device        string `json:"device"` // Device-Name, something like eth0 or can0 etc.
@@ -345,16 +344,16 @@ func getLink(devname, hwaddr, kernelpath, pciaddr string) (netlink.Link, error) 
 			return nil, fmt.Errorf("kernel device path %q must be absolute and begin with /sys/devices/", kernelpath)
 		}
 		netDir := filepath.Join(kernelpath, "net")
-		files, err := ioutil.ReadDir(netDir)
+		entries, err := os.ReadDir(netDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find network devices at %q", netDir)
 		}
 
 		// Grab the first device from eg /sys/devices/pci0000:00/0000:00:19.0/net
-		for _, file := range files {
+		for _, entry := range entries {
 			// Make sure it's really an interface
 			for _, l := range links {
-				if file.Name() == l.Attrs().Name {
+				if entry.Name() == l.Attrs().Name {
 					return l, nil
 				}
 			}
@@ -369,12 +368,12 @@ func getLink(devname, hwaddr, kernelpath, pciaddr string) (netlink.Link, error) 
 			}
 			netDir = matches[0]
 		}
-		fInfo, err := ioutil.ReadDir(netDir)
+		entries, err := os.ReadDir(netDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read net directory %s: %q", netDir, err)
 		}
-		if len(fInfo) > 0 {
-			return netlink.LinkByName(fInfo[0].Name())
+		if len(entries) > 0 {
+			return netlink.LinkByName(entries[0].Name())
 		}
 		return nil, fmt.Errorf("failed to find device name for pci address %s", pciaddr)
 	}

--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -1161,7 +1160,7 @@ type fakeFilesystem struct {
 
 func (fs *fakeFilesystem) use() func() {
 	// create the new fake fs root dir in /tmp/sriov...
-	tmpDir, err := ioutil.TempDir("", "sriov")
+	tmpDir, err := os.MkdirTemp("", "sriov")
 	if err != nil {
 		panic(fmt.Errorf("error creating fake root dir: %s", err.Error()))
 	}

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -25,9 +24,9 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/types/040"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -272,7 +271,7 @@ var _ = Describe("ipvlan Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "ipvlan_test")
+		dataDir, err = os.MkdirTemp("", "ipvlan_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = originalNS.Do(func(ns.NetNS) error {

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -25,9 +24,9 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/types/040"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -199,7 +198,7 @@ var _ = Describe("macvlan Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "macvlan_test")
+		dataDir, err = os.MkdirTemp("", "macvlan_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = originalNS.Do(func(ns.NetNS) error {

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -17,15 +17,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/types/040"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -221,7 +220,7 @@ var _ = Describe("ptp Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "ptp_test")
+		dataDir, err = os.MkdirTemp("", "ptp_test")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -25,9 +24,9 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/types/040"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -178,7 +177,7 @@ var _ = Describe("vlan Operations", func() {
 		targetNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		dataDir, err = ioutil.TempDir("", "vlan_test")
+		dataDir, err = os.MkdirTemp("", "vlan_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = originalNS.Do(func(ns.NetNS) error {

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -28,7 +27,7 @@ import (
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -896,7 +895,7 @@ var _ = Describe("bandwidth test", func() {
 				packetInBytes = rateInBytes * 25
 
 				var err error
-				dataDir, err = ioutil.TempDir("", "bandwidth_linux_test")
+				dataDir, err = os.MkdirTemp("", "bandwidth_linux_test")
 				Expect(err).NotTo(HaveOccurred())
 
 				ptpConf = fmt.Sprintf(`{

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -235,7 +234,7 @@ func createBackup(ifName, containerID, backupPath string, tuningConf *TuningConf
 	if err != nil {
 		return fmt.Errorf("failed to marshall data for %q: %v", ifName, err)
 	}
-	if err = ioutil.WriteFile(path.Join(backupPath, containerID+"_"+ifName+".json"), data, 0600); err != nil {
+	if err = os.WriteFile(path.Join(backupPath, containerID+"_"+ifName+".json"), data, 0600); err != nil {
 		return fmt.Errorf("failed to save file %s.json: %v", ifName, err)
 	}
 
@@ -250,7 +249,7 @@ func restoreBackup(ifName, containerID, backupPath string) error {
 		return nil
 	}
 
-	file, err := ioutil.ReadFile(filePath)
+	file, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %q: %v", filePath, err)
 	}
@@ -349,7 +348,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				return fmt.Errorf("invalid net sysctl key: %q", key)
 			}
 			content := []byte(value)
-			err := ioutil.WriteFile(fileName, content, 0644)
+			err := os.WriteFile(fileName, content, 0644)
 			if err != nil {
 				return err
 			}
@@ -441,7 +440,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 		for key, confValue := range tuningConf.SysCtl {
 			fileName := filepath.Join("/proc/sys", strings.Replace(key, ".", "/", -1))
 
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
io/ioutil package has been marked deprecated in Go 1.16.

https://go.dev/doc/go1.16#ioutil

Signed-off-by: Austin Vazquez <macedonv@amazon.com>