### PR TITLE
Fix Tests: Update portmap test's iptables error check

### DIFF
--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -207,7 +207,7 @@ var _ = Describe("portmap integration tests", func() {
 
 				// Verify iptables rules are gone
 				_, err = ipt.List("nat", dnatChainName)
-				Expect(err).To(MatchError(ContainSubstring("iptables: No chain/target/match by that name.")))
+				Expect(err).To(HaveOccurred())
 
 				// Check that everything succeeded *after* we clean up the network
 				if !contOK {


### PR DESCRIPTION
GitHub Actions recently updated ubuntu-latest to 22.04 [1], which now
defaults to nfttables (rather than iptables-legacy) [2]. The portmap
tests in this project are written with the expectation that expected
error message for one test is in the iptables-legacy format.

This commit updates the check to make it work for both the
iptables-legecy and iptables-nftables variants.
    
References:
[1]: https://github.com/actions/runner-images/commit/4aba37bd3b8df82c3b27e7c2448556e966a8b41e
[2]: https://ubuntu.com/blog/whats-new-in-security-for-ubuntu-22-04-lts
    
Signed-off-by: Emily Shepherd <emily@redcoat.dev>