### PR TITLE
Add IPv6 support for AddDefaultRoute

### DIFF
--- a/pkg/ip/route_linux.go
+++ b/pkg/ip/route_linux.go
@@ -42,6 +42,11 @@ func AddHostRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
 
 // AddDefaultRoute sets the default route on the given gateway.
 func AddDefaultRoute(gw net.IP, dev netlink.Link) error {
-	_, defNet, _ := net.ParseCIDR("0.0.0.0/0")
+	var defNet *net.IPNet
+	if gw.To4() != nil {
+		_, defNet, _ = net.ParseCIDR("0.0.0.0/0")
+	} else {
+		_, defNet, _ = net.ParseCIDR("::/0")
+	}
 	return AddRoute(defNet, gw, dev)
 }


### PR DESCRIPTION
AddDefaultRoute assumes that the user is adding a default route for IPv4, not IPv6. This pr will fix it.