### PR TITLE
Fix tuning allowlist

### DIFF
--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -502,6 +502,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 func validateSysctlConf(tuningConf *TuningConf) error {
 	isPresent, allowlist, err := readAllowlist()
 	if err != nil {
+		if os.IsPermission(err) {
+			return nil
+		}
 		return err
 	}
 	if !isPresent {


### PR DESCRIPTION
``` console
"failed to call cni.Setup: plugin type=\"tuning\" failed (add): open /etc/cni/tuning/allowlist.conf: permission denied"

```