### PR TITLE
Fix overwritten error var in getMTUByName

### DIFF
--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -148,7 +148,8 @@ func getMTUByName(ifName string, namespace string, inContainer bool) (int, error
 	var link netlink.Link
 	var err error
 	if inContainer {
-		netns, err := ns.GetNS(namespace)
+		var netns ns.NetNS
+		netns, err = ns.GetNS(namespace)
 		if err != nil {
 			return 0, fmt.Errorf("failed to open netns %q: %v", netns, err)
 		}

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -75,7 +75,8 @@ func getMTUByName(ifName string, namespace string, inContainer bool) (int, error
 	var link netlink.Link
 	var err error
 	if inContainer {
-		netns, err := ns.GetNS(namespace)
+		var netns ns.NetNS
+		netns, err = ns.GetNS(namespace)
 		if err != nil {
 			return 0, fmt.Errorf("failed to open netns %q: %v", netns, err)
 		}


### PR DESCRIPTION
this prevents the error to be lost which was causing the panic while accesing a nil var.

Fix #830

Signed-off-by: Marcelo Guerrero Viveros <marguerr@redhat.com>