### PR TITLE
Add option to bridge plugin to allow masquerading of same subnet

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -46,17 +46,18 @@ const defaultBrName = "cni0"
 
 type NetConf struct {
 	types.NetConf
-	BrName       string `json:"bridge"`
-	IsGW         bool   `json:"isGateway"`
-	IsDefaultGW  bool   `json:"isDefaultGateway"`
-	ForceAddress bool   `json:"forceAddress"`
-	IPMasq       bool   `json:"ipMasq"`
-	MTU          int    `json:"mtu"`
-	HairpinMode  bool   `json:"hairpinMode"`
-	PromiscMode  bool   `json:"promiscMode"`
-	Vlan         int    `json:"vlan"`
-	MacSpoofChk  bool   `json:"macspoofchk,omitempty"`
-	EnableDad    bool   `json:"enabledad,omitempty"`
+	BrName          string `json:"bridge"`
+	IsGW            bool   `json:"isGateway"`
+	IsDefaultGW     bool   `json:"isDefaultGateway"`
+	ForceAddress    bool   `json:"forceAddress"`
+	IPMasq          bool   `json:"ipMasq"`
+	IPMasqOwnSubnet bool   `json:"ipMasqOwnSubnet"`
+	MTU             int    `json:"mtu"`
+	HairpinMode     bool   `json:"hairpinMode"`
+	PromiscMode     bool   `json:"promiscMode"`
+	Vlan            int    `json:"vlan"`
+	MacSpoofChk     bool   `json:"macspoofchk,omitempty"`
+	EnableDad       bool   `json:"enabledad,omitempty"`
 
 	Args struct {
 		Cni BridgeArgs `json:"cni,omitempty"`
@@ -562,7 +563,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			chain := utils.FormatChainName(n.Name, args.ContainerID)
 			comment := utils.FormatComment(n.Name, args.ContainerID)
 			for _, ipc := range result.IPs {
-				if err = ip.SetupIPMasq(&ipc.Address, chain, comment); err != nil {
+				if err = ip.SetupIPMasq(&ipc.Address, chain, comment, n.IPMasqOwnSubnet); err != nil {
 					return err
 				}
 			}

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -233,7 +233,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		chain := utils.FormatChainName(conf.Name, args.ContainerID)
 		comment := utils.FormatComment(conf.Name, args.ContainerID)
 		for _, ipc := range result.IPs {
-			if err = ip.SetupIPMasq(&ipc.Address, chain, comment); err != nil {
+			if err = ip.SetupIPMasq(&ipc.Address, chain, comment, false); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Depending on the use case, it may be necessary to masquerade traffic destined for the same subnet as the pod's IP. This can be the case if the bridge plugin is used as a secondary interface with multus. Add an option to allow this use case.