### PR TITLE
bridge, spoofcheck: Apply nftable rules in the pod netns

### DIFF
--- a/pkg/link/spoofcheck_test.go
+++ b/pkg/link/spoofcheck_test.go
@@ -145,11 +145,11 @@ func assertExpectedBaseChainRuleDeletionInTeardownConfig(action configurerStub) 
 				{"delete": {"rule": {
 					"family": "bridge",
 					"table": "nat",
-					"chain": "PREROUTING",
+					"chain": "POSTROUTING",
 					"expr": [
 						{"match": {
 							"op": "==",
-							"left": {"meta": {"key": "iifname"}},
+							"left": {"meta": {"key": "oifname"}},
 							"right": "net0"
 						}},
 						{"jump": {"target": "cni-br-iface-container99-net1"}}
@@ -163,9 +163,9 @@ func assertExpectedBaseChainRuleDeletionInTeardownConfig(action configurerStub) 
 func rowConfigWithRulesOnly() string {
 	return `
             {"nftables":[
-                {"rule":{"family":"bridge","table":"nat","chain":"PREROUTING",
+                {"rule":{"family":"bridge","table":"nat","chain":"POSTROUTING",
                     "expr":[
-                        {"match":{"op":"==","left":{"meta":{"key":"iifname"}},"right":"net0"}},
+                        {"match":{"op":"==","left":{"meta":{"key":"oifname"}},"right":"net0"}},
                         {"jump":{"target":"cni-br-iface-container99-net1"}}
                     ],
                     "comment":"macspoofchk-container99-net1"}},
@@ -202,9 +202,9 @@ func assertExpectedTableAndChainsInSetupConfig(c configurerStub) {
             {"chain": {
                 "family": "bridge",
                 "table": "nat",
-                "name": "PREROUTING",
+                "name": "POSTROUTING",
                 "type": "filter",
-                "hook": "prerouting",
+                "hook": "postrouting",
                 "prio": -300,
                 "policy": "accept"
             }},
@@ -231,9 +231,9 @@ func assertExpectedRulesInSetupConfig(c configurerStub) {
             {"nftables":[
                 {"flush":{"chain":{"family":"bridge","table":"nat","name":"cni-br-iface-container99-net1"}}},
                 {"flush":{"chain":{"family":"bridge","table":"nat","name":"cni-br-iface-container99-net1-mac"}}},
-                {"rule":{"family":"bridge","table":"nat","chain":"PREROUTING",
+                {"rule":{"family":"bridge","table":"nat","chain":"POSTROUTING",
                     "expr":[
-                        {"match":{"op":"==","left":{"meta":{"key":"iifname"}},"right":"net0"}},
+                        {"match":{"op":"==","left":{"meta":{"key":"oifname"}},"right":"net0"}},
                         {"jump":{"target":"cni-br-iface-container99-net1"}}
                     ],
                     "comment":"macspoofchk-container99-net1"}},

--- a/pkg/link/spoofcheck_test.go
+++ b/pkg/link/spoofcheck_test.go
@@ -130,6 +130,16 @@ func assertExpectedRegularChainsDeletionInTeardownConfig(action configurerStub) 
 					"family": "bridge",
 					"table": "nat",
 					"name": "cni-br-iface-container99-net1-mac"
+				}}},
+				{"delete": {"chain": {
+					"family": "inet",
+					"table": "inet",
+					"name": "cni-br-iface-container99-net1"
+				}}},
+				{"delete": {"chain": {
+					"family": "inet",
+					"table": "inet",
+					"name": "cni-br-iface-container99-net1-mac"
 				}}}
 			]}`
 
@@ -145,6 +155,20 @@ func assertExpectedBaseChainRuleDeletionInTeardownConfig(action configurerStub) 
 				{"delete": {"rule": {
 					"family": "bridge",
 					"table": "nat",
+					"chain": "POSTROUTING",
+					"expr": [
+						{"match": {
+							"op": "==",
+							"left": {"meta": {"key": "oifname"}},
+							"right": "net0"
+						}},
+						{"jump": {"target": "cni-br-iface-container99-net1"}}
+					],
+					"comment": "macspoofchk-container99-net1"
+				}}},
+				{"delete": {"rule": {
+					"family": "inet",
+					"table": "inet",
 					"chain": "POSTROUTING",
 					"expr": [
 						{"match": {
@@ -187,6 +211,31 @@ func rowConfigWithRulesOnly() string {
                 {"rule":{"family":"bridge","table":"nat","chain":"cni-br-iface-container99-net1-mac",
                     "expr":[{"drop":null}],
                     "index":0,
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"POSTROUTING",
+                    "expr":[
+                        {"match":{"op":"==","left":{"meta":{"key":"oifname"}},"right":"net0"}},
+                        {"jump":{"target":"cni-br-iface-container99-net1"}}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1",
+                    "expr":[
+                        {"jump":{"target":"cni-br-iface-container99-net1-mac"}}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1-mac",
+                    "expr":[
+                        {"match":{
+                            "op":"==",
+                            "left":{"payload":{"protocol":"ether","field":"saddr"}},
+                            "right":"02:00:00:00:12:34"
+                        }},
+                        {"return":null}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1-mac",
+                    "expr":[{"drop":null}],
+                    "index":0,
                     "comment":"macspoofchk-container99-net1"}}
             ]}`
 }
@@ -216,6 +265,26 @@ func assertExpectedTableAndChainsInSetupConfig(c configurerStub) {
             {"chain": {
                 "family": "bridge",
                 "table": "nat",
+                "name": "cni-br-iface-container99-net1-mac"
+            }},
+            {"table": {"family": "inet", "name": "inet"}},
+            {"chain": {
+                "family": "inet",
+                "table": "inet",
+                "name": "POSTROUTING",
+                "type": "filter",
+                "hook": "postrouting",
+                "prio": -300,
+                "policy": "accept"
+            }},
+            {"chain": {
+                "family": "inet",
+                "table": "inet",
+                "name": "cni-br-iface-container99-net1"
+            }},
+            {"chain": {
+                "family": "inet",
+                "table": "inet",
                 "name": "cni-br-iface-container99-net1-mac"
             }}
         ]}`
@@ -253,6 +322,33 @@ func assertExpectedRulesInSetupConfig(c configurerStub) {
                     ],
                     "comment":"macspoofchk-container99-net1"}},
                 {"rule":{"family":"bridge","table":"nat","chain":"cni-br-iface-container99-net1-mac",
+                    "expr":[{"drop":null}],
+                    "index":0,
+                    "comment":"macspoofchk-container99-net1"}},
+                {"flush":{"chain":{"family":"inet","table":"inet","name":"cni-br-iface-container99-net1"}}},
+                {"flush":{"chain":{"family":"inet","table":"inet","name":"cni-br-iface-container99-net1-mac"}}},
+                {"rule":{"family":"inet","table":"inet","chain":"POSTROUTING",
+                    "expr":[
+                        {"match":{"op":"==","left":{"meta":{"key":"oifname"}},"right":"net0"}},
+                        {"jump":{"target":"cni-br-iface-container99-net1"}}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1",
+                    "expr":[
+                        {"jump":{"target":"cni-br-iface-container99-net1-mac"}}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1-mac",
+                    "expr":[
+                        {"match":{
+                            "op":"==",
+                            "left":{"payload":{"protocol":"ether","field":"saddr"}},
+                            "right":"02:00:00:00:12:34"
+                        }},
+                        {"return":null}
+                    ],
+                    "comment":"macspoofchk-container99-net1"}},
+                {"rule":{"family":"inet","table":"inet","chain":"cni-br-iface-container99-net1-mac",
                     "expr":[{"drop":null}],
                     "index":0,
                     "comment":"macspoofchk-container99-net1"}}

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -2303,10 +2303,10 @@ func assertMacSpoofCheckRules(assert func(actual interface{}, expectedLen int)) 
 
 	expectedTable := nft.NewTable("nat", "bridge")
 	filter := nft.TypeFilter
-	hook := nft.HookPreRouting
+	hook := nft.HookPostRouting
 	prio := -300
 	policy := nft.PolicyAccept
-	expectedBaseChain := nft.NewChain(expectedTable, "PREROUTING", &filter, &hook, &prio, &policy)
+	expectedBaseChain := nft.NewChain(expectedTable, "POSTROUTING", &filter, &hook, &prio, &policy)
 
 	assert(c.LookupRule(nft.NewRule(
 		expectedTable,


### PR DESCRIPTION
The spoofcheck nftables rules have been applied on the node root network namespace for ingress traffic that arrives from the pod netns.

When there are a large amount of rules visible, the user-space processing of adding and removing rules becomes slow. Field results showed the `nft` commands taking minutes to complete.

In addition, the removal of the rules is dependent on the execution of the DEL command, which is not always assured to occur. Therefore, the current solution where the rules are set on the node root network namespace may cause nftables configuration leaks.

This change suggests to place the rules in the pod network namespace, solving both issues.

It adds rules at two places: IP and Bridge stacks, on the postrouting hook.