### PR TITLE
enable durationcheck,  predeclared, unconvert, unused and wastedassign linters 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ issues:
 linters:
   enable:
     - contextcheck
+    - durationcheck
     - gci
     - gocritic
     - gofumpt
@@ -17,8 +18,12 @@ linters:
     - ineffassign
     - misspell
     - nonamedreturns
+    - predeclared
     - revive
     - staticcheck
+    - unconvert
+    - unused
+    - wastedassign
   disable:
     - errcheck
 

--- a/pkg/testutils/echo/echo_test.go
+++ b/pkg/testutils/echo/echo_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Echosvr", func() {
 		It("connects successfully using echo client", func() {
 			Eventually(session.Out).Should(gbytes.Say("\n"))
 			serverAddress := strings.TrimSpace(string(session.Out.Contents()))
-			fmt.Println("Server address", string(serverAddress))
+			fmt.Println("Server address", serverAddress)
 
 			cmd := exec.Command(clientBinaryPath, "-target", serverAddress, "-message", "hello")
 			clientSession, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -306,7 +306,7 @@ func (tc testCase) createCheckCmdArgs(targetNS ns.NetNS, config *Net, dataDir st
 		ContainerID: fmt.Sprintf("dummy-%d", counter),
 		Netns:       targetNS.Path(),
 		IfName:      IFNAME,
-		StdinData:   []byte(conf),
+		StdinData:   conf,
 	}
 }
 

--- a/plugins/meta/bandwidth/ifb_creator.go
+++ b/plugins/meta/bandwidth/ifb_creator.go
@@ -125,9 +125,9 @@ func createTBF(rateInBits, burstInBits uint64, linkIndex int) error {
 	}
 	rateInBytes := rateInBits / 8
 	burstInBytes := burstInBits / 8
-	bufferInBytes := buffer(uint64(rateInBytes), uint32(burstInBytes))
+	bufferInBytes := buffer(rateInBytes, uint32(burstInBytes))
 	latency := latencyInUsec(latencyInMillis)
-	limitInBytes := limit(uint64(rateInBytes), latency, uint32(burstInBytes))
+	limitInBytes := limit(rateInBytes, latency, uint32(burstInBytes))
 
 	qdisc := &netlink.Tbf{
 		QdiscAttrs: netlink.QdiscAttrs{
@@ -135,9 +135,9 @@ func createTBF(rateInBits, burstInBits uint64, linkIndex int) error {
 			Handle:    netlink.MakeHandle(1, 0),
 			Parent:    netlink.HANDLE_ROOT,
 		},
-		Limit:  uint32(limitInBytes),
-		Rate:   uint64(rateInBytes),
-		Buffer: uint32(bufferInBytes),
+		Limit:  limitInBytes,
+		Rate:   rateInBytes,
+		Buffer: bufferInBytes,
 	}
 	err := netlink.QdiscAdd(qdisc)
 	if err != nil {
@@ -147,7 +147,7 @@ func createTBF(rateInBits, burstInBits uint64, linkIndex int) error {
 }
 
 func time2Tick(time uint32) uint32 {
-	return uint32(float64(time) * float64(netlink.TickInUsec()))
+	return uint32(float64(time) * netlink.TickInUsec())
 }
 
 func buffer(rate uint64, burst uint32) uint32 {

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -299,9 +299,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 	if bandwidth.IngressRate > 0 && bandwidth.IngressBurst > 0 {
 		rateInBytes := bandwidth.IngressRate / 8
 		burstInBytes := bandwidth.IngressBurst / 8
-		bufferInBytes := buffer(uint64(rateInBytes), uint32(burstInBytes))
+		bufferInBytes := buffer(rateInBytes, uint32(burstInBytes))
 		latency := latencyInUsec(latencyInMillis)
-		limitInBytes := limit(uint64(rateInBytes), latency, uint32(burstInBytes))
+		limitInBytes := limit(rateInBytes, latency, uint32(burstInBytes))
 
 		qdiscs, err := SafeQdiscList(link)
 		if err != nil {
@@ -316,13 +316,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 			if !isTbf {
 				break
 			}
-			if tbf.Rate != uint64(rateInBytes) {
+			if tbf.Rate != rateInBytes {
 				return fmt.Errorf("Rate doesn't match")
 			}
-			if tbf.Limit != uint32(limitInBytes) {
+			if tbf.Limit != limitInBytes {
 				return fmt.Errorf("Limit doesn't match")
 			}
-			if tbf.Buffer != uint32(bufferInBytes) {
+			if tbf.Buffer != bufferInBytes {
 				return fmt.Errorf("Buffer doesn't match")
 			}
 		}
@@ -331,9 +331,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 	if bandwidth.EgressRate > 0 && bandwidth.EgressBurst > 0 {
 		rateInBytes := bandwidth.EgressRate / 8
 		burstInBytes := bandwidth.EgressBurst / 8
-		bufferInBytes := buffer(uint64(rateInBytes), uint32(burstInBytes))
+		bufferInBytes := buffer(rateInBytes, uint32(burstInBytes))
 		latency := latencyInUsec(latencyInMillis)
-		limitInBytes := limit(uint64(rateInBytes), latency, uint32(burstInBytes))
+		limitInBytes := limit(rateInBytes, latency, uint32(burstInBytes))
 
 		ifbDeviceName := getIfbDeviceName(bwConf.Name, args.ContainerID)
 
@@ -355,13 +355,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 			if !isTbf {
 				break
 			}
-			if tbf.Rate != uint64(rateInBytes) {
+			if tbf.Rate != rateInBytes {
 				return fmt.Errorf("Rate doesn't match")
 			}
-			if tbf.Limit != uint32(limitInBytes) {
+			if tbf.Limit != limitInBytes {
 				return fmt.Errorf("Limit doesn't match")
 			}
-			if tbf.Buffer != uint32(bufferInBytes) {
+			if tbf.Buffer != bufferInBytes {
 				return fmt.Errorf("Buffer doesn't match")
 			}
 		}

--- a/plugins/meta/firewall/firewall_firewalld_test.go
+++ b/plugins/meta/firewall/firewall_firewalld_test.go
@@ -82,7 +82,7 @@ func spawnSessionDbus(wg *sync.WaitGroup) (string, *exec.Cmd) {
 	// Wait for dbus-daemon to print the bus address
 	bytes, err := bufio.NewReader(stdout).ReadString('\n')
 	Expect(err).NotTo(HaveOccurred())
-	busAddr := strings.TrimSpace(string(bytes))
+	busAddr := strings.TrimSpace(bytes)
 	Expect(strings.HasPrefix(busAddr, "unix:abstract")).To(BeTrue())
 
 	var startWg sync.WaitGroup
@@ -197,9 +197,9 @@ var _ = Describe("firewalld test", func() {
 				ContainerID: "dummy",
 				Netns:       targetNs.Path(),
 				IfName:      ifname,
-				StdinData:   []byte(conf),
+				StdinData:   conf,
 			}
-			_, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, []byte(conf), func() error {
+			_, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, conf, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -223,9 +223,9 @@ var _ = Describe("firewalld test", func() {
 				ContainerID: "dummy",
 				Netns:       targetNs.Path(),
 				IfName:      ifname,
-				StdinData:   []byte(conf),
+				StdinData:   conf,
 			}
-			_, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, []byte(conf), func() error {
+			_, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, conf, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -241,9 +241,9 @@ var _ = Describe("firewalld test", func() {
 				ContainerID: "dummy",
 				Netns:       targetNs.Path(),
 				IfName:      ifname,
-				StdinData:   []byte(conf),
+				StdinData:   conf,
 			}
-			r, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, []byte(conf), func() error {
+			r, _, err := testutils.CmdAdd(targetNs.Path(), args.ContainerID, ifname, conf, func() error {
 				return cmdAdd(args)
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -265,7 +265,7 @@ var _ = Describe("firewalld test", func() {
 				ContainerID: "dummy",
 				Netns:       targetNs.Path(),
 				IfName:      ifname,
-				StdinData:   []byte(conf),
+				StdinData:   conf,
 			}
 			r, _, err := testutils.CmdAddWithArgs(args, func() error {
 				return cmdAdd(args)

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -256,7 +256,7 @@ func restoreBackup(ifName, containerID, backupPath string) error {
 	}
 
 	config := configToRestore{}
-	if err = json.Unmarshal([]byte(file), &config); err != nil {
+	if err = json.Unmarshal(file, &config); err != nil {
 		return nil
 	}
 

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -253,7 +253,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)
@@ -395,7 +395,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)
@@ -541,7 +541,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)
@@ -687,7 +687,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)
@@ -839,7 +839,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)
@@ -918,7 +918,7 @@ var _ = Describe("tuning plugin", func() {
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
-					err = json.Unmarshal([]byte(conf), &n)
+					err = json.Unmarshal(conf, &n)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, confString, err := buildOneConfig("testConfig", ver, n, r)

--- a/plugins/meta/vrf/vrf_test.go
+++ b/plugins/meta/vrf/vrf_test.go
@@ -587,7 +587,7 @@ var _ = Describe("vrf plugin", func() {
 			defer GinkgoRecover()
 			cniVersion := "0.4.0"
 			n := &VRFNetConf{}
-			err = json.Unmarshal([]byte(conf), &n)
+			err = json.Unmarshal(conf, &n)
 			_, confString, err := buildOneConfig("testConfig", cniVersion, n, prevRes)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>