### PR TITLE
Added trivy-scan for plugins

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,28 @@
+name: Trivy Security Scan
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee  # master
+        with:
+          scan-type: 'fs'
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@16964e90ba004cdf0cd845b866b5df21038b7723  # v2.2.6
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'code'


### PR DESCRIPTION
This PR introduces the security scanning for plugins repository. This job will run once any pull and push request changes made on the `main` branch.

**1. Why is this pull request needed and what does it do?**
The CVE scanning for the plugins repository will be enabled by this PR. It will make it easier to track down the HIGH and CRITICAL CVE being used.


**Test result:**
![Screenshot 2023-03-18 at 8 55 14 PM](https://user-images.githubusercontent.com/99066083/226115103-c92762cb-3f73-451a-927c-443eae32b8d9.png)


