### PR TITLE
Remove default native vlan on bridge

### DIFF
--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -118,7 +118,6 @@ func (s *Store) FindByID(id string, ifname string) bool {
 	s.Lock()
 	defer s.Unlock()
 
-	found := false
 	match := strings.TrimSpace(id) + LineBreak + ifname
 	found, err := s.FindByKey(match)
 
@@ -155,7 +154,6 @@ func (s *Store) ReleaseByKey(match string) (bool, error) {
 // N.B. This function eats errors to be tolerant and
 // release as much as possible
 func (s *Store) ReleaseByID(id string, ifname string) error {
-	found := false
 	match := strings.TrimSpace(id) + LineBreak + ifname
 	found, err := s.ReleaseByKey(match)
 

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -532,8 +532,10 @@ func (tester *testerV10x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 		// Check the bridge vlan filtering equals true
 		if tc.vlan != 0 {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(true))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(0)))
 		} else {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(false))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 		}
 
 		// Ensure bridge has expected gateway address(es)
@@ -837,8 +839,10 @@ func (tester *testerV04x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 		// Check the bridge vlan filtering equals true
 		if tc.vlan != 0 {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(true))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(0)))
 		} else {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(false))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 		}
 
 		// Ensure bridge has expected gateway address(es)
@@ -1137,8 +1141,10 @@ func (tester *testerV03x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 		// Check the bridge vlan filtering equals true
 		if tc.vlan != 0 {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(true))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(0)))
 		} else {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(false))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 		}
 
 		// Ensure bridge has expected gateway address(es)
@@ -1363,8 +1369,10 @@ func (tester *testerV01xOr02x) cmdAddTest(tc testCase, dataDir string) (types.Re
 		// Check the bridge vlan filtering equals true
 		if tc.vlan != 0 {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(true))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(0)))
 		} else {
 			Expect(*link.(*netlink.Bridge).VlanFiltering).To(Equal(false))
+			Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 		}
 
 		// Ensure bridge has expected gateway address(es)
@@ -1659,6 +1667,7 @@ var _ = Describe("bridge Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(link.Attrs().Name).To(Equal(BRNAME))
 				Expect(link.Attrs().Promisc).To(Equal(0))
+				Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1692,6 +1701,7 @@ var _ = Describe("bridge Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(link.Attrs().Name).To(Equal(BRNAME))
 				Expect(link.Attrs().Index).To(Equal(ifindex))
+				Expect(*link.(*netlink.Bridge).VlanDefaultPVID).To(Equal(uint16(1)))
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -265,6 +265,7 @@ type Bridge struct {
 	AgeingTime        *uint32
 	HelloTime         *uint32
 	VlanFiltering     *bool
+	VlanDefaultPVID   *uint16
 }
 
 func (bridge *Bridge) Attrs() *LinkAttrs {

--- a/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -345,6 +345,16 @@ func (h *Handle) BridgeSetVlanFiltering(link Link, on bool) error {
 	return h.linkModify(bridge, unix.NLM_F_ACK)
 }
 
+func BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
+	return pkgHandle.BridgeSetVlanDefaultPVID(link, pvid)
+}
+
+func (h *Handle) BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
+	bridge := link.(*Bridge)
+	bridge.VlanDefaultPVID = &pvid
+	return h.linkModify(bridge, unix.NLM_F_ACK)
+}
+
 func SetPromiscOn(link Link) error {
 	return pkgHandle.SetPromiscOn(link)
 }
@@ -3115,6 +3125,9 @@ func addBridgeAttrs(bridge *Bridge, linkInfo *nl.RtAttr) {
 	if bridge.VlanFiltering != nil {
 		data.AddRtAttr(nl.IFLA_BR_VLAN_FILTERING, boolToByte(*bridge.VlanFiltering))
 	}
+	if bridge.VlanDefaultPVID != nil {
+		data.AddRtAttr(nl.IFLA_BR_VLAN_DEFAULT_PVID, nl.Uint16Attr(*bridge.VlanDefaultPVID))
+	}
 }
 
 func parseBridgeData(bridge Link, data []syscall.NetlinkRouteAttr) {
@@ -3133,6 +3146,9 @@ func parseBridgeData(bridge Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_BR_VLAN_FILTERING:
 			vlanFiltering := datum.Value[0] == 1
 			br.VlanFiltering = &vlanFiltering
+		case nl.IFLA_BR_VLAN_DEFAULT_PVID:
+			vlanDefaultPVID := native.Uint16(datum.Value[0:2])
+			br.VlanDefaultPVID = &vlanDefaultPVID
 		}
 	}
 }


### PR DESCRIPTION
These changes prevent pods connected to a VLAN
to receive the native traffic of the bridge.

Fixes: #667