### PR TITLE
Fix revive linter errors

### DIFF
--- a/pkg/testutils/bad_reader.go
+++ b/pkg/testutils/bad_reader.go
@@ -21,7 +21,7 @@ type BadReader struct {
 	Error error
 }
 
-func (r *BadReader) Read(buffer []byte) (int, error) {
+func (r *BadReader) Read(_ []byte) (int, error) {
 	if r.Error != nil {
 		return 0, r.Error
 	}

--- a/pkg/testutils/cmd.go
+++ b/pkg/testutils/cmd.go
@@ -81,7 +81,7 @@ func CmdAddWithArgs(args *skel.CmdArgs, f func() error) (types.Result, []byte, e
 	return CmdAdd(args.Netns, args.ContainerID, args.IfName, args.StdinData, f)
 }
 
-func CmdCheck(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() error) error {
+func CmdCheck(cniNetns, cniContainerID, cniIfname string, f func() error) error {
 	os.Setenv("CNI_COMMAND", "CHECK")
 	os.Setenv("CNI_PATH", os.Getenv("PATH"))
 	os.Setenv("CNI_NETNS", cniNetns)
@@ -93,7 +93,7 @@ func CmdCheck(cniNetns, cniContainerID, cniIfname string, conf []byte, f func() 
 }
 
 func CmdCheckWithArgs(args *skel.CmdArgs, f func() error) error {
-	return CmdCheck(args.Netns, args.ContainerID, args.IfName, args.StdinData, f)
+	return CmdCheck(args.Netns, args.ContainerID, args.IfName, f)
 }
 
 func CmdDel(cniNetns, cniContainerID, cniIfname string, f func() error) error {

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -115,7 +115,7 @@ func (d *DHCP) Allocate(args *skel.CmdArgs, result *current.Result) error {
 
 // Release stops maintenance of the lease acquired in Allocate()
 // and sends a release msg to the DHCP server.
-func (d *DHCP) Release(args *skel.CmdArgs, reply *struct{}) error {
+func (d *DHCP) Release(args *skel.CmdArgs, _ *struct{}) error {
 	conf := NetConf{}
 	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
 		return fmt.Errorf("error parsing netconf: %v", err)

--- a/plugins/ipam/dhcp/dhcp2_test.go
+++ b/plugins/ipam/dhcp/dhcp2_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"sync"
@@ -39,11 +38,10 @@ var _ = Describe("DHCP Multiple Lease Operations", func() {
 	var clientCmd *exec.Cmd
 	var socketPath string
 	var tmpDir string
-	var serverIP net.IPNet
 	var err error
 
 	BeforeEach(func() {
-		dhcpServerStopCh, serverIP, socketPath, originalNS, targetNS, err = dhcpSetupOriginalNS()
+		dhcpServerStopCh, socketPath, originalNS, targetNS, err = dhcpSetupOriginalNS()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Move the container side to the container's NS
@@ -63,7 +61,7 @@ var _ = Describe("DHCP Multiple Lease Operations", func() {
 		})
 
 		// Start the DHCP server
-		dhcpServerDone, err = dhcpServerStart(originalNS, net.IPv4(192, 168, 1, 5), serverIP.IP, 2, dhcpServerStopCh)
+		dhcpServerDone, err = dhcpServerStart(originalNS, 2, dhcpServerStopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the DHCP client daemon

--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -48,7 +48,7 @@ func getTmpDir() (string, error) {
 	return tmpDir, err
 }
 
-func dhcpServerStart(netns ns.NetNS, leaseIP, serverIP net.IP, numLeases int, stopCh <-chan bool) (*sync.WaitGroup, error) {
+func dhcpServerStart(netns ns.NetNS, numLeases int, stopCh <-chan bool) (*sync.WaitGroup, error) {
 	// Add the expected IP to the pool
 	lp := memorypool.MemoryPool{}
 
@@ -200,7 +200,7 @@ var _ = Describe("DHCP Operations", func() {
 		})
 
 		// Start the DHCP server
-		dhcpServerDone, err = dhcpServerStart(originalNS, net.IPv4(192, 168, 1, 5), serverIP.IP, 1, dhcpServerStopCh)
+		dhcpServerDone, err = dhcpServerStart(originalNS, 1, dhcpServerStopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the DHCP client daemon
@@ -361,7 +361,7 @@ const (
 	contVethName1  string = "eth1"
 )
 
-func dhcpSetupOriginalNS() (chan bool, net.IPNet, string, ns.NetNS, ns.NetNS, error) {
+func dhcpSetupOriginalNS() (chan bool, string, ns.NetNS, ns.NetNS, error) {
 	var originalNS, targetNS ns.NetNS
 	var dhcpServerStopCh chan bool
 	var socketPath string
@@ -381,11 +381,6 @@ func dhcpSetupOriginalNS() (chan bool, net.IPNet, string, ns.NetNS, ns.NetNS, er
 
 	targetNS, err = testutils.NewNS()
 	Expect(err).NotTo(HaveOccurred())
-
-	serverIP := net.IPNet{
-		IP:   net.IPv4(192, 168, 1, 1),
-		Mask: net.IPv4Mask(255, 255, 255, 0),
-	}
 
 	// Use (original) NS
 	err = originalNS.Do(func(ns.NetNS) error {
@@ -481,7 +476,7 @@ func dhcpSetupOriginalNS() (chan bool, net.IPNet, string, ns.NetNS, ns.NetNS, er
 		return nil
 	})
 
-	return dhcpServerStopCh, serverIP, socketPath, originalNS, targetNS, err
+	return dhcpServerStopCh, socketPath, originalNS, targetNS, err
 }
 
 var _ = Describe("DHCP Lease Unavailable Operations", func() {
@@ -491,11 +486,10 @@ var _ = Describe("DHCP Lease Unavailable Operations", func() {
 	var clientCmd *exec.Cmd
 	var socketPath string
 	var tmpDir string
-	var serverIP net.IPNet
 	var err error
 
 	BeforeEach(func() {
-		dhcpServerStopCh, serverIP, socketPath, originalNS, targetNS, err = dhcpSetupOriginalNS()
+		dhcpServerStopCh, socketPath, originalNS, targetNS, err = dhcpSetupOriginalNS()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Move the container side to the container's NS
@@ -515,7 +509,7 @@ var _ = Describe("DHCP Lease Unavailable Operations", func() {
 		})
 
 		// Start the DHCP server
-		dhcpServerDone, err = dhcpServerStart(originalNS, net.IPv4(192, 168, 1, 5), serverIP.IP, 1, dhcpServerStopCh)
+		dhcpServerDone, err = dhcpServerStart(originalNS, 1, dhcpServerStopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the DHCP client daemon

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -234,7 +234,7 @@ func (l *DHCPLease) getAllOptions() dhcp4.Options {
 }
 
 func (l *DHCPLease) acquire() error {
-	c, err := newDHCPClient(l.link, l.clientID, l.timeout, l.broadcast)
+	c, err := newDHCPClient(l.link, l.timeout, l.broadcast)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func (l *DHCPLease) downIface() {
 }
 
 func (l *DHCPLease) renew() error {
-	c, err := newDHCPClient(l.link, l.clientID, l.timeout, l.broadcast)
+	c, err := newDHCPClient(l.link, l.timeout, l.broadcast)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (l *DHCPLease) renew() error {
 func (l *DHCPLease) release() error {
 	log.Printf("%v: releasing lease", l.clientID)
 
-	c, err := newDHCPClient(l.link, l.clientID, l.timeout, l.broadcast)
+	c, err := newDHCPClient(l.link, l.timeout, l.broadcast)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func backoffRetry(resendMax time.Duration, f func() (*dhcp4.Packet, error)) (*dh
 }
 
 func newDHCPClient(
-	link netlink.Link, clientID string,
+	link netlink.Link,
 	timeout time.Duration,
 	broadcast bool,
 ) (*dhcp4client.Client, error) {

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -118,10 +118,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 func cmdDel(args *skel.CmdArgs) error {
 	result := struct{}{}
-	if err := rpcCall("DHCP.Release", args, &result); err != nil {
-		return err
-	}
-	return nil
+	return rpcCall("DHCP.Release", args, &result)
 }
 
 func cmdCheck(args *skel.CmdArgs) error {
@@ -134,11 +131,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 
 	result := &current.Result{CNIVersion: current.ImplementedSpecVersion}
-	if err := rpcCall("DHCP.Allocate", args, result); err != nil {
-		return err
-	}
-
-	return nil
+	return rpcCall("DHCP.Allocate", args, result)
 }
 
 func getSocketPath(stdinData []byte) (string, error) {

--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -95,7 +95,7 @@ func (s *Store) LastReservedIP(rangeID string) (net.IP, error) {
 	return net.ParseIP(string(data)), nil
 }
 
-func (s *Store) FindByKey(id string, ifname string, match string) (bool, error) {
+func (s *Store) FindByKey(match string) (bool, error) {
 	found := false
 
 	err := filepath.Walk(s.dataDir, func(path string, info os.FileInfo, err error) error {
@@ -120,18 +120,18 @@ func (s *Store) FindByID(id string, ifname string) bool {
 
 	found := false
 	match := strings.TrimSpace(id) + LineBreak + ifname
-	found, err := s.FindByKey(id, ifname, match)
+	found, err := s.FindByKey(match)
 
 	// Match anything created by this id
 	if !found && err == nil {
 		match := strings.TrimSpace(id)
-		found, _ = s.FindByKey(id, ifname, match)
+		found, _ = s.FindByKey(match)
 	}
 
 	return found
 }
 
-func (s *Store) ReleaseByKey(id string, ifname string, match string) (bool, error) {
+func (s *Store) ReleaseByKey(match string) (bool, error) {
 	found := false
 	err := filepath.Walk(s.dataDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
@@ -157,12 +157,12 @@ func (s *Store) ReleaseByKey(id string, ifname string, match string) (bool, erro
 func (s *Store) ReleaseByID(id string, ifname string) error {
 	found := false
 	match := strings.TrimSpace(id) + LineBreak + ifname
-	found, err := s.ReleaseByKey(id, ifname, match)
+	found, err := s.ReleaseByKey(match)
 
 	// For backwards compatibility, look for files written by a previous version
 	if !found && err == nil {
 		match := strings.TrimSpace(id)
-		_, err = s.ReleaseByKey(id, ifname, match)
+		_, err = s.ReleaseByKey(match)
 	}
 	return err
 }

--- a/plugins/ipam/host-local/backend/testing/fake_store.go
+++ b/plugins/ipam/host-local/backend/testing/fake_store.go
@@ -45,7 +45,7 @@ func (s *FakeStore) Close() error {
 	return nil
 }
 
-func (s *FakeStore) Reserve(id string, ifname string, ip net.IP, rangeID string) (bool, error) {
+func (s *FakeStore) Reserve(id string, _ string, ip net.IP, rangeID string) (bool, error) {
 	key := ip.String()
 	if _, ok := s.ipMap[key]; !ok {
 		s.ipMap[key] = id
@@ -63,7 +63,7 @@ func (s *FakeStore) LastReservedIP(rangeID string) (net.IP, error) {
 	return ip, nil
 }
 
-func (s *FakeStore) ReleaseByID(id string, ifname string) error {
+func (s *FakeStore) ReleaseByID(id string, _ string) error {
 	toDelete := []string{}
 	for k, v := range s.ipMap {
 		if v == id {
@@ -76,7 +76,7 @@ func (s *FakeStore) ReleaseByID(id string, ifname string) error {
 	return nil
 }
 
-func (s *FakeStore) GetByID(id string, ifname string) []net.IP {
+func (s *FakeStore) GetByID(id string, _ string) []net.IP {
 	var ips []net.IP
 	for k, v := range s.ipMap {
 		if v == id {

--- a/plugins/ipam/static/main.go
+++ b/plugins/ipam/static/main.go
@@ -276,7 +276,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	return types.PrintResult(result, confVersion)
 }
 
-func cmdDel(args *skel.CmdArgs) error {
+func cmdDel(_ *skel.CmdArgs) error {
 	// Nothing required because of no resource allocation in static plugin.
 	return nil
 }

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -508,10 +508,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
 
 			// Add the IP to the interface
-			if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-				return err
-			}
-			return nil
+			return ipam.ConfigureIface(args.IfName, result)
 		}); err != nil {
 			return err
 		}
@@ -953,7 +950,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 
 	// Check prevResults for ips, routes and dns against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
+	return netns.Do(func(_ ns.NetNS) error {
 		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
 		if err != nil {
 			return err
@@ -964,11 +961,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 			return err
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func uniqueID(containerID, cniIface string) string {

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -296,7 +296,7 @@ func (tc testCase) createCmdArgs(targetNS ns.NetNS, dataDir string) *skel.CmdArg
 
 // createCheckCmdArgs generates network configuration and creates command
 // arguments for a Check test case.
-func (tc testCase) createCheckCmdArgs(targetNS ns.NetNS, config *Net, dataDir string) *skel.CmdArgs {
+func (tc testCase) createCheckCmdArgs(targetNS ns.NetNS, config *Net) *skel.CmdArgs {
 	conf, err := json.Marshal(config)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -660,9 +660,9 @@ func (tester *testerV10x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 	return result, nil
 }
 
-func (tester *testerV10x) cmdCheckTest(tc testCase, conf *Net, dataDir string) {
+func (tester *testerV10x) cmdCheckTest(tc testCase, conf *Net, _ string) {
 	// Generate network config and command arguments
-	tester.args = tc.createCheckCmdArgs(tester.targetNS, conf, dataDir)
+	tester.args = tc.createCheckCmdArgs(tester.targetNS, conf)
 
 	// Execute cmdCHECK on the plugin
 	err := tester.testNS.Do(func(ns.NetNS) error {
@@ -960,9 +960,9 @@ func (tester *testerV04x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 	return result, nil
 }
 
-func (tester *testerV04x) cmdCheckTest(tc testCase, conf *Net, dataDir string) {
+func (tester *testerV04x) cmdCheckTest(tc testCase, conf *Net, _ string) {
 	// Generate network config and command arguments
-	tester.args = tc.createCheckCmdArgs(tester.targetNS, conf, dataDir)
+	tester.args = tc.createCheckCmdArgs(tester.targetNS, conf)
 
 	// Execute cmdCHECK on the plugin
 	err := tester.testNS.Do(func(ns.NetNS) error {
@@ -1258,10 +1258,10 @@ func (tester *testerV03x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 	return result, nil
 }
 
-func (tester *testerV03x) cmdCheckTest(tc testCase, conf *Net, dataDir string) {
+func (tester *testerV03x) cmdCheckTest(_ testCase, _ *Net, _ string) {
 }
 
-func (tester *testerV03x) cmdDelTest(tc testCase, dataDir string) {
+func (tester *testerV03x) cmdDelTest(_ testCase, _ string) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
@@ -1488,10 +1488,10 @@ func (tester *testerV01xOr02x) cmdAddTest(tc testCase, dataDir string) (types.Re
 	return nil, nil
 }
 
-func (tester *testerV01xOr02x) cmdCheckTest(tc testCase, conf *Net, dataDir string) {
+func (tester *testerV01xOr02x) cmdCheckTest(_ testCase, _ *Net, _ string) {
 }
 
-func (tester *testerV01xOr02x) cmdDelTest(tc testCase, dataDir string) {
+func (tester *testerV01xOr02x) cmdDelTest(tc testCase, _ string) {
 	err := tester.testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 

--- a/plugins/main/dummy/dummy.go
+++ b/plugins/main/dummy/dummy.go
@@ -40,7 +40,7 @@ func parseNetConf(bytes []byte) (*types.NetConf, error) {
 	return conf, nil
 }
 
-func createDummy(conf *types.NetConf, ifName string, netns ns.NetNS) (*current.Interface, error) {
+func createDummy(ifName string, netns ns.NetNS) (*current.Interface, error) {
 	dummy := &current.Interface{}
 
 	dm := &netlink.Dummy{
@@ -90,7 +90,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer netns.Close()
 
-	dummyInterface, err := createDummy(conf, args.IfName, netns)
+	dummyInterface, err := createDummy(args.IfName, netns)
 	if err != nil {
 		return err
 	}
@@ -134,10 +134,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.Interfaces = []*current.Interface{dummyInterface}
 
 	err = netns.Do(func(_ ns.NetNS) error {
-		if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-			return err
-		}
-		return nil
+		return ipam.ConfigureIface(args.IfName, result)
 	})
 
 	if err != nil {

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -151,7 +151,7 @@ func (t *testerV03x) verifyResult(result types.Result, name string) string {
 }
 
 // verifyResult minimally verifies the Result and returns the interface's MAC address
-func (t *testerV01xOr02x) verifyResult(result types.Result, name string) string {
+func (t *testerV01xOr02x) verifyResult(result types.Result, _ string) string {
 	r, err := types020.GetResult(result)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -210,17 +210,11 @@ var _ = Describe("dummy Operations", func() {
 		ver := ver
 
 		It(fmt.Sprintf("[%s] creates an dummy link in a non-default namespace", ver), func() {
-			conf := &types.NetConf{
-				CNIVersion: ver,
-				Name:       "testConfig",
-				Type:       "dummy",
-			}
-
 			// Create dummy in other namespace
 			err := originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				_, err := createDummy(conf, "foobar0", targetNS)
+				_, err := createDummy("foobar0", targetNS)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			})

--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -158,10 +158,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	if !cfg.DPDKMode {
 		err = containerNs.Do(func(_ ns.NetNS) error {
-			if err := ipam.ConfigureIface(args.IfName, newResult); err != nil {
-				return err
-			}
-			return nil
+			return ipam.ConfigureIface(args.IfName, newResult)
 		})
 		if err != nil {
 			return err

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -294,10 +294,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	err = netns.Do(func(_ ns.NetNS) error {
 		_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
 
-		if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-			return err
-		}
-		return nil
+		return ipam.ConfigureIface(args.IfName, result)
 	})
 	if err != nil {
 		return err
@@ -405,14 +402,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 			contMap.Sandbox, args.Netns)
 	}
 
-	var m netlink.Link
 	if n.LinkContNs {
 		err = netns.Do(func(_ ns.NetNS) error {
-			m, err = netlink.LinkByName(n.Master)
+			_, err = netlink.LinkByName(n.Master)
 			return err
 		})
 	} else {
-		m, err = netlink.LinkByName(n.Master)
+		_, err = netlink.LinkByName(n.Master)
 	}
 
 	if err != nil {
@@ -422,7 +418,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	// Check prevResults for ips, routes and dns against values found in the container
 	if err := netns.Do(func(_ ns.NetNS) error {
 		// Check interface against values found in the container
-		err := validateCniContainerInterface(contMap, m.Attrs().Index, n.Mode)
+		err := validateCniContainerInterface(contMap, n.Mode)
 		if err != nil {
 			return err
 		}
@@ -444,7 +440,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-func validateCniContainerInterface(intf current.Interface, masterIndex int, modeExpected string) error {
+func validateCniContainerInterface(intf current.Interface, modeExpected string) error {
 	var link netlink.Link
 	var err error
 

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -250,7 +250,7 @@ func (t *testerV04x) verifyResult(result types.Result, name string) string {
 }
 
 // verifyResult minimally verifies the Result and returns the interface's MAC address
-func (t *testerV02x) verifyResult(result types.Result, name string) string {
+func (t *testerV02x) verifyResult(result types.Result, _ string) string {
 	r, err := types020.GetResult(result)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -352,10 +352,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		err = netns.Do(func(_ ns.NetNS) error {
 			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
 
-			if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-				return err
-			}
-			return nil
+			return ipam.ConfigureIface(args.IfName, result)
 		})
 		if err != nil {
 			return err
@@ -484,14 +481,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 			contMap.Sandbox, args.Netns)
 	}
 
-	var m netlink.Link
 	if n.LinkContNs {
 		err = netns.Do(func(_ ns.NetNS) error {
-			m, err = netlink.LinkByName(n.Master)
+			_, err = netlink.LinkByName(n.Master)
 			return err
 		})
 	} else {
-		m, err = netlink.LinkByName(n.Master)
+		_, err = netlink.LinkByName(n.Master)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to lookup master %q: %v", n.Master, err)
@@ -500,7 +496,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	// Check prevResults for ips, routes and dns against values found in the container
 	if err := netns.Do(func(_ ns.NetNS) error {
 		// Check interface against values found in the container
-		err := validateCniContainerInterface(contMap, m.Attrs().Index, n.Mode)
+		err := validateCniContainerInterface(contMap, n.Mode)
 		if err != nil {
 			return err
 		}
@@ -522,7 +518,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-func validateCniContainerInterface(intf current.Interface, parentIndex int, modeExpected string) error {
+func validateCniContainerInterface(intf current.Interface, modeExpected string) error {
 	var link netlink.Link
 	var err error
 

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -168,7 +168,7 @@ func (t *testerV03x) verifyResult(result types.Result, err error, name string, n
 }
 
 // verifyResult minimally verifies the Result and returns the interface's MAC address
-func (t *testerV01xOr02x) verifyResult(result types.Result, err error, name string, numAddrs int) string {
+func (t *testerV01xOr02x) verifyResult(result types.Result, err error, _ string, numAddrs int) string {
 	if result == nil && numAddrs == 0 {
 		Expect(err).To(MatchError("cannot convert: no valid IP addresses"))
 		return ""

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -186,7 +186,7 @@ func (t *testerV03x) verifyResult(result types.Result, expectedIfName, expectedS
 }
 
 // verifyResult minimally verifies the Result and returns the interface's IP addresses and MAC address
-func (t *testerV01xOr02x) verifyResult(result types.Result, expectedIfName, expectedSandbox string, expectedDNS types.DNS) ([]resultIP, string) {
+func (t *testerV01xOr02x) verifyResult(result types.Result, _, _ string, _ types.DNS) ([]resultIP, string) {
 	r, err := types020.GetResult(result)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/plugins/main/tap/tap.go
+++ b/plugins/main/tap/tap.go
@@ -302,10 +302,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		err = netns.Do(func(_ ns.NetNS) error {
 			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
 
-			if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-				return err
-			}
-			return nil
+			return ipam.ConfigureIface(args.IfName, result)
 		})
 		if err != nil {
 			return err
@@ -433,7 +430,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 
 	// Check prevResults for ips, routes and dns against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
+	return netns.Do(func(_ ns.NetNS) error {
 		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
 		if err != nil {
 			return err
@@ -444,9 +441,5 @@ func cmdCheck(args *skel.CmdArgs) error {
 			return err
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }

--- a/plugins/main/tap/tap_test.go
+++ b/plugins/main/tap/tap_test.go
@@ -154,7 +154,7 @@ func (t *testerV03x) verifyResult(result types.Result, name string) string {
 }
 
 // verifyResult minimally verifies the Result and returns the interface's MAC address
-func (t *testerV01xOr02x) verifyResult(result types.Result, name string) string {
+func (t *testerV01xOr02x) verifyResult(result types.Result, _ string) string {
 	r, err := types020.GetResult(result)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -308,14 +308,14 @@ func cmdCheck(args *skel.CmdArgs) error {
 		return fmt.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
 			contMap.Sandbox, args.Netns)
 	}
-	var m netlink.Link
+
 	if conf.LinkContNs {
 		err = netns.Do(func(_ ns.NetNS) error {
-			m, err = netlink.LinkByName(conf.Master)
+			_, err = netlink.LinkByName(conf.Master)
 			return err
 		})
 	} else {
-		m, err = netlink.LinkByName(conf.Master)
+		_, err = netlink.LinkByName(conf.Master)
 	}
 
 	if err != nil {
@@ -326,7 +326,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	// Check prevResults for ips, routes and dns against values found in the container
 	if err := netns.Do(func(_ ns.NetNS) error {
 		// Check interface against values found in the container
-		err := validateCniContainerInterface(contMap, m.Attrs().Index, conf.VlanID, conf.MTU)
+		err := validateCniContainerInterface(contMap, conf.VlanID, conf.MTU)
 		if err != nil {
 			return err
 		}
@@ -348,7 +348,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-func validateCniContainerInterface(intf current.Interface, masterIndex int, vlanID int, mtu int) error {
+func validateCniContainerInterface(intf current.Interface, vlanID int, mtu int) error {
 	var link netlink.Link
 	var err error
 

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -158,7 +158,7 @@ func (t *testerV03x) verifyResult(result types.Result, name string) string {
 }
 
 // verifyResult minimally verifies the Result and returns the interface's MAC address
-func (t *testerV01xOr02x) verifyResult(result types.Result, name string) string {
+func (t *testerV01xOr02x) verifyResult(result types.Result, _ string) string {
 	r, err := types020.GetResult(result)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -987,7 +987,7 @@ var _ = Describe("bandwidth test", func() {
 							StdinData:   newCheckBytes,
 						}
 
-						err = testutils.CmdCheck(containerWithTbfNS.Path(), args.ContainerID, "", newCheckBytes, func() error { return cmdCheck(args) })
+						err = testutils.CmdCheck(containerWithTbfNS.Path(), args.ContainerID, "", func() error { return cmdCheck(args) })
 						Expect(err).NotTo(HaveOccurred())
 					}
 

--- a/plugins/meta/bandwidth/main.go
+++ b/plugins/meta/bandwidth/main.go
@@ -236,11 +236,7 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	ifbDeviceName := getIfbDeviceName(conf.Name, args.ContainerID)
 
-	if err := TeardownIfb(ifbDeviceName); err != nil {
-		return err
-	}
-
-	return nil
+	return TeardownIfb(ifbDeviceName)
 }
 
 func main() {

--- a/plugins/meta/firewall/firewall.go
+++ b/plugins/meta/firewall/firewall.go
@@ -116,12 +116,12 @@ func getBackend(conf *FirewallNetConf) (FirewallBackend, error) {
 	case "iptables":
 		return newIptablesBackend(conf)
 	case "firewalld":
-		return newFirewalldBackend(conf)
+		return newFirewalldBackend()
 	}
 
 	// Default to firewalld if it's running
 	if isFirewalldRunning() {
-		return newFirewalldBackend(conf)
+		return newFirewalldBackend()
 	}
 
 	// Otherwise iptables
@@ -175,11 +175,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := teardownIngressPolicy(conf, result); err != nil {
-		return err
-	}
-
-	return nil
+	return teardownIngressPolicy(conf)
 }
 
 func main() {
@@ -202,9 +198,5 @@ func cmdCheck(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := backend.Check(conf, result); err != nil {
-		return err
-	}
-
-	return nil
+	return backend.Check(conf, result)
 }

--- a/plugins/meta/firewall/firewalld.go
+++ b/plugins/meta/firewall/firewalld.go
@@ -71,7 +71,7 @@ func isFirewalldRunning() bool {
 	return true
 }
 
-func newFirewalldBackend(conf *FirewallNetConf) (FirewallBackend, error) {
+func newFirewalldBackend() (FirewallBackend, error) {
 	conn, err := getConn()
 	if err != nil {
 		return nil, err

--- a/plugins/meta/firewall/ingresspolicy.go
+++ b/plugins/meta/firewall/ingresspolicy.go
@@ -62,7 +62,7 @@ func setupIngressPolicySameBridge(conf *FirewallNetConf, prevResult *types100.Re
 	return nil
 }
 
-func teardownIngressPolicy(conf *FirewallNetConf, prevResult *types100.Result) error {
+func teardownIngressPolicy(conf *FirewallNetConf) error {
 	switch conf.IngressPolicy {
 	case "", IngressPolicyOpen:
 		// NOP
@@ -151,11 +151,7 @@ func setupIsolationChains(ipt *iptables.IPTables, bridgeName string) error {
 		return err
 	}
 	stage2Return := withDefaultComment([]string{"-j", "RETURN"})
-	if err := utils.InsertUnique(ipt, filterTableName, stage2Chain, false, stage2Return); err != nil {
-		return err
-	}
-
-	return nil
+	return utils.InsertUnique(ipt, filterTableName, stage2Chain, false, stage2Return)
 }
 
 func isolationStage1BridgeRule(bridgeName, stage2Chain string) []string {

--- a/plugins/meta/firewall/iptables.go
+++ b/plugins/meta/firewall/iptables.go
@@ -74,11 +74,7 @@ func (ib *iptablesBackend) setupChains(ipt *iptables.IPTables) error {
 	}
 
 	// Ensure our admin override chain rule exists in our private chain
-	if err := ensureFirstChainRule(ipt, ib.privChainName, adminRule); err != nil {
-		return err
-	}
-
-	return nil
+	return ensureFirstChainRule(ipt, ib.privChainName, adminRule)
 }
 
 func protoForIP(ip net.IPNet) iptables.Protocol {
@@ -88,7 +84,7 @@ func protoForIP(ip net.IPNet) iptables.Protocol {
 	return iptables.ProtocolIPv6
 }
 
-func (ib *iptablesBackend) addRules(conf *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
+func (ib *iptablesBackend) addRules(_ *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
 	rules := make([][]string, 0)
 	for _, ip := range result.IPs {
 		if protoForIP(ip.Address) == proto {
@@ -120,7 +116,7 @@ func (ib *iptablesBackend) addRules(conf *FirewallNetConf, result *current.Resul
 	return nil
 }
 
-func (ib *iptablesBackend) delRules(conf *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
+func (ib *iptablesBackend) delRules(_ *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
 	rules := make([][]string, 0)
 	for _, ip := range result.IPs {
 		if protoForIP(ip.Address) == proto {
@@ -135,7 +131,7 @@ func (ib *iptablesBackend) delRules(conf *FirewallNetConf, result *current.Resul
 	return nil
 }
 
-func (ib *iptablesBackend) checkRules(conf *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
+func (ib *iptablesBackend) checkRules(_ *FirewallNetConf, result *current.Result, ipt *iptables.IPTables, proto iptables.Protocol) error {
 	rules := make([][]string, 0)
 	for _, ip := range result.IPs {
 		if protoForIP(ip.Address) == proto {

--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -130,10 +130,7 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	// We don't need to parse out whether or not we're using v6 or snat,
 	// deletion is idempotent
-	if err := unforwardPorts(netConf); err != nil {
-		return err
-	}
-	return nil
+	return unforwardPorts(netConf)
 }
 
 func main() {

--- a/plugins/meta/sbr/main.go
+++ b/plugins/meta/sbr/main.go
@@ -164,7 +164,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	// Do the actual work.
 	err = withLockAndNetNS(args.Netns, func(_ ns.NetNS) error {
-		return doRoutes(ipCfgs, conf.PrevResult.Routes, args.IfName)
+		return doRoutes(ipCfgs, args.IfName)
 	})
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func getNextTableID(rules []netlink.Rule, routes []netlink.Route, candidateID in
 }
 
 // doRoutes does all the work to set up routes and rules during an add.
-func doRoutes(ipCfgs []*current.IPConfig, origRoutes []*types.Route, iface string) error {
+func doRoutes(ipCfgs []*current.IPConfig, iface string) error {
 	// Get a list of rules and routes ready.
 	rules, err := netlink.RuleList(netlink.FAMILY_ALL)
 	if err != nil {
@@ -398,6 +398,6 @@ func main() {
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("sbr"))
 }
 
-func cmdCheck(args *skel.CmdArgs) error {
+func cmdCheck(_ *skel.CmdArgs) error {
 	return nil
 }

--- a/plugins/sample/main.go
+++ b/plugins/sample/main.go
@@ -153,7 +153,7 @@ func main() {
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("TODO"))
 }
 
-func cmdCheck(args *skel.CmdArgs) error {
+func cmdCheck(_ *skel.CmdArgs) error {
 	// TODO: implement
 	return fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
Golangci-lint is now running version 1.52.1. This introduced some errors.