### PR TITLE
linter: fix ginkgolinter errors

### DIFF
--- a/pkg/ip/link_linux_test.go
+++ b/pkg/ip/link_linux_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Link", func() {
 			// this will delete the host endpoint too
 			addr, err := ip.DelLinkByNameAddr(containerVethName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(addr).To(HaveLen(0))
+			Expect(addr).To(BeEmpty())
 			return nil
 		})
 	})

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -914,7 +914,7 @@ var _ = Describe("tuning plugin", func() {
 
 				link, err := netlink.LinkByName(IFNAME)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(link.Attrs().RawFlags&unix.IFF_ALLMULTI != 0).To(BeTrue())
+				Expect(link.Attrs().RawFlags & unix.IFF_ALLMULTI).NotTo(BeZero())
 
 				if testutils.SpecVersionHasCHECK(ver) {
 					n := &TuningConf{}
@@ -995,7 +995,7 @@ var _ = Describe("tuning plugin", func() {
 
 				link, err := netlink.LinkByName(IFNAME)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(link.Attrs().RawFlags&unix.IFF_ALLMULTI != 0).To(BeTrue())
+				Expect(link.Attrs().RawFlags & unix.IFF_ALLMULTI).NotTo(BeZero())
 
 				err = testutils.CmdDel(originalNS.Path(),
 					args.ContainerID, "", func() error { return cmdDel(args) })


### PR DESCRIPTION
Use:
- `BeEmpty` instead of `HaveLen(0)`
- `Expect(x).To(BeZero())` instead of `Expect(x == 0).To(BeTrue())`