### PR TITLE
Fix ValidateExpectedRoute with non default routes and nil GW

### DIFF
--- a/pkg/ip/utils_linux.go
+++ b/pkg/ip/utils_linux.go
@@ -83,7 +83,10 @@ func ValidateExpectedRoute(resultRoutes []*types.Route) error {
 	// Ensure that each static route in prevResults is found in the routing table
 	for _, route := range resultRoutes {
 		find := &netlink.Route{Dst: &route.Dst, Gw: route.GW}
-		routeFilter := netlink.RT_FILTER_DST | netlink.RT_FILTER_GW
+		routeFilter := netlink.RT_FILTER_DST
+		if route.GW != nil {
+			routeFilter |= netlink.RT_FILTER_GW
+		}
 		var family int
 
 		switch {

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -368,7 +368,7 @@ var _ = Describe("ptp Operations", func() {
 			doTest(conf, ver, 1, dnsConf, targetNS)
 		})
 
-		It(fmt.Sprintf("[%s] configures and deconfigures a dual-stack ptp link with ADD/DEL", ver), func() {
+		It(fmt.Sprintf("[%s] configures and deconfigures a dual-stack ptp link + routes with ADD/DEL", ver), func() {
 			conf := fmt.Sprintf(`{
 			    "cniVersion": "%s",
 			    "name": "mynet",
@@ -380,6 +380,11 @@ var _ = Describe("ptp Operations", func() {
 				"ranges": [
 					[{ "subnet": "10.1.2.0/24"}],
 					[{ "subnet": "2001:db8:1::0/66"}]
+				],
+				"routes": [
+				  { "dst": "0.0.0.0/0" },
+				  { "dst": "192.168.0.0/16" },
+				  { "dst": "1.2.3.4/32" }
 				],
 				"dataDir": "%s"
 			    }


### PR DESCRIPTION
Using ptp plugin with non default routes, we get the following error when cri-o call CheckNetworkList():
```
Expected Route {Dst:{IP:198.18.128.0 Mask:ffff8000} GW:<nil>} not found in routing table
```
Using cniVersion 0.3.1 to bypass the check, we can see that the route is added with a gateway
```
$ ip r
198.18.0.0/17 via 198.18.0.1 dev eth0 src 198.18.3.102
198.18.0.1 dev eth0 scope link src 198.18.3.102
198.18.128.0/17 via 198.18.0.1 dev eth0
```

If GW is nil only check if we have a route with a DST that matches, and ignore the GW.

Fixes #886