### PR TITLE
Fix race conditions in DHCP test

### DIFF
--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -332,9 +332,17 @@ var _ = Describe("DHCP Operations", func() {
 					started.Done()
 					started.Wait()
 
-					err = originalNS.Do(func(ns.NetNS) error {
+					err := originalNS.Do(func(ns.NetNS) error {
 						return testutils.CmdDelWithArgs(args, func() error {
-							return cmdDel(args)
+							copiedArgs := &skel.CmdArgs{
+								ContainerID: args.ContainerID,
+								Netns:       args.Netns,
+								IfName:      args.IfName,
+								StdinData:   args.StdinData,
+								Path:        args.Path,
+								Args:        args.Args,
+							}
+							return cmdDel(copiedArgs)
 						})
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -15,7 +15,7 @@ source ./build_linux.sh
 echo "Running tests"
 
 function testrun {
-    sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test $@"
+    sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race $@"
 }
 
 COVERALLS=${COVERALLS:-""}
@@ -31,7 +31,7 @@ PKG=${PKG:-$(go list ./... | xargs echo)}
 i=0
 for t in ${PKG}; do
     if [ -n "${COVERALLS}" ]; then
-        COVERFLAGS="-covermode set -coverprofile ${i}.coverprofile"
+        COVERFLAGS="-covermode atomic -coverprofile ${i}.coverprofile"
     fi
     echo "${t}"
     testrun "${COVERFLAGS:-""} ${t}"

--- a/test_windows.sh
+++ b/test_windows.sh
@@ -17,4 +17,4 @@ for d in $PLUGINS; do
 done
 
 echo "testing packages $PKGS"
-go test -v $PKGS -ginkgo.randomizeAllSpecs -ginkgo.failOnPending -ginkgo.progress
+go test -race -v $PKGS -ginkgo.randomizeAllSpecs -ginkgo.failOnPending -ginkgo.progress


### PR DESCRIPTION
This PR addresses the race conditions discovered during local testing using the Go race command. 

The test named "correctly handles multiple DELs for the same container" in the ipam/dhcp package experiences race conditions when multiple goroutines concurrently access and modify the Args struct (of type CmdArgs). 
Before applying the fix, the race detector logs indicated conflicting accesses as can be seen here:

```
==================
WARNING: DATA RACE
Write at 0x00c00031e630 by goroutine 210:
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.rpcCall()](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.rpcCall())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/main.go:165 +0x35c
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.cmdDel()](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.cmdDel())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/main.go:121 +0x4a
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.glob](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.glob)..func3.4.2.1.1()
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/dhcp_test.go:337 +0x4b
  [github.com/containernetworking/plugins/pkg/testutils.CmdDel()](http://github.com/containernetworking/plugins/pkg/testutils.CmdDel())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/testutils/cmd.go:107 +0x136
  [github.com/containernetworking/plugins/pkg/testutils.CmdDelWithArgs()](http://github.com/containernetworking/plugins/pkg/testutils.CmdDelWithArgs())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/testutils/cmd.go:111 +0xc4
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.glob](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.glob)..func3.4.2.1()
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/dhcp_test.go:336 +0x2e
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:197 +0x36e
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:218 +0xc8

Previous read at 0x00c00031e630 by goroutine 211:
  [github.com/containernetworking/plugins/pkg/testutils.CmdDelWithArgs()](http://github.com/containernetworking/plugins/pkg/testutils.CmdDelWithArgs())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/testutils/cmd.go:111 +0x57
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.glob](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.glob)..func3.4.2.1()
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/dhcp_test.go:336 +0x2e
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:197 +0x36e
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:218 +0xc8

Goroutine 210 (running) created at:
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:215 +0x517
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.glob](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.glob)..func3.4.2()
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/dhcp_test.go:335 +0x14e

Goroutine 211 (running) created at:
  [github.com/containernetworking/plugins/pkg/ns.(*netNS).Do()](http://github.com/containernetworking/plugins/pkg/ns.(*netNS).Do())
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/pkg/ns/ns_linux.go:215 +0x517
  [github.com/containernetworking/plugins/plugins/ipam/dhcp.glob](http://github.com/containernetworking/plugins/plugins/ipam/dhcp.glob)..func3.4.2()
      /home/asudakov/go/src/github.com/AlinaSecret/plugins/plugins/ipam/dhcp/dhcp_test.go:335 +0x14e
==================
```


To address these issues, a copy of the CmdArgs struct is now created in each function to eliminate data races.

Also, the test-linux.sh and test-windows.sh scripts have been updated to include the '-race' flag, enabling race detection during testing. This change helps prevent future race conditions by activating the Go race detector.

for further reference about race detection view: https://go.dev/doc/articles/race_detector)