### PR TITLE
Two minor testsuite fixes

### DIFF
--- a/plugins/meta/firewall/firewall_firewalld_test.go
+++ b/plugins/meta/firewall/firewall_firewalld_test.go
@@ -86,7 +86,8 @@ func spawnSessionDbus(wg *sync.WaitGroup) (string, *exec.Cmd) {
 	bytes, err := bufio.NewReader(stdout).ReadString('\n')
 	Expect(err).NotTo(HaveOccurred())
 	busAddr := strings.TrimSpace(bytes)
-	Expect(strings.HasPrefix(busAddr, "unix:abstract")).To(BeTrue())
+	Expect(strings.HasPrefix(busAddr, "unix:abstract") ||
+		strings.HasPrefix(busAddr, "unix:path")).To(BeTrue())
 
 	var startWg sync.WaitGroup
 	wg.Add(1)

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -39,5 +39,5 @@ for t in ${PKG}; do
 done
 
 # Run the pkg/ns tests as non root user
-mkdir /tmp/cni-rootless
+mkdir -p /tmp/cni-rootless
 (export XDG_RUNTIME_DIR=/tmp/cni-rootless; cd pkg/ns/; unshare -rmn go test)


### PR DESCRIPTION
Patch 1 fixes for unexpected output from dbus-daemon on Fedora Rawhide, patch 2 fixes a spurious error when calling test_linux.sh a second time.