### PR TITLE
Review code using go-iptables module

### DIFF
--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -29,9 +29,9 @@ func EnsureChain(ipt *iptables.IPTables, table, chain string) error {
 	if ipt == nil {
 		return errors.New("failed to ensure iptable chain: IPTables was nil")
 	}
-	exists, err := ChainExists(ipt, table, chain)
+	exists, err := ipt.ChainExists(table, chain)
 	if err != nil {
-		return fmt.Errorf("failed to list iptables chains: %v", err)
+		return fmt.Errorf("failed to check iptables chain existence: %v", err)
 	}
 	if !exists {
 		err = ipt.NewChain(table, chain)
@@ -43,24 +43,6 @@ func EnsureChain(ipt *iptables.IPTables, table, chain string) error {
 		}
 	}
 	return nil
-}
-
-// ChainExists checks whether an iptables chain exists.
-func ChainExists(ipt *iptables.IPTables, table, chain string) (bool, error) {
-	if ipt == nil {
-		return false, errors.New("failed to check iptable chain: IPTables was nil")
-	}
-	chains, err := ipt.ListChains(table)
-	if err != nil {
-		return false, err
-	}
-
-	for _, ch := range chains {
-		if ch == chain {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // DeleteRule idempotently delete the iptables rule in the specified table/chain.

--- a/plugins/meta/portmap/chain.go
+++ b/plugins/meta/portmap/chain.go
@@ -103,7 +103,7 @@ func (c *chain) teardown(ipt *iptables.IPTables) error {
 
 // check the chain.
 func (c *chain) check(ipt *iptables.IPTables) error {
-	exists, err := utils.ChainExists(ipt, c.table, c.name)
+	exists, err := ipt.ChainExists(c.table, c.name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Patch 1 makes callers use the module-provided ChainExists() method, it is faster than the custom implementation. This does not bump dependencies, the required version of go-iptables in go.mod is already sufficient.
Patch 2 tries to speed up meta/portmap plugin's teardown() by avoiding an expensive ipt.List() call (in big rulesets). Make it fall back to the old code for unexpected cases.