### PR TITLE
vrf: fix route filter to use output iface

### DIFF
--- a/plugins/meta/vrf/vrf.go
+++ b/plugins/meta/vrf/vrf.go
@@ -111,7 +111,7 @@ func addInterface(vrf *netlink.Vrf, intf string) error {
 		LinkIndex: i.Attrs().Index,
 		Scope:     netlink.SCOPE_UNIVERSE, // Exclude local and connected routes
 	}
-	filterMask := netlink.RT_FILTER_IIF | netlink.RT_FILTER_SCOPE // Filter based on link index and scope
+	filterMask := netlink.RT_FILTER_OIF | netlink.RT_FILTER_SCOPE // Filter based on link index and scope
 	routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, filter, filterMask)
 	if err != nil {
 		return fmt.Errorf("failed getting all routes for %s", intf)


### PR DESCRIPTION
# Summary
The route filter currently filters based on the `LinkIndex` and `Scope`. The corresponding filter flag for `LinkIndex` should be `netlink.RT_FILTER_OIF`, and not `netlink.RT_FILTER_IIF`. This renders the filter ineffective, causing the wrong routes to be copied into the new VRF.

The [netlink code here](https://github.com/vishvananda/netlink/blob/v1.2.1-beta.2/route_linux.go#L1056-L1059) tells us which filter flags corresponds to which field.

# Example
I have a k8s cluster that's using Multus to have multiple interfaces. Here's a concrete example demonstrating this issue:
1. create a pod with 2 interfaces, the default pod CNI and an additional one, say, the bridge CNI
```
# ip -4 -br a
lo               UNKNOWN        127.0.0.1/8
eth0@if398       UP             10.244.2.151/24
net1@if399       UP             10.8.1.1/24
```
2. on the second CNI, we also chain the VRF plugin
```
# ip vrf
Name              Table
-----------------------
gateway              1
```
3. we see that the routes that are being added into the new VRF also has the routes that's being used for pod networking
```
# ip route
default via 10.244.2.1 dev eth0
10.244.0.0/16 via 10.244.2.1 dev eth0
10.244.2.0/24 dev eth0 proto kernel scope link src 10.244.2.151

# ip route list vrf gateway
default via 10.244.2.1 dev eth0
10.8.1.0/24 dev net1 proto kernel scope link src 10.8.1.1
10.244.0.0/16 via 10.244.2.1 dev eth0
``` 
4. what we want to see instead:
```
# ip route list vrf gateway
default via 10.8.1.1 dev net1
10.8.1.0/24 dev net1 proto kernel scope link src 10.8.1.1
```

# PR notes
- I've added a test scenario roughly equivalent to the above description
- I've changed `checkRoutesOnVRF` to filter only based on the table ID so we can check the `LinkIndex` of the routes that were copied to the new VRF