### PR TITLE
ci(lint) extend timeout to 5 min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,4 @@ linters-settings:
 run:
   skip-dirs:
     - vendor
+  timeout: 5m


### PR DESCRIPTION
This extends the timeout or golangci-lint execution to 5 min as it is only one minute now it fails for several PR.