### PR TITLE
build: Use POSIX sh for shell scripts

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 cd "$(dirname "$0")"
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
 	export GOOS="${GOOS:-linux}"
 fi
 

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 cd "$(dirname "$0")"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Run CNI plugin tests.
 # 
@@ -10,12 +10,12 @@ set -e
 cd "$(dirname "$0")"
 
 # Build all plugins before testing
-source ./build_linux.sh
+. ./build_linux.sh
 
 echo "Running tests"
 
-function testrun {
-    sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race $@"
+testrun() {
+    sudo -E sh -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race $*"
 }
 
 COVERALLS=${COVERALLS:-""}

--- a/test_windows.sh
+++ b/test_windows.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Run CNI plugin tests.
 #
 set -e
 cd "$(dirname "$0")"
 
-source ./build_windows.sh
+. ./build_windows.sh
 
 echo "Running tests"
 


### PR DESCRIPTION
The scripts didn't really use any bash specific features. Convert them to POSIX shell scripts, so that the plugins can be built without requiring bash.