### PR TITLE
Create IPAM files with 0600 permissions

### DIFF
--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -60,7 +60,7 @@ func New(network, dataDir string) (*Store, error) {
 func (s *Store) Reserve(id string, ifname string, ip net.IP, rangeID string) (bool, error) {
 	fname := GetEscapedPath(s.dataDir, ip.String())
 
-	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0o644)
+	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0o600)
 	if os.IsExist(err) {
 		return false, nil
 	}
@@ -78,7 +78,7 @@ func (s *Store) Reserve(id string, ifname string, ip net.IP, rangeID string) (bo
 	}
 	// store the reserved ip in lastIPFile
 	ipfile := GetEscapedPath(s.dataDir, lastIPFilePrefix+rangeID)
-	err = os.WriteFile(ipfile, []byte(ip.String()), 0o644)
+	err = os.WriteFile(ipfile, []byte(ip.String()), 0o600)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Conform to CIS Benchmarks "1.1.9 Ensure that the Container Network Interface file permissions are set to 600 or more restrictive" https://www.tenable.com/audits/items/CIS_Kubernetes_v1.20_v1.0.1_Level_1_Master.audit:f1717a5dd65d498074dd41c4a639e47d

https://issues.redhat.com/browse/OCPBUGS-16788