### PR TITLE
macvlan cmdDel: replace the loadConf function with json.unmarshal

### DIFF
--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -382,13 +382,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	n, _, err := loadConf(args, args.Args)
+	var n NetConf
+	err := json.Unmarshal(args.StdinData, &n)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load netConf: %v", err)
 	}
 
 	isLayer3 := n.IPAM.Type != ""
-
 	if isLayer3 {
 		err = ipam.ExecDel(n.IPAM.Type, args.StdinData)
 		if err != nil {


### PR DESCRIPTION
When the master interface on the node has been deleted, and loadConf tries 
to get the MTU, This causes cmdDel to return a linkNotFound error to the
runtime. The cmdDel only needs to unmarshal the net config. No need to
get the MTU. So we just replaced the loadConf function with
json.unmarshal in cmdDel.

Fixes https://github.com/containernetworking/plugins/issues/953