### PR TITLE
dependabot: batch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      golang:
+        patterns:
+          - "*"


### PR DESCRIPTION
Rather than endless rebases, just batch all go updates to once a week.