### PR TITLE
bridge: remove useless code

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -729,7 +729,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Use incoming DNS settings if provided, otherwise use the
-	// settings that were already configued by the IPAM plugin
+	// settings that were already configured by the IPAM plugin
 	if dnsConfSet(n.DNS) {
 		result.DNS = n.DNS
 	}

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -629,14 +629,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 
 		if n.IsGW {
-			var firstV4Addr net.IP
 			var vlanInterface *current.Interface
 			// Set the IP address(es) on the bridge and enable forwarding
 			for _, gws := range []*gwInfo{gwsV4, gwsV6} {
 				for _, gw := range gws.gws {
-					if gw.IP.To4() != nil && firstV4Addr == nil {
-						firstV4Addr = gw.IP
-					}
 					if n.Vlan != 0 {
 						vlanIface, err := ensureVlanInterface(br, n.Vlan, n.PreserveDefaultVlan)
 						if err != nil {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -240,7 +240,7 @@ func calcGateways(result *current.Result, n *NetConf) (*gwInfo, *gwInfo, error) 
 
 		// Add a default route for this family using the current
 		// gateway address if necessary.
-		if n.IsDefaultGW && !gws.defaultRouteFound {
+		if n.IsDefaultGW {
 			for _, route := range result.Routes {
 				if route.GW != nil && defaultNet.String() == route.Dst.String() {
 					gws.defaultRouteFound = true


### PR DESCRIPTION
gws.defaultRouteFound is always false.
firstV4Addr it is declared but not used anywhere in the code.