### PR TITLE
allow configuring numTxQueues and numRxQueues for macvlan and ipvlan

### DIFF
--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -38,6 +38,7 @@ type NetConf struct {
 	Master     string `json:"master"`
 	Mode       string `json:"mode"`
 	MTU        int    `json:"mtu"`
+	Queues     int    `json:"queues,omitempty"`
 	LinkContNs bool   `json:"linkInContainer,omitempty"`
 }
 
@@ -87,6 +88,10 @@ func loadConf(args *skel.CmdArgs, cmdCheck bool) (*NetConf, string, error) {
 			}
 		}
 	}
+	if n.Queues < 0 {
+		return nil, "", fmt.Errorf("invalid Queues %d, must be greater than 0", n.Queues)
+	}
+
 	return n, n.CNIVersion, nil
 }
 
@@ -149,6 +154,8 @@ func createIpvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Interf
 			MTU:         conf.MTU,
 			Name:        tmpName,
 			ParentIndex: m.Attrs().Index,
+			NumTxQueues: conf.Queues,
+			NumRxQueues: conf.Queues,
 			Namespace:   netlink.NsFd(int(netns.Fd())),
 		},
 		Mode: mode,

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -343,6 +343,7 @@ var _ = Describe("ipvlan Operations", func() {
 					Master:     masterInterface,
 					Mode:       "l2",
 					MTU:        1500,
+					Queues:     20,
 					LinkContNs: isInContainer,
 				}
 

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -39,6 +39,7 @@ type NetConf struct {
 	Master     string `json:"master"`
 	Mode       string `json:"mode"`
 	MTU        int    `json:"mtu"`
+	Queues     int    `json:"queues,omitempty"`
 	Mac        string `json:"mac,omitempty"`
 	LinkContNs bool   `json:"linkInContainer,omitempty"`
 
@@ -122,6 +123,9 @@ func loadConf(args *skel.CmdArgs, envArgs string) (*NetConf, string, error) {
 	}
 	if n.MTU < 0 || n.MTU > masterMTU {
 		return nil, "", fmt.Errorf("invalid MTU %d, must be [0, master MTU(%d)]", n.MTU, masterMTU)
+	}
+	if n.Queues < 0 {
+		return nil, "", fmt.Errorf("invalid Queues %d, must be greater than 0", n.Queues)
 	}
 
 	if envArgs != "" {
@@ -229,6 +233,8 @@ func createMacvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Inter
 		MTU:         conf.MTU,
 		Name:        tmpName,
 		ParentIndex: m.Attrs().Index,
+		NumTxQueues: conf.Queues,
+		NumRxQueues: conf.Queues,
 		Namespace:   netlink.NsFd(int(netns.Fd())),
 	}
 

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -271,6 +271,7 @@ var _ = Describe("macvlan Operations", func() {
 					Master:     masterInterface,
 					Mode:       "bridge",
 					MTU:        1500,
+					Queues:     20,
 					LinkContNs: isInContainer != nil && *isInContainer,
 				}
 


### PR DESCRIPTION
Adding a new configuration option: 'queues,' which is used to configure the "numtxqueues" and "numrxqueues" properties of the network card. It can only be a non-negative integer or 0. The default is 0, indicating that netlink API will configure the default numqueues as 1. In scenarios where network bandwidth sensitivity is crucial, allowing the configuration of numqueues will enhance network bandwidth.

Fixes https://github.com/containernetworking/plugins/issues/985

related-link: https://github.com/projectcalico/cni-plugin/pull/1116