### PR TITLE
Add github action to build binaries for each platform at release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,106 @@
+---
+name: Release binaries
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  linux_release:
+    name: Release linux binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm, arm64, mips64le, ppc64le, riscv64, s390x]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: ./build_linux.sh
+
+      - name: COPY files
+        run: cp README.md LICENSE bin/
+
+      - name: Create dist directory
+        run: mkdir dist
+
+      - name: Create archive file
+        working-directory: ./bin
+        run: tar cfzv ../dist/cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
+
+      - name: Create sha256 checksum
+        working-directory: ./dist
+        run: sha256sum cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz | tee cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz.sha256
+
+      - name: Create sha512 checksum
+        working-directory: ./dist
+        run: sha512sum cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz | tee cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz.sha512
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./dist/*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+  windows_releases:
+    name: Release windows binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64]
+    steps:
+      - name: Install dos2unix
+        run: sudo apt-get install dos2unix
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: ./build_windows.sh
+
+      - name: COPY files
+        run: cp README.md LICENSE bin/
+
+      - name: Create dist directory
+        run: mkdir dist
+
+      - name: Create archive file
+        working-directory: ./bin
+        run: tar cfzv ../dist/cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
+
+      - name: Create sha256 checksum
+        working-directory: ./dist
+        run: sha256sum cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz | tee cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz.sha256
+
+      - name: Create sha512 checksum
+        working-directory: ./dist
+        run: sha512sum cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz | tee cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz.sha512
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./dist/*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
This change introduces new github action to build cni plugin binaries for each platform at tagged new release.