### PR TITLE
Update golangci-lint-action package to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           format: auto
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.55.2
           args: -v

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -790,7 +790,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return err
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/dummy/dummy.go
+++ b/plugins/main/dummy/dummy.go
@@ -136,7 +136,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	err = netns.Do(func(_ ns.NetNS) error {
 		return ipam.ConfigureIface(args.IfName, result)
 	})
-
 	if err != nil {
 		return err
 	}
@@ -165,7 +164,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return err
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -371,7 +371,7 @@ var _ = Describe("dummy Operations", func() {
 				StdinData:   []byte(fmt.Sprintf(confFmt, ver)),
 			}
 
-			_ = originalNS.Do(func(netNS ns.NetNS) error {
+			_ = originalNS.Do(func(_ ns.NetNS) error {
 				defer GinkgoRecover()
 
 				_, _, err = testutils.CmdAddWithArgs(args, func() error {

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -334,7 +334,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -411,7 +411,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/tap/tap.go
+++ b/plugins/main/tap/tap.go
@@ -371,7 +371,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -244,7 +244,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return err
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -499,7 +499,7 @@ var _ = Describe("vlan Operations", func() {
 						StdinData:   []byte(fmt.Sprintf(confFmt, ver, masterInterface, 1600, isInContainer, dataDir)),
 					}
 
-					_ = originalNS.Do(func(netNS ns.NetNS) error {
+					_ = originalNS.Do(func(_ ns.NetNS) error {
 						defer GinkgoRecover()
 
 						_, _, err = testutils.CmdAddWithArgs(args, func() error {
@@ -520,7 +520,7 @@ var _ = Describe("vlan Operations", func() {
 						StdinData:   []byte(fmt.Sprintf(confFmt, ver, masterInterface, -100, isInContainer, dataDir)),
 					}
 
-					_ = originalNS.Do(func(netNS ns.NetNS) error {
+					_ = originalNS.Do(func(_ ns.NetNS) error {
 						defer GinkgoRecover()
 
 						_, _, err = testutils.CmdAddWithArgs(args, func() error {

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -165,7 +165,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					r, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 					Expect(err).NotTo(HaveOccurred(), string(out))
@@ -202,7 +202,7 @@ var _ = Describe("bandwidth test", func() {
 					return nil
 				})).To(Succeed())
 
-				Expect(hostNs.Do(func(n ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					ifbLink, err := netlink.LinkByName(hostIfname)
@@ -260,7 +260,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
@@ -271,7 +271,7 @@ var _ = Describe("bandwidth test", func() {
 					return nil
 				})).To(Succeed())
 
-				Expect(hostNs.Do(func(n ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					containerIfLink, err := netlink.LinkByName(hostIfname)
@@ -327,7 +327,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, ifbDeviceName, []byte(conf), func() error { return cmdAdd(args) })
@@ -338,7 +338,7 @@ var _ = Describe("bandwidth test", func() {
 					return nil
 				})).To(Succeed())
 
-				Expect(hostNs.Do(func(n ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					containerIfLink, err := netlink.LinkByName(hostIfname)
@@ -396,7 +396,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
@@ -448,7 +448,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					r, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 					Expect(err).NotTo(HaveOccurred(), string(out))
@@ -485,7 +485,7 @@ var _ = Describe("bandwidth test", func() {
 					return nil
 				})).To(Succeed())
 
-				Expect(hostNs.Do(func(n ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					ifbLink, err := netlink.LinkByName(hostIfname)
@@ -551,7 +551,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
@@ -601,7 +601,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					_, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 					Expect(err).NotTo(HaveOccurred(), string(out))
@@ -669,7 +669,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 					r, out, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
 					Expect(err).NotTo(HaveOccurred(), string(out))
@@ -706,7 +706,7 @@ var _ = Describe("bandwidth test", func() {
 					return nil
 				})).To(Succeed())
 
-				Expect(hostNs.Do(func(n ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					ifbLink, err := netlink.LinkByName(hostIfname)
@@ -768,7 +768,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
@@ -801,7 +801,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })
@@ -853,7 +853,7 @@ var _ = Describe("bandwidth test", func() {
 					StdinData:   []byte(conf),
 				}
 
-				Expect(hostNs.Do(func(netNS ns.NetNS) error {
+				Expect(hostNs.Do(func(_ ns.NetNS) error {
 					defer GinkgoRecover()
 
 					_, _, err := testutils.CmdAdd(containerNs.Path(), args.ContainerID, "", []byte(conf), func() error { return cmdAdd(args) })

--- a/plugins/meta/sbr/main.go
+++ b/plugins/meta/sbr/main.go
@@ -66,7 +66,6 @@ func withLockAndNetNS(nspath string, toRun func(_ ns.NetNS) error) error {
 	}
 
 	err = ns.WithNetNSPath(nspath, toRun)
-
 	if err != nil {
 		return err
 	}

--- a/plugins/meta/vrf/main.go
+++ b/plugins/meta/vrf/main.go
@@ -75,7 +75,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("cmdAdd failed: %v", err)
 	}
@@ -121,7 +120,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
 		// so don't return an error if the device is already removed.


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change renames unused parameters in test to resolve linter warnings. It also updates golangci-lint-action package to v4 to resolve NodeJS 16 deprecation warnings.

### Testing:
Lint check passes without deprecation warnings

### Additional References:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/