### PR TITLE
Update to Go v1.22 in CI and release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ name: test
 on: ["push", "pull_request"]
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
   LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le riscv64"
 
 jobs:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@ set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"
 DOCKER="${DOCKER:-docker}"
-GOLANG="${GOLANG:-golang:1.21-alpine}"
+GOLANG="${GOLANG:-golang:1.22-alpine}"
 
 TAG=$(git describe --tags --dirty)
 RELEASE_DIR=release-${TAG}


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change updates the version of Go in CI and release to Go v1.22

### Additional resources:
- https://go.dev/doc/go1.22