### PR TITLE
Fix version of golangci-lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
           format: auto
       - uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.55.2
           args: -v
           skip-cache: true
   build:


### PR DESCRIPTION
currently the workflow will use latest
version which is a moving target.

newer versions may cause ci failures due
to new checks added.