### PR TITLE
bandwidth: introduce configurable queue length

### DIFF
--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -295,8 +295,10 @@ var _ = Describe("bandwidth test", func() {
 					"type": "bandwidth",
 					"egressRate": 0,
 					"egressBurst": 0,
+					"egressLatency": 0,
 					"ingressRate": 8000,
 					"ingressBurst": 80,
+					"ingressLatency": 25000,
 					"prevResult": {
 						"interfaces": [
 							{


### PR DESCRIPTION
Currently, the bandwidth plugin uses tc tbf and set default latency to 25ms, which easily causes Head-Of-Line blocking and bufferbloat. This commit proposes to make it a configurable value.