### PR TITLE
ip: include peer name in error message

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -90,7 +90,7 @@ func makeVeth(name, vethPeerName string, mtu int, mac string, hostNS ns.NetNS) (
 			if peerExists(peerName) && vethPeerName == "" {
 				continue
 			}
-			return peerName, veth, fmt.Errorf("container veth name provided (%v) already exists", name)
+			return peerName, veth, fmt.Errorf("container veth name (%q) peer provided (%q) already exists", name, peerName)
 		default:
 			return peerName, veth, fmt.Errorf("failed to make veth pair: %v", err)
 		}

--- a/pkg/ip/link_linux_test.go
+++ b/pkg/ip/link_linux_test.go
@@ -149,9 +149,9 @@ var _ = Describe("Link", func() {
 		It("returns useful error", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
-
-				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
-				Expect(err.Error()).To(Equal(fmt.Sprintf("container veth name provided (%s) already exists", containerVethName)))
+				testHostVethName := "test" + hostVethName
+				_, _, err := ip.SetupVethWithName(containerVethName, testHostVethName, mtu, "", hostNetNS)
+				Expect(err.Error()).To(Equal(fmt.Sprintf("container veth name (%q) peer provided (%q) already exists", containerVethName, testHostVethName)))
 
 				return nil
 			})
@@ -180,9 +180,8 @@ var _ = Describe("Link", func() {
 		It("returns useful error", func() {
 			_ = containerNetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
-				_, _, err := ip.SetupVeth(containerVethName, mtu, "", hostNetNS)
-				Expect(err.Error()).To(HavePrefix("container veth name provided"))
-				Expect(err.Error()).To(HaveSuffix("already exists"))
+				_, _, err := ip.SetupVethWithName(containerVethName, hostVethName, mtu, "", hostNetNS)
+				Expect(err.Error()).To(Equal(fmt.Sprintf("container veth name (%q) peer provided (%q) already exists", containerVethName, hostVethName)))
 				return nil
 			})
 		})


### PR DESCRIPTION
If makeVeth fails as a peer exists, the existing peer name should be included in the error message.