### PR TITLE
Fix release script in github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
-        run: ./build_linux.sh
+        run: ./build_linux.sh -ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${{ github.ref_name }}'
 
       - name: COPY files
         run: cp README.md LICENSE bin/
@@ -76,7 +76,7 @@ jobs:
         env:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
-        run: ./build_windows.sh
+        run: ./build_windows.sh -ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${{ github.ref_name }}'
 
       - name: COPY files
         run: cp README.md LICENSE bin/


### PR DESCRIPTION
This changes adds BuildVersion linker flag in release to fix CNI plugins output. Fixes #1019.