### PR TITLE
dependabot: don't automatically update cni packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
       golang:
         patterns:
           - "*"
+        exclude-patterns:
+          - "github.com/containernetworking/*"


### PR DESCRIPTION
We should manage their lifecycle separately.