### PR TITLE
Updated the hardcoded dependencies

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -7,7 +7,7 @@ export GOOS=windows
 export GOFLAGS="${GOFLAGS} -mod=vendor"
 echo "$GOFLAGS"
 
-PLUGINS=$(cat plugins/windows_only.txt | dos2unix )
+PLUGINS=$(cat plugins/windows_only.txt | sed 's/\r//' )
 for d in $PLUGINS; do
 	plugin="$(basename "$d").exe"
 	echo "building $plugin"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,12 +3,27 @@ set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"
 DOCKER="${DOCKER:-docker}"
-GOLANG="${GOLANG:-golang:1.22-alpine}"
 
-TAG=$(git describe --tags --dirty)
+GO_IMAGE="${GO_IMAGE:-golang}"
+GO_VERSION="${GO_VERSION:-1.22-alpine}"
+GOLANG="${GO_IMAGE}:${GO_VERSION}"
+
+_defaultTag=$(git describe --tags --dirty)
+TAG=${TAG:-$_defaultTag}
 RELEASE_DIR=release-${TAG}
 
-BUILDFLAGS="-ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG}'"
+DOCKER_RUN_ARGS=${DOCKER_RUN_ARGS:-'-ti'}
+
+CGO_ENABLED="${CGO_ENABLED:-0}"
+EXTLDFLAGS_LINUX=""
+if [ "${CGO_ENABLED}" == "0" ]; then
+  EXTLDFLAGS_LINUX="-extldflags -static"
+fi
+
+GOARCH_LIST="${GOARCH_LIST:-amd64 arm arm64 ppc64le s390x mips64le riscv64}"
+
+BUILDFLAGS_LINUX="-ldflags '${EXTLDFLAGS_LINUX} -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG}'"
+BUILDFLAGS_WINDOWS="-ldflags '-extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${TAG}'"
 
 OUTPUT_DIR=bin
 
@@ -17,14 +32,18 @@ rm -Rf ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${OUTPUT_DIR}
 
-$DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm "${GOLANG}" \
+$DOCKER run ${DOCKER_RUN_ARGS} -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm "${GOLANG}" \
 /bin/sh -xe -c "\
-    apk --no-cache add bash tar;
+    for cmd in bash tar; do
+      command -v apk && apk --no-cache add \$cmd
+      command -v \$cmd || (echo \$cmd not found && exit 1);
+    done
+
     cd /go/src/github.com/containernetworking/plugins; umask 0022;
 
-    for arch in amd64 arm arm64 ppc64le s390x mips64le riscv64; do \
+    for arch in ${GOARCH_LIST}; do \
         rm -f ${OUTPUT_DIR}/*; \
-        CGO_ENABLED=0 GOARCH=\$arch ./build_linux.sh ${BUILDFLAGS}; \
+        CGO_ENABLED=${CGO_ENABLED} GOARCH=\$arch ./build_linux.sh ${BUILDFLAGS_LINUX}; \
         for format in tgz; do \
             FILENAME=cni-plugins-linux-\$arch-${TAG}.\$format; \
             FILEPATH=${RELEASE_DIR}/\$FILENAME; \
@@ -33,7 +52,7 @@ $DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z -
     done;
 
     rm -rf ${OUTPUT_DIR}/*; \
-    CGO_ENABLED=0 GOARCH=amd64 ./build_windows.sh ${BUILDFLAGS}; \
+    CGO_ENABLED=0 GOARCH=amd64 ./build_windows.sh ${BUILDFLAGS_WINDOWS}; \
     for format in tgz; do \
         FILENAME=cni-plugins-windows-amd64-${TAG}.\$format; \
         FILEPATH=${RELEASE_DIR}/\$FILENAME; \


### PR DESCRIPTION
The PR fixes the following changes-

- Allow default `run` args `-it` to be overridden by specifying `DOCKER_RUN_ARGS`.
-  Introduce `GO_IMAGE` and `GO_VERSION` to allow the compiliation docker image to be specified.
- Add logic to handle the case where a non `alpine` golang image is used so that the script no longer blindly attempts to `apk` install `bash` and `tar`. Scripts checks for presence of both commands.
- Avoid using dos2unix, use sed