### PR TITLE
Fix release tar images' owner to root

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,12 +30,16 @@ jobs:
       - name: COPY files
         run: cp README.md LICENSE bin/
 
+      - name: Change plugin file ownership
+        working-directory: ./bin
+        run: sudo chown root:root ./*
+
       - name: Create dist directory
         run: mkdir dist
 
       - name: Create archive file
         working-directory: ./bin
-        run: tar cfzv ../dist/cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
+        run: tar cfzpv ../dist/cni-plugins-linux-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
 
       - name: Create sha256 checksum
         working-directory: ./dist
@@ -81,12 +85,16 @@ jobs:
       - name: COPY files
         run: cp README.md LICENSE bin/
 
+      - name: Change plugin file ownership
+        working-directory: ./bin
+        run: sudo chown root:root ./*
+
       - name: Create dist directory
         run: mkdir dist
 
       - name: Create archive file
         working-directory: ./bin
-        run: tar cfzv ../dist/cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
+        run: tar cpfzv ../dist/cni-plugins-windows-${{ matrix.goarch }}-${{ github.ref_name }}.tgz .
 
       - name: Create sha256 checksum
         working-directory: ./dist


### PR DESCRIPTION
Fix #1053

Results with fixed one with this PR
```
$ curl -LO https://github.com/s1061123/plugin-dummy/releases/download/v1.0.0/cni-plugins-linux-amd64-v1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 45.9M  100 45.9M    0     0  9299k      0  0:00:05  0:00:05 --:--:-- 9920k
$ tar tvzfp cni-plugins-linux-amd64-v1.0.0.tgz
drwxr-xr-x runner/docker     0 2024-06-17 10:37 ./
-rwxr-xr-x root/root  11423522 2024-06-17 10:37 ./dhcp
-rwxr-xr-x root/root   3750466 2024-06-17 10:37 ./loopback
-rw-r--r-- root/root      2343 2024-06-17 10:37 ./README.md
-rwxr-xr-x root/root   4272418 2024-06-17 10:37 ./bandwidth
-rwxr-xr-x root/root   4447481 2024-06-17 10:37 ./ipvlan
-rwxr-xr-x root/root   4440184 2024-06-17 10:37 ./vlan
-rwxr-xr-x root/root   3223971 2024-06-17 10:37 ./static
-rwxr-xr-x root/root   4344900 2024-06-17 10:37 ./host-device
-rw-r--r-- root/root     11357 2024-06-17 10:37 ./LICENSE
-rwxr-xr-x root/root   4791599 2024-06-17 10:37 ./bridge
-rwxr-xr-x root/root   4424538 2024-06-17 10:37 ./dummy
-rwxr-xr-x root/root   3837619 2024-06-17 10:37 ./tuning
-rwxr-xr-x root/root   4103132 2024-06-17 10:37 ./vrf
-rwxr-xr-x root/root   4503406 2024-06-17 10:37 ./tap
-rwxr-xr-x root/root   4228036 2024-06-17 10:37 ./portmap
-rwxr-xr-x root/root   4947598 2024-06-17 10:37 ./firewall
-rwxr-xr-x root/root   4602449 2024-06-17 10:37 ./ptp
-rwxr-xr-x root/root   3679255 2024-06-17 10:37 ./host-local
-rwxr-xr-x root/root   4479990 2024-06-17 10:37 ./macvlan
-rwxr-xr-x root/root   3956670 2024-06-17 10:37 ./sbr
```

Last CNI release (which contains the issue)
```
$ curl -LO https://github.com/containernetworking/plugins/releases/download/v1.5.0/cni-plugins-linux-amd64-v1.5.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 45.9M  100 45.9M    0     0  9764k      0  0:00:04  0:00:04 --:--:-- 10.7M
$ tar tvfpz cni-plugins-linux-amd64-v1.5.0.tgz
drwxr-xr-x runner/docker     0 2024-05-20 16:23 ./
-rwxr-xr-x runner/docker 11430474 2024-05-20 16:23 ./dhcp
-rwxr-xr-x runner/docker  3750042 2024-05-20 16:23 ./loopback
-rw-r--r-- runner/docker     2343 2024-05-20 16:23 ./README.md
-rwxr-xr-x runner/docker  4272394 2024-05-20 16:23 ./bandwidth
-rwxr-xr-x runner/docker  4440601 2024-05-20 16:23 ./ipvlan
-rwxr-xr-x runner/docker  4439832 2024-05-20 16:23 ./vlan
-rwxr-xr-x runner/docker  3223795 2024-05-20 16:23 ./static
-rwxr-xr-x runner/docker  4344044 2024-05-20 16:23 ./host-device
-rw-r--r-- runner/docker    11357 2024-05-20 16:23 ./LICENSE
-rwxr-xr-x runner/docker  4787319 2024-05-20 16:23 ./bridge
-rwxr-xr-x runner/docker  4422354 2024-05-20 16:23 ./dummy
-rwxr-xr-x runner/docker  3837627 2024-05-20 16:23 ./tuning
-rwxr-xr-x runner/docker  4102988 2024-05-20 16:23 ./vrf
-rwxr-xr-x runner/docker  4503238 2024-05-20 16:23 ./tap
-rwxr-xr-x runner/docker  4228716 2024-05-20 16:23 ./portmap
-rwxr-xr-x runner/docker  4943785 2024-05-20 16:23 ./firewall
-rwxr-xr-x runner/docker  4600833 2024-05-20 16:23 ./ptp
-rwxr-xr-x runner/docker  3679567 2024-05-20 16:23 ./host-local
-rwxr-xr-x runner/docker  4478854 2024-05-20 16:23 ./macvlan
-rwxr-xr-x runner/docker  3956598 2024-05-20 16:23 ./sbr
```