### PR TITLE
macvlan: add bcqueuelen setting

### DIFF
--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -41,6 +41,7 @@ type NetConf struct {
 	MTU        int    `json:"mtu"`
 	Mac        string `json:"mac,omitempty"`
 	LinkContNs bool   `json:"linkInContainer,omitempty"`
+	BcQueueLen uint32 `json:"bcqueuelen,omitempty"`
 
 	RuntimeConfig struct {
 		Mac string `json:"mac,omitempty"`
@@ -244,6 +245,8 @@ func createMacvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Inter
 		LinkAttrs: linkAttrs,
 		Mode:      mode,
 	}
+
+	mv.BCQueueLen = conf.BcQueueLen
 
 	if conf.LinkContNs {
 		err = netns.Do(func(_ ns.NetNS) error {


### PR DESCRIPTION
This setting was introduced in Linux 5.11
https://github.com/torvalds/linux/commit/d4bff72c8401e6f56194ecf455db70ebc22929e2
https://github.com/iproute2/iproute2/commit/42f5642a40a70e2ad0a10563397d6aa714299390