### PR TITLE
SBR: option to pass the table id

### DIFF
--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -119,8 +119,12 @@ func ConfigureIface(ifName string, res *current.Result) error {
 			Gw:        gw,
 		}
 
+		if r.Table != nil {
+			route.Table = *r.Table
+		}
+
 		if err = netlink.RouteAddEcmp(&route); err != nil {
-			return fmt.Errorf("failed to add route '%v via %v dev %v': %v", r.Dst, gw, ifName, err)
+			return fmt.Errorf("failed to add route '%v via %v dev %v (Table: %d)': %v", r.Dst, gw, ifName, route.Table, err)
 		}
 	}
 


### PR DESCRIPTION
Use of Table ID in IPAM

Using the option to set the table number in the SBR meta plugin will create a policy route for each IP added for the interface returned by the main plugin.
Unlike the default behavior, the routes will not be moved to the table.
The default behavior of the SBR plugin is kept if the table id is not set.

https://github.com/containernetworking/cni/pull/1062