### PR TITLE
Fix inadvertent txqueuelen being set to zero

### DIFF
--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -32,11 +32,12 @@ var ErrLinkNotFound = errors.New("link not found")
 
 // makeVethPair is called from within the container's network namespace
 func makeVethPair(name, peer string, mtu int, mac string, hostNS ns.NetNS) (netlink.Link, error) {
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = name
+	linkAttrs.MTU = mtu
+
 	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: name,
-			MTU:  mtu,
-		},
+		LinkAttrs:     linkAttrs,
 		PeerName:      peer,
 		PeerNamespace: netlink.NsFd(int(hostNS.Fd())),
 	}

--- a/pkg/ipam/ipam_linux_test.go
+++ b/pkg/ipam/ipam_linux_test.go
@@ -56,11 +56,12 @@ var _ = Describe("ConfigureIface", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = LINK_NAME
+
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: LINK_NAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(LINK_NAME)

--- a/pkg/ns/README.md
+++ b/pkg/ns/README.md
@@ -13,10 +13,10 @@ The `ns.Do()` method provides **partial** control over network namespaces for yo
 
 ```go
 err = targetNs.Do(func(hostNs ns.NetNS) error {
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = "dummy0"
 	dummy := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: "dummy0",
-		},
+		LinkAttrs: linkAttrs,
 	}
 	return netlink.LinkAdd(dummy)
 })

--- a/pkg/utils/sysctl/sysctl_linux_test.go
+++ b/pkg/utils/sysctl/sysctl_linux_test.go
@@ -48,11 +48,11 @@ var _ = Describe("Sysctl tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		testIfaceName = fmt.Sprintf("cnitest.%d", rand.Intn(100000))
+		testLinkAttrs := netlink.NewLinkAttrs()
+		testLinkAttrs.Name = testIfaceName
+		testLinkAttrs.Namespace = netlink.NsFd(int(testNs.Fd()))
 		testIface := &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:      testIfaceName,
-				Namespace: netlink.NsFd(int(testNs.Fd())),
-			},
+			LinkAttrs: testLinkAttrs,
 		}
 
 		err = netlink.LinkAdd(testIface)

--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -155,11 +155,11 @@ var _ = Describe("DHCP Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = hostVethName
 			err = netlink.LinkAdd(&netlink.Veth{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: hostVethName,
-				},
-				PeerName: contVethName,
+				LinkAttrs: linkAttrs,
+				PeerName:  contVethName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -394,11 +394,11 @@ func dhcpSetupOriginalNS() (chan bool, string, ns.NetNS, ns.NetNS, error) {
 	err = originalNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
+		linkAttrs := netlink.NewLinkAttrs()
+		linkAttrs.Name = hostBridgeName
 		// Create bridge in the "host" (original) NS
 		br = &netlink.Bridge{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: hostBridgeName,
-			},
+			LinkAttrs: linkAttrs,
 		}
 
 		err = netlink.LinkAdd(br)

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -335,16 +335,11 @@ func bridgeByName(name string) (*netlink.Bridge, error) {
 }
 
 func ensureBridge(brName string, mtu int, promiscMode, vlanFiltering bool) (*netlink.Bridge, error) {
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = brName
+	linkAttrs.MTU = mtu
 	br := &netlink.Bridge{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: brName,
-			MTU:  mtu,
-			// Let kernel use default txqueuelen; leaving it unset
-			// means 0, and a zero-length TX queue messes up FIFO
-			// traffic shapers which use TX queue length as the
-			// default packet limit
-			TxQLen: -1,
-		},
+		LinkAttrs: linkAttrs,
 	}
 	if vlanFiltering {
 		br.VlanFiltering = &vlanFiltering

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -1890,10 +1890,10 @@ var _ = Describe("bridge Operations", func() {
 			err := originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = BRNAME
 				err := netlink.LinkAdd(&netlink.Bridge{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: BRNAME,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				link, err := netlink.LinkByName(BRNAME)

--- a/plugins/main/dummy/dummy.go
+++ b/plugins/main/dummy/dummy.go
@@ -43,11 +43,12 @@ func parseNetConf(bytes []byte) (*types.NetConf, error) {
 func createDummy(ifName string, netns ns.NetNS) (*current.Interface, error) {
 	dummy := &current.Interface{}
 
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = ifName
+	linkAttrs.Namespace = netlink.NsFd(int(netns.Fd()))
+
 	dm := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:      ifName,
-			Namespace: netlink.NsFd(int(netns.Fd())),
-		},
+		LinkAttrs: linkAttrs,
 	}
 
 	if err := netlink.LinkAdd(dm); err != nil {

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -180,11 +180,11 @@ var _ = Describe("dummy Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			m, err := netlink.LinkByName(MASTER_NAME)

--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -341,10 +341,10 @@ var _ = Describe("base functionality", func() {
 			// prepare ifname in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -422,10 +422,10 @@ var _ = Describe("base functionality", func() {
 			// prepare host device in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -483,10 +483,10 @@ var _ = Describe("base functionality", func() {
 			// create another conflict host device with same name "dummy0"
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				conflictLink, err = netlink.LinkByName(ifname)
@@ -608,10 +608,10 @@ var _ = Describe("base functionality", func() {
 			// prepare ifname in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -720,10 +720,10 @@ var _ = Describe("base functionality", func() {
 			// prepare ifname in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -912,10 +912,10 @@ var _ = Describe("base functionality", func() {
 			// prepare ifname in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -969,10 +969,10 @@ var _ = Describe("base functionality", func() {
 			// prepare ifname in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -1093,10 +1093,10 @@ var _ = Describe("base functionality", func() {
 			// prepare host device in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(ifname)
@@ -1154,10 +1154,10 @@ var _ = Describe("base functionality", func() {
 			// create another conflict host device with same name "dummy0"
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				conflictLink, err = netlink.LinkByName(ifname)
@@ -1227,10 +1227,10 @@ var _ = Describe("base functionality", func() {
 			// prepare host device in original namespace
 			_ = originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = hostIfname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: hostIfname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				origLink, err = netlink.LinkByName(hostIfname)
@@ -1243,10 +1243,10 @@ var _ = Describe("base functionality", func() {
 			// prepare device in container namespace with same name as host device
 			_ = targetNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = containerAdditionalIfname
 				err := netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: containerAdditionalIfname,
-					},
+					LinkAttrs: linkAttrs,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				containerLink, err = netlink.LinkByName(containerAdditionalIfname)

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -144,14 +144,15 @@ func createIpvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Interf
 		return nil, err
 	}
 
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.MTU = conf.MTU
+	linkAttrs.Name = tmpName
+	linkAttrs.ParentIndex = m.Attrs().Index
+	linkAttrs.Namespace = netlink.NsFd(int(netns.Fd()))
+
 	mv := &netlink.IPVlan{
-		LinkAttrs: netlink.LinkAttrs{
-			MTU:         conf.MTU,
-			Name:        tmpName,
-			ParentIndex: m.Attrs().Index,
-			Namespace:   netlink.NsFd(int(netns.Fd())),
-		},
-		Mode: mode,
+		LinkAttrs: linkAttrs,
+		Mode:      mode,
 	}
 
 	if conf.LinkContNs {

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -281,11 +281,11 @@ var _ = Describe("ipvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(MASTER_NAME)
@@ -297,11 +297,11 @@ var _ = Describe("ipvlan Operations", func() {
 		err = targetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME_INCONTAINER
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME_INCONTAINER,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(MASTER_NAME_INCONTAINER)

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -226,12 +226,11 @@ func createMacvlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Inter
 		return nil, err
 	}
 
-	linkAttrs := netlink.LinkAttrs{
-		MTU:         conf.MTU,
-		Name:        tmpName,
-		ParentIndex: m.Attrs().Index,
-		Namespace:   netlink.NsFd(int(netns.Fd())),
-	}
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.MTU = conf.MTU
+	linkAttrs.Name = tmpName
+	linkAttrs.ParentIndex = m.Attrs().Index
+	linkAttrs.Namespace = netlink.NsFd(int(netns.Fd()))
 
 	if conf.Mac != "" {
 		addr, err := net.ParseMAC(conf.Mac)

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -208,11 +208,11 @@ var _ = Describe("macvlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(MASTER_NAME)
@@ -224,11 +224,11 @@ var _ = Describe("macvlan Operations", func() {
 		err = targetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME_INCONTAINER
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME_INCONTAINER,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(MASTER_NAME_INCONTAINER)

--- a/plugins/main/tap/tap.go
+++ b/plugins/main/tap/tap.go
@@ -137,10 +137,9 @@ func createTapWithIptool(tmpName string, mtu int, multiqueue bool, mac string, o
 }
 
 func createLinkWithNetlink(tmpName string, mtu int, nsFd int, multiqueue bool, mac string, owner *uint32, group *uint32) error {
-	linkAttrs := netlink.LinkAttrs{
-		Name:      tmpName,
-		Namespace: netlink.NsFd(nsFd),
-	}
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = tmpName
+	linkAttrs.Namespace = netlink.NsFd(nsFd)
 	if mtu != 0 {
 		linkAttrs.MTU = mtu
 	}

--- a/plugins/main/tap/tap_test.go
+++ b/plugins/main/tap/tap_test.go
@@ -346,10 +346,10 @@ var _ = Describe("Add, check, remove tap plugin", func() {
 
 			Expect(
 				targetNS.Do(func(ns.NetNS) error {
+					linkAttrs := netlink.NewLinkAttrs()
+					linkAttrs.Name = bridgeName
 					if err := netlink.LinkAdd(&netlink.Bridge{
-						LinkAttrs: netlink.LinkAttrs{
-							Name: bridgeName,
-						},
+						LinkAttrs: linkAttrs,
 					}); err != nil {
 						return err
 					}

--- a/plugins/main/vlan/vlan.go
+++ b/plugins/main/vlan/vlan.go
@@ -119,14 +119,15 @@ func createVlan(conf *NetConf, ifName string, netns ns.NetNS) (*current.Interfac
 		return nil, err
 	}
 
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.MTU = conf.MTU
+	linkAttrs.Name = tmpName
+	linkAttrs.ParentIndex = m.Attrs().Index
+	linkAttrs.Namespace = netlink.NsFd(int(netns.Fd()))
+
 	v := &netlink.Vlan{
-		LinkAttrs: netlink.LinkAttrs{
-			MTU:         conf.MTU,
-			Name:        tmpName,
-			ParentIndex: m.Attrs().Index,
-			Namespace:   netlink.NsFd(int(netns.Fd())),
-		},
-		VlanId: conf.VlanID,
+		LinkAttrs: linkAttrs,
+		VlanId:    conf.VlanID,
 	}
 
 	if conf.LinkContNs {

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -187,11 +187,11 @@ var _ = Describe("vlan Operations", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			m, err := netlink.LinkByName(MASTER_NAME)
@@ -205,11 +205,11 @@ var _ = Describe("vlan Operations", func() {
 		err = targetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = MASTER_NAME_INCONTAINER
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME_INCONTAINER,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			m, err := netlink.LinkByName(MASTER_NAME_INCONTAINER)

--- a/plugins/meta/firewall/firewall_iptables_test.go
+++ b/plugins/meta/firewall/firewall_iptables_test.go
@@ -205,10 +205,10 @@ var _ = Describe("firewall plugin iptables backend", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = IFNAME
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: IFNAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(IFNAME)

--- a/plugins/meta/sbr/sbr_linux_test.go
+++ b/plugins/meta/sbr/sbr_linux_test.go
@@ -53,7 +53,9 @@ func setup(targetNs ns.NetNS, status netStatus) error {
 	err := targetNs.Do(func(_ ns.NetNS) error {
 		for _, dev := range status.Devices {
 			log.Printf("Adding dev %s\n", dev.Name)
-			link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: dev.Name}}
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = dev.Name
+			link := &netlink.Dummy{LinkAttrs: linkAttrs}
 			err := netlink.LinkAdd(link)
 			if err != nil {
 				return err

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -110,10 +110,10 @@ var _ = Describe("tuning plugin", func() {
 		err = originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			linkAttrs := netlink.NewLinkAttrs()
+			linkAttrs.Name = IFNAME
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: IFNAME,
-				},
+				LinkAttrs: linkAttrs,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			link, err := netlink.LinkByName(IFNAME)

--- a/plugins/meta/vrf/vrf.go
+++ b/plugins/meta/vrf/vrf.go
@@ -48,11 +48,11 @@ func createVRF(name string, tableID uint32) (*netlink.Vrf, error) {
 		}
 	}
 
+	linkAttrs := netlink.NewLinkAttrs()
+	linkAttrs.Name = name
 	vrf := &netlink.Vrf{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: name,
-		},
-		Table: tableID,
+		LinkAttrs: linkAttrs,
+		Table:     tableID,
 	}
 
 	err = netlink.LinkAdd(vrf)

--- a/plugins/meta/vrf/vrf_test.go
+++ b/plugins/meta/vrf/vrf_test.go
@@ -94,19 +94,19 @@ var _ = Describe("vrf plugin", func() {
 		err = targetNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
+			la0 := netlink.NewLinkAttrs()
+			la0.Name = IF0Name
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: IF0Name,
-				},
+				LinkAttrs: la0,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(IF0Name)
 			Expect(err).NotTo(HaveOccurred())
 
+			la1 := netlink.NewLinkAttrs()
+			la1.Name = IF1Name
 			err = netlink.LinkAdd(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: IF1Name,
-				},
+				LinkAttrs: la1,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = netlink.LinkByName(IF1Name)
@@ -437,10 +437,10 @@ var _ = Describe("vrf plugin", func() {
 				defer GinkgoRecover()
 				l, err := netlink.LinkByName(IF0Name)
 				Expect(err).NotTo(HaveOccurred())
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = "testrbridge"
 				br := &netlink.Bridge{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: "testrbridge",
-					},
+					LinkAttrs: linkAttrs,
 				}
 				err = netlink.LinkAdd(br)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When diagnosing networking issues, I noticed that `txqueuelen` on `veth` pairs and `tap` devices was set to zero. In investigating the issue, I found that most usages of `netlink.LinkAttrs` in this repository uses the struct literal, which in the `netlink` docs is advised against unless `TxQLen` is explicitly set.

> Note `NewLinkAttrs` constructor, it sets default values in structure. For now it sets only `TxQLen` to `-1`, so kernel will set default by itself. If you're using simple initialization(`LinkAttrs{Name: "foo"}`) `TxQLen` will be set to `0` unless you specify it like `LinkAttrs{Name: "foo", TxQLen: 1000}`.
> ([link](https://pkg.go.dev/github.com/vishvananda/netlink#section-readme))

When using the `ip` command directly without specifying `txqueuelen`, Linux will automatically to 1000:

```sh
$ ip tuntap add tap0 mode tap
$ ip link show tap0
4: tap0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 8a:06:b2:30:4d:1e brd ff:ff:ff:ff:ff:ff
```

This change goes through every single usage of `netlink.LinkAttrs{` and replaces it with the `netlink.NewLinkAttrs` constructor, and then overrides the individual fields in the struct.

I even noticed that in the `bridge` plugin, this is [somewhat called out](https://github.com/containernetworking/plugins/blob/fa737f82b2e0268e67bdf6e1ca18ad4ae7393469/plugins/main/bridge/bridge.go#L342-L346) when using the literal. I've replaced this explicitly in d376c8df5088e62c3a993ce14e5653b7d37407a0 though.