### PR TITLE
Ignore link-local routes in SBR tests

### DIFF
--- a/plugins/meta/sbr/sbr_linux_test.go
+++ b/plugins/meta/sbr/sbr_linux_test.go
@@ -117,11 +117,16 @@ func readback(targetNs ns.NetNS, devNames []string) (netStatus, error) {
 				return err
 			}
 
+			routesNoLinkLocal := []netlink.Route{}
 			for _, route := range routes {
+				if route.Dst.IP.IsLinkLocalMulticast() || route.Dst.IP.IsLinkLocalUnicast() {
+					continue
+				}
 				log.Printf("Got %s route %v", name, route)
+				routesNoLinkLocal = append(routesNoLinkLocal, route)
 			}
 
-			retVal.Devices[i].Routes = routes
+			retVal.Devices[i].Routes = routesNoLinkLocal
 		}
 
 		rules, err := netlink.RuleList(netlink.FAMILY_ALL)


### PR DESCRIPTION
The tests were flaky due to a route with the link-local IP being automatically added after the test run saves the initial state (routes before SBR plugin is ran). When the SBR plugin is ran, the new state is compared with the old state. The new state will then contain the route with the link-local IP (that has been added after saving the old state), the old state was not containing it, so the tests were failing

The solution here is to ignore routes with the link-local IP for the tests.

fixes: #1096