### PR TITLE
VRF: Wait for the local/host routes to be added

### DIFF
--- a/plugins/meta/vrf/vrf_test.go
+++ b/plugins/meta/vrf/vrf_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -207,6 +208,18 @@ var _ = Describe("vrf plugin", func() {
 				// Add IP addresses for network reachability
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv4})
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv6})
+				// Wait for the corresponding route to be addeded
+				Eventually(func() bool {
+					ipv6RouteDst := &net.IPNet{
+						IP:   ipv6.IP,
+						Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+					}
+					routes, _ := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
+						Dst:   ipv6RouteDst,
+						Table: 0,
+					}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+					return err == nil && len(routes) >= 1
+				}, time.Second, 500*time.Millisecond).Should(BeTrue())
 
 				ipAddrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
 				Expect(err).NotTo(HaveOccurred())
@@ -304,6 +317,18 @@ var _ = Describe("vrf plugin", func() {
 				// Add IP addresses for network reachability
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv4})
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv6})
+				// Wait for the corresponding route to be addeded
+				Eventually(func() bool {
+					ipv6RouteDst := &net.IPNet{
+						IP:   ipv6.IP,
+						Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+					}
+					routes, _ := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
+						Dst:   ipv6RouteDst,
+						Table: 0,
+					}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+					return err == nil && len(routes) >= 1
+				}, time.Second, 500*time.Millisecond).Should(BeTrue())
 
 				ipAddrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
 				Expect(err).NotTo(HaveOccurred())
@@ -362,6 +387,18 @@ var _ = Describe("vrf plugin", func() {
 				// Add IP addresses for network reachability
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv4})
 				netlink.AddrAdd(link, &netlink.Addr{IPNet: ipv6})
+				// Wait for the corresponding route to be addeded
+				Eventually(func() bool {
+					ipv6RouteDst := &net.IPNet{
+						IP:   ipv6.IP,
+						Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+					}
+					routes, _ := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
+						Dst:   ipv6RouteDst,
+						Table: 0,
+					}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+					return err == nil && len(routes) >= 1
+				}, time.Second, 500*time.Millisecond).Should(BeTrue())
 
 				ipAddrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Without waiting for the local/host routes to be added by the kernel after the IP address is being added to an interface. The routes requiring the local/host routes may failed. This caused flaky e2e tests, but could also happen during the execution of the VRF plugin when the IPv6 addresses were being re-added to the interface and when the route were being moved to the VRF table.

fixes: #1103