### PR TITLE
go.mod: restore the support for Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containernetworking/plugins
 
-go 1.23
+go 1.22.0
 
 require (
 	github.com/Microsoft/hcsshim v0.12.9


### PR DESCRIPTION
Go 1.22 is still actively maintained.