### PR TITLE
portmap: fix iptables conditions detection

### DIFF
--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -349,10 +349,11 @@ func detectBackendOfConditions(conditions *[]string) string {
 		return ""
 	}
 
-	// The first token of any iptables condition would start with a hyphen (e.g. "-d",
-	// "--sport", "-m"). No nftables condition would start that way. (An nftables
-	// condition might include a negative number, but not as the first token.)
-	if (*conditions)[0][0] == '-' {
+	// The first character of any iptables condition would either be an hyphen
+	// (e.g. "-d", "--sport", "-m") or an exclamation mark.
+	// No nftables condition would start that way. (An nftables condition might
+	// include a negative number, but not as the first token.)
+	if (*conditions)[0][0] == '-' || (*conditions)[0][0] == '!' {
 		return iptablesBackend
 	}
 	return nftablesBackend

--- a/plugins/meta/portmap/portmap_test.go
+++ b/plugins/meta/portmap/portmap_test.go
@@ -44,7 +44,7 @@ var _ = Describe("portmapping configuration", func() {
 					},
 					"snat": false,
 					"conditionsV4": ["-s", "1.2.3.4"],
-					"conditionsV6": ["-s", "12::34"],
+					"conditionsV6": ["!", "-s", "12::34"],
 					"prevResult": {
 						"interfaces": [
 							{"name": "host"},
@@ -76,7 +76,7 @@ var _ = Describe("portmapping configuration", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.CNIVersion).To(Equal(ver))
 				Expect(c.ConditionsV4).To(Equal(&[]string{"-s", "1.2.3.4"}))
-				Expect(c.ConditionsV6).To(Equal(&[]string{"-s", "12::34"}))
+				Expect(c.ConditionsV6).To(Equal(&[]string{"!", "-s", "12::34"}))
 				fvar := false
 				Expect(c.SNAT).To(Equal(&fvar))
 				Expect(c.Name).To(Equal("test"))


### PR DESCRIPTION
As show in the docs, iptables conditions can also start with '!'

Fixes 01a94e17c77e6ff8e5019e15c42d8d92cf87194f
Fixes #1114 