### PR TITLE
host-device: Return interface name in result

### DIFF
--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -218,7 +218,7 @@ func buildOneConfig(name, cniVersion string, orig *Net, prevResult types.Result)
 
 type tester interface {
 	expectInterfaces(result types.Result, name, mac, sandbox string)
-	expectDpdkInterfaceIP(result types.Result, ipAddress string)
+	expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string)
 }
 
 type testerBase struct{}
@@ -256,11 +256,16 @@ func (t *testerV10x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV10x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV10x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types100.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types100.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -278,11 +283,16 @@ func (t *testerV04x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV04x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV04x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types040.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types040.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -300,11 +310,16 @@ func (t *testerV03x) expectInterfaces(result types.Result, name, mac, sandbox st
 	}))
 }
 
-func (t *testerV03x) expectDpdkInterfaceIP(result types.Result, ipAddress string) {
+func (t *testerV03x) expectDpdkInterfaceIP(result types.Result, name, sandbox, ipAddress string) {
 	// check that the result was sane
 	res, err := types040.NewResultFromResult(result)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(res.Interfaces).To(BeEmpty())
+	Expect(res.Interfaces).To(Equal([]*types040.Interface{
+		{
+			Name:    name,
+			Sandbox: sandbox,
+		},
+	}))
 	Expect(res.IPs).To(HaveLen(1))
 	Expect(res.IPs[0].Address.String()).To(Equal(ipAddress))
 }
@@ -598,7 +613,7 @@ var _ = Describe("base functionality", func() {
 
 			// check that the result was sane
 			t := newTesterByVersion(ver)
-			t.expectDpdkInterfaceIP(resI, targetIP)
+			t.expectDpdkInterfaceIP(resI, cniName, targetNS.Path(), targetIP)
 
 			// call CmdDel
 			_ = originalNS.Do(func(ns.NetNS) error {
@@ -870,7 +885,7 @@ var _ = Describe("base functionality", func() {
 
 			// check that the result was sane
 			t := newTesterByVersion(ver)
-			t.expectDpdkInterfaceIP(resI, targetIP)
+			t.expectDpdkInterfaceIP(resI, cniName, targetNS.Path(), targetIP)
 
 			// call CmdCheck
 			n := &Net{}


### PR DESCRIPTION
It would be nice to see the interface name in network-status pod annotation when called by multus, or other meta plugin when the host device is bound to a userspace driver.

For e.g. when I have a NAD as follows, and attach it to a pod
```
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    k8s.v1.cni.cncf.io/resourceName: openshift.io/pci_sriov_vf
  name: net-a
spec:
  config: |-
    {
        "cniVersion": "1.0.0",
        "name": "net-a",
        "type": "host-device",
        "pciBusID": "0000:07:00.0",
        "ipam": {}
    }

```
    k8s.v1.cni.cncf.io/network-status: |-
      [{
          "name": "ovn-kubernetes",
          "interface": "eth0",
          "ips": [
              "fd02:0:0:1::2ed"
          ],
          "mac": "0a:58:70:d0:c0:27",
          "default": true,
          "dns": {}
      },{
          "name": "sriramy/net-a",
          "interface": "net1",
          "dns": {},
          "device-info": {
              "type": "pci",
              "version": "1.1.0",
              "pci": {
                  "pci-address": "0000:07:00.0"
              }
          }
      }]
    k8s.v1.cni.cncf.io/networks: '[{"name":"net-a","namespace":"sriramy"}]'

What is added is the below line in network status annotation field for net-a
"interface": "net1",
