### PR TITLE
Fix addresses and routes reinserted to the VRF

### DIFF
--- a/plugins/meta/vrf/vrf_test.go
+++ b/plugins/meta/vrf/vrf_test.go
@@ -412,6 +412,7 @@ var _ = Describe("vrf plugin", func() {
 				// Add additional route to 10.11.10.0/24 via 10.0.0.1 gateway
 				r := netlink.Route{
 					LinkIndex: link.Attrs().Index,
+					Src:       ipv4.IP,
 					Dst:       routev4,
 					Gw:        net.ParseIP("10.0.0.1"),
 					Priority:  100,


### PR DESCRIPTION
Fix addresses and routes reinserted to the VRF
    
These changes make sure that only IPV6 global addresses and non local/connected routes are reinserted to the VRF table after slaving the interface

Issue:

Consistent failure

```
plugin type="vrf" failed (add): cmdAdd failed: failed getting local/host addresses for net1 in table 1 with dst fe80::2204:fff:fef1:88a1/64
```

After slaving an interface to a VRF, global IPV6 addresses (unless a sysctl option is enabled) are lost. The plugin gets the IPV6 addresses after and before slaving the interface and adds the ones that are missing. It checks that those addresses are present in the kernel to prevent failures when adding missing global routes associated with these addresses (subsequent operation). There is a retrying mechanism for checking the presence of these addresses since the kernel takes some time to add them.

First approach was to increase the number of retries (from 10 retries to 100 retries - same sleep time 10ms). It works, however, as seen in the log, the IPV6 address is a link-local one. These are moved by the kernel automatically. For some reason, when combining SRIOV and VRF, the kernel takes longer to add these. So, instead, a logic was added to only reinsert global IPV6 addresses. The issue was fixed with this without having to increment the retries. There were some routes that don't need to be added. This PR includes a fix for this as well. This latter approach is preferred instead of blindly increasing the retries.

https://docs.kernel.org/networking/vrf.html

