### PR TITLE
Allow vlan parameter to set native vlan on trunk ports

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -123,11 +123,6 @@ func loadNetConf(bytes []byte, envArgs string) (*NetConf, string, error) {
 		return nil, "", err
 	}
 
-	// Currently bridge CNI only support access port(untagged only) or trunk port(tagged only)
-	if n.Vlan > 0 && n.vlans != nil {
-		return nil, "", errors.New("cannot set vlan and vlanTrunk at the same time")
-	}
-
 	if envArgs != "" {
 		e := MacEnvArgs{}
 		if err := types.LoadArgs(envArgs, &e); err != nil {
@@ -468,7 +463,6 @@ func setupVeth(
 		}
 	}
 
-	// Currently bridge CNI only support access port(untagged only) or trunk port(tagged only)
 	if vlanID != 0 {
 		err = netlink.BridgeVlanAdd(hostVeth, uint16(vlanID), true, true, false, true)
 		if err != nil {
@@ -480,6 +474,15 @@ func setupVeth(
 		err = netlink.BridgeVlanAdd(hostVeth, uint16(v), false, false, false, true)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to setup vlan tag on interface %q: %w", hostIface.Name, err)
+		}
+	}
+
+	// Backwards compatibility with users that did not specify a vlanID
+	if vlanID == 0 && len(vlans) > 0 {
+		// If no vlan is specified, we set the native vlan on the trunk equal to 1
+		err = netlink.BridgeVlanAdd(hostVeth, 1, true, true, false, true)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to setup default native vlan tag on interface %q: %v", hostIface.Name, err)
 		}
 	}
 

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -691,6 +691,13 @@ func (tester *testerV10x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 					}
 				}
 			}
+
+			// Check native vlan
+			nativeVlan := tc.vlan
+			if tc.vlan == 0 {
+				nativeVlan = 1
+			}
+			Expect(checkVlan(nativeVlan, vlans)).To(BeTrue())
 		}
 
 		// Check that the bridge has a different mac from the veth
@@ -1032,6 +1039,13 @@ func (tester *testerV04x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 					}
 				}
 			}
+
+			// Check native vlan
+			nativeVlan := tc.vlan
+			if tc.vlan == 0 {
+				nativeVlan = 1
+			}
+			Expect(checkVlan(nativeVlan, vlans)).To(BeTrue())
 		}
 
 		// Check that the bridge has a different mac from the veth
@@ -1366,6 +1380,13 @@ func (tester *testerV03x) cmdAddTest(tc testCase, dataDir string) (types.Result,
 					}
 				}
 			}
+
+			// Check native vlan
+			nativeVlan := tc.vlan
+			if tc.vlan == 0 {
+				nativeVlan = 1
+			}
+			Expect(checkVlan(nativeVlan, vlans)).To(BeTrue())
 		}
 
 		// Check that the bridge has a different mac from the veth
@@ -2021,11 +2042,31 @@ var _ = Describe("bridge Operations", func() {
 		})
 
 		// TODO find some way to put pointer
-		It(fmt.Sprintf("[%s] configures and deconfigures a l2 bridge with vlan id 100, vlanTrunk 101,200~210 using ADD/DEL", ver), func() {
+		It(fmt.Sprintf("[%s] configures and deconfigures a l2 bridge with vlanTrunk 101,200~210 using ADD/DEL", ver), func() {
 			id, minID, maxID := 101, 200, 210
 			tc := testCase{
 				cniVersion: ver,
 				isLayer2:   true,
+				vlanTrunk: []*VlanTrunk{
+					{ID: &id},
+					{
+						MinID: &minID,
+						MaxID: &maxID,
+					},
+				},
+				AddErr020: "cannot convert: no valid IP addresses",
+				AddErr010: "cannot convert: no valid IP addresses",
+			}
+			cmdAddDelTest(originalNS, targetNS, tc, dataDir)
+		})
+
+		It(fmt.Sprintf("[%s] configures and deconfigures a l2 bridge with vlan 100, and vlanTrunk 101,200~210 using ADD/DEL", ver), func() {
+			nativeVlan := 100
+			id, minID, maxID := 101, 200, 210
+			tc := testCase{
+				cniVersion: ver,
+				isLayer2:   true,
+				vlan:       nativeVlan,
 				vlanTrunk: []*VlanTrunk{
 					{ID: &id},
 					{


### PR DESCRIPTION
This allows to set the native vlan on trunk ports
via the vlan parameter. It removes all previous
limitations set on the vlan trunk implementation.