### PR TITLE
Set default value of PreserveDefaultVlan to False

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -107,8 +107,6 @@ func init() {
 func loadNetConf(bytes []byte, envArgs string) (*NetConf, string, error) {
 	n := &NetConf{
 		BrName: defaultBrName,
-		// Set default value equal to true to maintain existing behavior.
-		PreserveDefaultVlan: true,
 	}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, "", fmt.Errorf("failed to load netconf: %v", err)


### PR DESCRIPTION
Default behavior of the vlan implementation on the bridge should guarantee complete vlan isolation. This complies with what regular users expect from the vlan feature.