### PR TITLE
Set value of gw to nil for opt121 routes in DHCP

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -474,7 +474,13 @@ func (l *DHCPLease) Routes() []*types.Route {
 	opt121Routes := ack.ClasslessStaticRoute()
 	if len(opt121Routes) > 0 {
 		for _, r := range opt121Routes {
-			routes = append(routes, &types.Route{Dst: *r.Dest, GW: r.Router})
+			route := &types.Route{Dst: *r.Dest, GW: r.Router}
+			// if router is not specified, add SCOPE_LINK so routes are installed
+			if r.Router.IsUnspecified() {
+				scopeLinkValue := int(netlink.SCOPE_LINK)
+				route.Scope = &scopeLinkValue
+			}
+			routes = append(routes, route)
 		}
 		return routes
 	}


### PR DESCRIPTION
Default behavior of the plugin is to try and install routes without using SRC which prevents routes from being installed in the routing table in (some) cloud environment that assign /32 IPs to NICs. This change enables routes to be installed without this value (and making the scope to be set to SCOPE_LINK. Another way of fixing it would be if the plugin would be refactored to use the SRC object of the struct in github.com/vishvananda/netlink which would require more work and potentially impact other plugins.