### PR TITLE
.github: bump golangci-lint version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ jobs:
       - uses: ibiqlik/action-yamllint@v3
         with:
           format: auto
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0.2
+          version: v2.3.0
           args: -v
   verify-vendor:
     name: Verify vendor directory


### PR DESCRIPTION
Need a newer version to upgade the action.