### PR TITLE
Fix file exists errro in dummy cni

### DIFF
--- a/plugins/main/dummy/dummy.go
+++ b/plugins/main/dummy/dummy.go
@@ -44,20 +44,19 @@ func parseNetConf(bytes []byte) (*types.NetConf, error) {
 func createDummy(ifName string, netns ns.NetNS) (*current.Interface, error) {
 	dummy := &current.Interface{}
 
-	linkAttrs := netlink.NewLinkAttrs()
-	linkAttrs.Name = ifName
-	linkAttrs.Namespace = netlink.NsFd(int(netns.Fd()))
-
-	dm := &netlink.Dummy{
-		LinkAttrs: linkAttrs,
-	}
-
-	if err := netlink.LinkAdd(dm); err != nil {
-		return nil, fmt.Errorf("failed to create dummy: %v", err)
-	}
-	dummy.Name = ifName
-
 	err := netns.Do(func(_ ns.NetNS) error {
+		linkAttrs := netlink.NewLinkAttrs()
+		linkAttrs.Name = ifName
+
+		dm := &netlink.Dummy{
+			LinkAttrs: linkAttrs,
+		}
+
+		if err := netlink.LinkAdd(dm); err != nil {
+			return fmt.Errorf("failed to create dummy: %v", err)
+		}
+		dummy.Name = ifName
+
 		// Re-fetch interface to get all properties/attributes
 		contDummy, err := netlinksafe.LinkByName(ifName)
 		if err != nil {

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -233,6 +233,26 @@ var _ = Describe("dummy Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It(fmt.Sprintf("[%s] creates an dummy link in a non-default namespace with conflicting name in original namespace", ver), func() {
+			ifName := "foobar0"
+			err := originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				// Create dummy in the original namespace, with the same name
+				linkAttrs := netlink.NewLinkAttrs()
+				linkAttrs.Name = ifName
+				dm := &netlink.Dummy{
+					LinkAttrs: linkAttrs,
+				}
+				err := netlink.LinkAdd(dm)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = createDummy(ifName, targetNS)
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It(fmt.Sprintf("[%s] configures and deconfigures a dummy link with ADD/CHECK/DEL", ver), func() {
 			const IFNAME = "dummy0"
 


### PR DESCRIPTION
When the root net ns has "eth0", dummy CNI returns errror "failed to create dummy: file exists"

The fix is to create the dummy interface directly in the pod net ns