### PR TITLE
Ignore settling with down state since it would never settle

### DIFF
--- a/pkg/ip/addr_linux.go
+++ b/pkg/ip/addr_linux.go
@@ -66,9 +66,16 @@ func SettleAddresses(ifName string, timeout time.Duration) error {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("link %s still has tentative addresses after %d seconds",
-				ifName,
-				timeout)
+			link, err := netlinksafe.LinkByName(ifName)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve link: %v", err)
+			}
+			if link.Attrs().OperState == netlink.OperUp {
+				return fmt.Errorf("link %s still has tentative addresses after %d seconds",
+					ifName,
+					timeout)
+			}
+			return nil
 		}
 
 		time.Sleep(SETTLE_INTERVAL)


### PR DESCRIPTION
Ignore settling with down state since the interface would never settle. Literally that: if there is no cable, then this will error out. In the past, it didn't.