### PR TITLE
portmap: ensure nftables backend only intercept local traffic

### DIFF
--- a/plugins/meta/portmap/portmap_nftables.go
+++ b/plugins/meta/portmap/portmap_nftables.go
@@ -26,9 +26,14 @@ import (
 const (
 	tableName = "cni_hostport"
 
+	// Intermediate chain to jump to both 'hostip_hostports' and 'hostports'
+	hostPortsAllChain = "hostports_all"
+	// This chain was used for rules with hostIP, we do not use it anymore,
+	// but we keep it to make upgrade transparent
 	hostIPHostPortsChain = "hostip_hostports"
-	hostPortsChain       = "hostports"
-	masqueradingChain    = "masquerading"
+	// Chain containing all the rules
+	hostPortsChain    = "hostports"
+	masqueradingChain = "masquerading"
 )
 
 // The nftables portmap implementation is fairly similar to the iptables implementation:
@@ -104,10 +109,34 @@ func (pmNFT *portMapperNFTables) forwardPorts(config *PortMapConf, containerNet 
 	})
 
 	tx.Add(&knftables.Chain{
-		Name: "hostports",
+		Name: hostPortsChain,
 	})
+
 	tx.Add(&knftables.Chain{
-		Name: "hostip_hostports",
+		Name: hostIPHostPortsChain,
+	})
+
+	// setup intermediate chain
+	tx.Add(&knftables.Chain{
+		Name: hostPortsAllChain,
+	})
+
+	tx.Flush(&knftables.Chain{
+		Name: hostPortsAllChain,
+	})
+
+	tx.Add(&knftables.Rule{
+		Chain: hostPortsAllChain,
+		Rule: knftables.Concat(
+			"jump", hostIPHostPortsChain,
+		),
+	})
+
+	tx.Add(&knftables.Rule{
+		Chain: hostPortsAllChain,
+		Rule: knftables.Concat(
+			"jump", hostPortsChain,
+		),
 	})
 
 	tx.Add(&knftables.Chain{
@@ -123,14 +152,8 @@ func (pmNFT *portMapperNFTables) forwardPorts(config *PortMapConf, containerNet 
 		Chain: "prerouting",
 		Rule: knftables.Concat(
 			conditions,
-			"jump", hostIPHostPortsChain,
-		),
-	})
-	tx.Add(&knftables.Rule{
-		Chain: "prerouting",
-		Rule: knftables.Concat(
-			conditions,
-			"jump", hostPortsChain,
+			"fib daddr type local",
+			"jump", hostPortsAllChain,
 		),
 	})
 
@@ -147,15 +170,8 @@ func (pmNFT *portMapperNFTables) forwardPorts(config *PortMapConf, containerNet 
 		Chain: "output",
 		Rule: knftables.Concat(
 			conditions,
-			"jump", hostIPHostPortsChain,
-		),
-	})
-	tx.Add(&knftables.Rule{
-		Chain: "output",
-		Rule: knftables.Concat(
-			conditions,
 			"fib daddr type local",
-			"jump", hostPortsChain,
+			"jump", hostPortsAllChain,
 		),
 	})
 
@@ -184,8 +200,10 @@ func (pmNFT *portMapperNFTables) forwardPorts(config *PortMapConf, containerNet 
 		}
 
 		if useHostIP {
+			// we add the rule to 'hostports' instead of 'hostip_hostports'
+			// as we want to remove 'hostip_hostports' long-term
 			tx.Add(&knftables.Rule{
-				Chain: hostIPHostPortsChain,
+				Chain: hostPortsChain,
 				Rule: knftables.Concat(
 					ipX, "daddr", e.HostIP,
 					e.Protocol, "dport", e.HostPort,
@@ -243,7 +261,7 @@ func (pmNFT *portMapperNFTables) forwardPorts(config *PortMapConf, containerNet 
 func (pmNFT *portMapperNFTables) checkPorts(config *PortMapConf, containerNet net.IPNet) error {
 	isV6 := (containerNet.IP.To4() == nil)
 
-	var hostPorts, hostIPHostPorts, masqueradings int
+	var hostPorts, masqueradings int
 	for _, e := range config.RuntimeConfig.PortMaps {
 		if e.HostIP != "" {
 			hostIP := net.ParseIP(e.HostIP)
@@ -252,14 +270,8 @@ func (pmNFT *portMapperNFTables) checkPorts(config *PortMapConf, containerNet ne
 			if isV6 != isHostV6 {
 				continue
 			}
-			if hostIP.IsUnspecified() {
-				hostPorts++
-			} else {
-				hostIPHostPorts++
-			}
-		} else {
-			hostPorts++
 		}
+		hostPorts++
 	}
 	if *config.SNAT {
 		masqueradings = 1
@@ -274,12 +286,6 @@ func (pmNFT *portMapperNFTables) checkPorts(config *PortMapConf, containerNet ne
 	}
 	if hostPorts > 0 {
 		err := checkPortsAgainstRules(nft, hostPortsChain, config.ContainerID, hostPorts)
-		if err != nil {
-			return err
-		}
-	}
-	if hostIPHostPorts > 0 {
-		err := checkPortsAgainstRules(nft, hostIPHostPortsChain, config.ContainerID, hostIPHostPorts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- portmap: fix CHECK for nftables backend

- portmap: ensure nftables backend only intercept local traffic

    portmap iptables backend uses `-m addrtype --dst-type LOCAL`
    and a common chain (CNI-HOSTPORT-DNAT) for both hostPort and hostIP/hostPort.
    
    Before this commit, nftables backend was using 2 separate chains,
    `hostip_hostports` and `hostports`. The goal was to avoid using
    `fib daddr type local` before we jump to `hostip_hostports`,
    but this is a behavior change compared to iptables backend,
    and a security issue (hostIP: 1.1.1.1 / hostPort: 53).
    Also while switching from input to prerouting hook, we forgot to
    add the fib lookup for `hostports`, rendering the nftables backend half broken.
    
    To allow transparent upgrades and avoid running the fib lookup twice,
    we use an intermediate chain (`hostports_all`)
    ```
    chain hostports_all {
        jump hostip_hostports
        jump hostports
    }
    ```
    
    Long-term we want to remove `hostip_hostports`,
    so all new rules are created in the `hostports` chain.
    
    We can't use implicit chains (`jump { jump hostip_hostports; jump hostports }`)
    as it's not supported by knftables.Fake yet.


Fixes 9296c5f80a319b63f25ab0708d022d94eebc00d8
Fixes 01a94e17c77e6ff8e5019e15c42d8d92cf87194f

Fixes #1209