### PR TITLE
bridge: include attempted IP address in AddrAdd error message

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -295,7 +295,7 @@ func ensureAddr(br netlink.Link, family int, ipn *net.IPNet, forceAddress bool) 
 
 	addr := &netlink.Addr{IPNet: ipn, Label: ""}
 	if err := netlink.AddrAdd(br, addr); err != nil && err != syscall.EEXIST {
-		return fmt.Errorf("could not add IP address to %q: %v", br.Attrs().Name, err)
+		return fmt.Errorf("could not add IP address %s to %q: %v", ipnStr, br.Attrs().Name, err)
 	}
 
 	// Set the bridge's MAC to itself. Otherwise, the bridge will take the


### PR DESCRIPTION
We recently encountered the error:
```
rpc error: code = Unknown desc = failed to setup network for sandbox "c44369cc2c061e4fe9943c27526025815413c7230642e1541aa23b408f4afdcd": plugin type="bridge" failed (add): failed to set bridge addr: could not add IP address to "cni0": permission denied
```
It turns out this was due to IPv6 being disabled on the host when the machine went down and was rebooted.

This PR includes the IP in the `AddrAdd` error message which could help debug better with any issues while adding the IP address to the bridge and improves the readability.
