### PR TITLE
vrf: fix route filtering to preserve IPAM-configured routes

### DIFF
--- a/plugins/meta/vrf/vrf.go
+++ b/plugins/meta/vrf/vrf.go
@@ -116,17 +116,9 @@ func addInterface(vrf *netlink.Vrf, intf string) error {
 		Scope:     netlink.SCOPE_UNIVERSE, // Exclude local and connected routes
 	}
 	filterMask := netlink.RT_FILTER_OIF | netlink.RT_FILTER_SCOPE // Filter based on link index and scope
-	r, err := netlinksafe.RouteListFiltered(netlink.FAMILY_ALL, filter, filterMask)
+	globalRoutes, err := netlinksafe.RouteListFiltered(netlink.FAMILY_ALL, filter, filterMask)
 	if err != nil {
 		return fmt.Errorf("failed getting all routes for %s", intf)
-	}
-
-	// Filter out connected IPV6 routes
-	globalRoutes := make([]netlink.Route, 0, len(r))
-	for _, route := range r {
-		if route.Src != nil {
-			globalRoutes = append(globalRoutes, route)
-		}
 	}
 
 	err = netlink.LinkSetMaster(i, vrf)


### PR DESCRIPTION
The previous implementation filtered out routes without an explicit source address (route.Src == nil), which incorrectly removed routes added by IPAM plugins. IPAM plugins typically configure routes without setting a source address, causing those routes to be lost when the interface was moved to the VRF.

The SCOPE_UNIVERSE filter already excludes local and connected routes that are automatically recreated by the kernel, so the additional route.Src filter was both unnecessary and harmful.

Fixes #1223