### PR TITLE
Simplify some code with slices and for-range.

### DIFF
--- a/pkg/ip/ipmasq_iptables_linux.go
+++ b/pkg/ip/ipmasq_iptables_linux.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -63,18 +64,11 @@ func SetupIPMasq(ipn *net.IPNet, chain string, comment string) error {
 	}
 
 	// Create chain if doesn't exist
-	exists := false
 	chains, err := ipt.ListChains("nat")
 	if err != nil {
 		return fmt.Errorf("failed to list chains: %v", err)
 	}
-	for _, ch := range chains {
-		if ch == chain {
-			exists = true
-			break
-		}
-	}
-	if !exists {
+	if !slices.Contains(chains, chain) {
 		if err = ipt.NewChain("nat", chain); err != nil {
 			return err
 		}

--- a/pkg/ip/link_linux.go
+++ b/pkg/ip/link_linux.go
@@ -73,7 +73,7 @@ func makeVeth(name, vethPeerName string, mtu int, mac string, hostNS ns.NetNS) (
 	var peerName string
 	var veth netlink.Link
 	var err error
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if vethPeerName != "" {
 			peerName = vethPeerName
 		} else {

--- a/pkg/ip/utils_linux.go
+++ b/pkg/ip/utils_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2016 CNI authors
 //

--- a/pkg/netlinksafe/netlink.go
+++ b/pkg/netlinksafe/netlink.go
@@ -54,7 +54,7 @@ func (h Handle) Close() {
 }
 
 func retryOnIntr(f func() error) {
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for range maxAttempts {
 		if err := f(); !errors.Is(err, netlink.ErrDumpInterrupted) {
 			return
 		}

--- a/pkg/ns/ns_linux_test.go
+++ b/pkg/ns/ns_linux_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Linux namespace operations", func() {
 
 				var wg sync.WaitGroup
 				wg.Add(concurrency)
-				for i := 0; i < concurrency; i++ {
+				for range concurrency {
 					go func() {
 						defer wg.Done()
 						targetNetNS.Do(func(hostNS ns.NetNS) error {

--- a/pkg/testutils/testing.go
+++ b/pkg/testutils/testing.go
@@ -15,6 +15,8 @@
 package testutils
 
 import (
+	"slices"
+
 	"github.com/containernetworking/cni/pkg/version"
 )
 
@@ -24,12 +26,7 @@ var AllSpecVersions = [...]string{"0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "
 // SpecVersionHasIPVersion returns true if the given CNI specification version
 // includes the "version" field in the IP address elements
 func SpecVersionHasIPVersion(ver string) bool {
-	for _, i := range []string{"0.3.0", "0.3.1", "0.4.0"} {
-		if ver == i {
-			return true
-		}
-	}
-	return false
+	return slices.Contains([]string{"0.3.0", "0.3.1", "0.4.0"}, ver)
 }
 
 // SpecVersionHasCHECK returns true if the given CNI specification version

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Utils", func() {
 		It("is (nearly) perfect (injective function)", func() {
 			hashes := map[string]int{}
 
-			for i := 0; i < 1000; i++ {
+			for i := range 1000 {
 				name := fmt.Sprintf("string %d", i)
 				hashes[MustFormatHashWithPrefix(8, "", name)]++
 			}

--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -342,7 +342,7 @@ var _ = Describe("DHCP Operations", func() {
 			wg.Add(3)
 			started := sync.WaitGroup{}
 			started.Add(3)
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				go func() {
 					defer GinkgoRecover()
 

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -46,7 +46,7 @@ func validateRoutes(t *testing.T, routes []*types.Route) {
 		t.Fatalf("wrong length slice; expected %v, got %v", len(expected), len(routes))
 	}
 
-	for i := 0; i < len(routes); i++ {
+	for i := range routes {
 		a := routes[i]
 		e := expected[i]
 

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"sort"
+	"slices"
 	"syscall"
 	"time"
 
@@ -194,7 +194,7 @@ func collectVlanTrunk(vlanTrunk []*VlanTrunk) ([]int, error) {
 	for k := range vlanMap {
 		vlans = append(vlans, k)
 	}
-	sort.Slice(vlans, func(i int, j int) bool { return vlans[i] < vlans[j] })
+	slices.Sort(vlans)
 	return vlans, nil
 }
 

--- a/plugins/main/host-device/host-device.go
+++ b/plugins/main/host-device/host-device.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -474,12 +475,7 @@ func hasDpdkDriver(pciaddr string) (bool, error) {
 		return false, err
 	}
 	driverName := driverStat.Name()
-	for _, drv := range userspaceDrivers {
-		if driverName == drv {
-			return true, nil
-		}
-	}
-	return false, nil
+	return slices.Contains(userspaceDrivers, driverName), nil
 }
 
 func printLink(dev netlink.Link, cniVersion string, containerNs ns.NetNS) error {

--- a/plugins/meta/firewall/firewall_integ_test.go
+++ b/plugins/meta/firewall/firewall_integ_test.go
@@ -105,7 +105,7 @@ var _ = Describe("firewall integration tests (ingressPolicy: same-bridge)", func
 		Expect(err).NotTo(HaveOccurred())
 		fmt.Fprintf(GinkgoWriter, "root namespace: %s\n", testRootNS.Path())
 
-		for i := 0; i < nsCount; i++ {
+		for i := range nsCount {
 			targetNS, err := testutils.NewNS()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Fprintf(GinkgoWriter, "namespace %d:%s\n", i, targetNS.Path())
@@ -202,7 +202,7 @@ func setupNetworks(cniConf *libcni.CNIConfig, testRootNS ns.NetNS, namespaces [n
 ) [nsCount]*types100.Result {
 	var results [nsCount]*types100.Result
 
-	for i := 0; i < nsCount; i++ {
+	for i := range nsCount {
 		runtimeConfig := libcni.RuntimeConf{
 			ContainerID: fmt.Sprintf("test-cni-firewall-%d", i),
 			NetNS:       namespaces[i].Path(),

--- a/plugins/meta/portmap/chain_test.go
+++ b/plugins/meta/portmap/chain_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -101,16 +102,9 @@ var _ = Describe("chain tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify the chain exists
-		ok := false
 		chains, err := ipt.ListChains(TABLE)
 		Expect(err).NotTo(HaveOccurred())
-		for _, chain := range chains {
-			if chain == testChain.name {
-				ok = true
-				break
-			}
-		}
-		if !ok {
+		if !slices.Contains(chains, testChain.name) {
 			Fail("Could not find created chain")
 		}
 
@@ -208,7 +202,7 @@ var _ = Describe("chain tests", func() {
 		err := testChain.setup(ipt)
 		Expect(err).NotTo(HaveOccurred())
 		errCh := make(chan error, N)
-		for i := 0; i < N; i++ {
+		for range N {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()


### PR DESCRIPTION
I applied a few of the modernize rules to simplify the code slightly:

* [slices.Contains](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_slicescontains) removes some chunks of iterations that do exactly what can be leveraged to `slices.Contains`
* [for range N](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_slicescontains) which is syntactic sugar.
* A single `// +build` which definitely needs to go.
* `slices.Sort` instead of `sort.Slice`.

The golangci-lint version is a bit old, and I didn't want to tamper around with it in this PR.