### PR TITLE
Remove redefinitions of loop variables in for-loops.

### DIFF
--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -256,10 +256,6 @@ var _ = Describe("DHCP Operations", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] configures and deconfigures a link with ADD/DEL", ver), func() {
 			conf := fmt.Sprintf(`{
 			    "cniVersion": "%s",
@@ -579,10 +575,6 @@ var _ = Describe("DHCP Lease Unavailable Operations", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] configures multiple links with multiple ADD with second lease unavailable", ver), func() {
 			conf := fmt.Sprintf(`{
 			    "cniVersion": "%s",

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -52,10 +52,6 @@ var _ = Describe("host-local Operations", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] allocates and releases addresses with ADD/DEL", ver), func() {
 			err := os.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0o644)
 			Expect(err).NotTo(HaveOccurred())

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -30,10 +30,6 @@ import (
 
 var _ = Describe("static Operations", func() {
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] allocates and releases addresses with ADD/DEL", ver), func() {
 			const ifname string = "eth0"
 			const nspath string = "/some/where"

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -1910,10 +1910,6 @@ var _ = Describe("bridge Operations", func() {
 	)
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] creates a bridge", ver), func() {
 			conf := testCase{cniVersion: ver}.netConf()
 			err := originalNS.Do(func(ns.NetNS) error {
@@ -2012,8 +2008,6 @@ var _ = Describe("bridge Operations", func() {
 				resolvConf: resolvConf,
 			},
 		} {
-			tc := tc
-			i := i
 			It(fmt.Sprintf("[%s] (%d) configures and deconfigures a bridge and veth with default route with ADD/DEL", ver, i), func() {
 				tc.cniVersion = ver
 				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
@@ -2136,8 +2130,6 @@ var _ = Describe("bridge Operations", func() {
 				DelErr010: "CNI version 0.1.0 does not support more than 1 address per family",
 			},
 		} {
-			tc := tc
-			i := i
 			It(fmt.Sprintf("[%s] (%d) configures and deconfigures a bridge, veth with default route and vlanID 100 with ADD/DEL", ver, i), func() {
 				tc.cniVersion = ver
 				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
@@ -2172,8 +2164,6 @@ var _ = Describe("bridge Operations", func() {
 				},
 			},
 		} {
-			tc := tc
-			i := i
 			It(fmt.Sprintf("[%s] (%d) configures and deconfigures a bridge and veth with default route with ADD/DEL", ver, i), func() {
 				tc.cniVersion = ver
 				cmdAddDelTest(originalNS, targetNS, tc, dataDir)
@@ -2217,8 +2207,6 @@ var _ = Describe("bridge Operations", func() {
 				gwCIDRSecond: "fd00:1234::1/64",
 			},
 		} {
-			tc := tc
-			i := i
 			It(fmt.Sprintf("[%s] (%d) ensure bridge address", ver, i), func() {
 				conf := testCase{cniVersion: ver, isGW: true}.netConf()
 
@@ -2353,8 +2341,6 @@ var _ = Describe("bridge Operations", func() {
 				subnet: "2001:db8:42::/64",
 			},
 		} {
-			tc := tc
-			i := i
 			It(fmt.Sprintf("[%s] (%d) creates a bridge with a stable MAC addresses", ver, i), func() {
 				err := originalNS.Do(func(ns.NetNS) error {
 					defer GinkgoRecover()
@@ -2496,7 +2482,6 @@ var _ = Describe("bridge Operations", func() {
 					cniVersion:    ver,
 				},
 			} {
-				tc := tc
 				It(fmt.Sprintf("[%s] configures a bridge and ipMasq rules with ipMasqBackend %q", ver, tc.ipMasqBackend), func() {
 					err := originalNS.Do(func(ns.NetNS) error {
 						defer GinkgoRecover()
@@ -2575,8 +2560,6 @@ var _ = Describe("bridge Operations", func() {
 					},
 				},
 			} {
-				tc := tc
-				i := i
 				It(fmt.Sprintf("[%s] (%d) configures and deconfigures a bridge and veth with default route with ADD/DEL/CHECK", ver, i), func() {
 					tc.cniVersion = ver
 					cmdAddDelCheckTest(originalNS, targetNS, tc, dataDir)

--- a/plugins/main/dummy/dummy_test.go
+++ b/plugins/main/dummy/dummy_test.go
@@ -206,10 +206,6 @@ var _ = Describe("dummy Operations", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] creates an dummy link in a non-default namespace", ver), func() {
 			// Create dummy in other namespace
 			err := originalNS.Do(func(ns.NetNS) error {

--- a/plugins/main/host-device/host-device_test.go
+++ b/plugins/main/host-device/host-device_test.go
@@ -347,10 +347,6 @@ var _ = Describe("base functionality", func() {
 	})
 
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] works with a valid config without IPAM", ver), func() {
 			var origLink netlink.Link
 

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -336,9 +336,6 @@ var _ = Describe("ipvlan Operations", func() {
 		}
 		// for _, ver := range testutils.AllSpecVersions {
 		for _, ver := range [...]string{"1.0.0"} {
-			// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-			// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-			ver := ver
 			isInContainer := inContainer // Tests need a local var with constant value
 
 			It(fmt.Sprintf("[%s] creates an ipvlan link in a non-default namespace", ver), func() {

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -62,10 +62,6 @@ var _ = Describe("Loopback", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Context("when given a network namespace", func() {
 			It(fmt.Sprintf("[%s] sets the lo device to UP", ver), func() {
 				command.Stdin = generateConfig(ver)

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -258,10 +258,6 @@ var _ = Describe("macvlan Operations", func() {
 			linkInContainer = fmt.Sprintf("\"linkInContainer\": %t,", *isInContainer)
 		}
 		for _, ver := range testutils.AllSpecVersions {
-			// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-			// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-			ver := ver
-
 			It(fmt.Sprintf("[%s] creates an macvlan link in a non-default namespace", ver), func() {
 				conf := &NetConf{
 					NetConf: types.NetConf{

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -346,10 +346,6 @@ var _ = Describe("ptp Operations", func() {
 	}
 
 	for _, ver := range testutils.AllSpecVersions {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] configures and deconfigures a ptp link with ADD/DEL", ver), func() {
 			dnsConf := types.DNS{
 				Nameservers: []string{"10.1.2.123"},

--- a/plugins/main/tap/tap_test.go
+++ b/plugins/main/tap/tap_test.go
@@ -192,8 +192,6 @@ var _ = Describe("Add, check, remove tap plugin", func() {
 	})
 
 	for _, ver := range testutils.AllSpecVersions {
-		ver := ver
-
 		It(fmt.Sprintf("[%s] add, check and remove a tap device run correctly", ver), func() {
 			conf := fmt.Sprintf(`{
 				    "cniVersion": "%s",

--- a/plugins/main/vlan/vlan_test.go
+++ b/plugins/main/vlan/vlan_test.go
@@ -238,10 +238,6 @@ var _ = Describe("vlan Operations", func() {
 		isInContainer := inContainer // Tests need a local var with constant value
 
 		for _, ver := range testutils.AllSpecVersions {
-			// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-			// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-			ver := ver
-
 			It(fmt.Sprintf("[%s] creates an vlan link in a non-default namespace with given MTU", ver), func() {
 				conf := &NetConf{
 					NetConf: types.NetConf{

--- a/plugins/meta/bandwidth/bandwidth_linux_test.go
+++ b/plugins/meta/bandwidth/bandwidth_linux_test.go
@@ -122,10 +122,6 @@ var _ = Describe("bandwidth test", func() {
 	// Bandwidth requires host-side interface info, and thus only
 	// supports 0.3.0 and later CNI versions
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Describe("cmdADD", func() {
 			It(fmt.Sprintf("[%s] works with a Veth pair", ver), func() {
 				conf := fmt.Sprintf(`{

--- a/plugins/meta/firewall/firewall_firewalld_test.go
+++ b/plugins/meta/firewall/firewall_firewalld_test.go
@@ -189,10 +189,6 @@ var _ = Describe("firewalld test", func() {
 	// firewall plugin requires a prevResult and thus only supports 0.3.0
 	// and later CNI versions
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] works with a config", ver), func() {
 			Expect(isFirewalldRunning()).To(BeTrue())
 

--- a/plugins/meta/firewall/firewall_iptables_test.go
+++ b/plugins/meta/firewall/firewall_iptables_test.go
@@ -231,10 +231,6 @@ var _ = Describe("firewall plugin iptables backend", func() {
 	// firewall plugin requires a prevResult and thus only supports 0.3.0
 	// and later CNI versions
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] passes prevResult through unchanged", ver), func() {
 			fullConf := makeIptablesConf(ver)
 			args := &skel.CmdArgs{

--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -94,10 +94,6 @@ var _ = Describe("portmap integration tests", func() {
 	})
 
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Describe("Creating an interface in a namespace with the ptp plugin", func() {
 			// This needs to be done using Ginkgo's asynchronous testing mode.
 			It(fmt.Sprintf("[%s] forwards a TCP port on ipv4", ver), func(done Done) {

--- a/plugins/meta/portmap/portmap_iptables_test.go
+++ b/plugins/meta/portmap/portmap_iptables_test.go
@@ -28,10 +28,6 @@ var _ = Describe("portmapping configuration (iptables)", func() {
 	containerID := "icee6giejonei6sohng6ahngee7laquohquee9shiGo7fohferakah3Feiyoolu2pei7ciPhoh7shaoX6vai3vuf0ahfaeng8yohb9ceu0daez5hashee8ooYai5wa3y"
 
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Describe("Generating iptables chains", func() {
 			Context("for DNAT", func() {
 				It(fmt.Sprintf("[%s] generates a correct standard container chain", ver), func() {

--- a/plugins/meta/portmap/portmap_nftables_test.go
+++ b/plugins/meta/portmap/portmap_nftables_test.go
@@ -54,10 +54,6 @@ var _ = Describe("portmapping configuration (nftables)", func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Describe("nftables rules", func() {
 			var pmNFT *portMapperNFTables
 			var ipv4Fake, ipv6Fake *knftables.Fake

--- a/plugins/meta/portmap/portmap_test.go
+++ b/plugins/meta/portmap/portmap_test.go
@@ -25,10 +25,6 @@ import (
 
 var _ = Describe("portmapping configuration", func() {
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		Context("config parsing", func() {
 			It(fmt.Sprintf("[%s] correctly parses an ADD config", ver), func() {
 				configBytes := []byte(fmt.Sprintf(`{

--- a/plugins/meta/tuning/tuning_test.go
+++ b/plugins/meta/tuning/tuning_test.go
@@ -143,10 +143,6 @@ var _ = Describe("tuning plugin", func() {
 	})
 
 	for _, ver := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0"} {
-		// Redefine ver inside for scope so real value is picked up by each dynamically defined It()
-		// See Gingkgo's "Patterns for dynamically generating tests" documentation.
-		ver := ver
-
 		It(fmt.Sprintf("[%s] passes prevResult through unchanged", ver), func() {
 			conf := []byte(fmt.Sprintf(`{
 				"name": "test",


### PR DESCRIPTION
This pattern was made obsolete with the GoLang 1.22 [semantics](https://go.dev/blog/loopvar-preview) for the for-loop.

I have opened an [issue](https://github.com/onsi/ginkgo/issues/1641) to get the ginkgo documentation updated.