### PR TITLE
ipam: test ECMP support

### DIFF
--- a/pkg/ipam/ipam_linux_test.go
+++ b/pkg/ipam/ipam_linux_test.go
@@ -201,6 +201,89 @@ var _ = Describe("ConfigureIface", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("configures multiple routes with the same destination (ECMP)", func() {
+		altGateway := net.ParseIP("1.2.3.6")
+		Expect(altGateway).NotTo(BeNil())
+
+		originalRoutes := result.Routes
+		// Inject two gateway options for the same destination to validate ECMP behaviour.
+		result.Routes = []*types.Route{
+			{Dst: *routev4, GW: routegwv4},
+			{Dst: *routev4, GW: altGateway},
+		}
+		defer func() {
+			result.Routes = originalRoutes
+		}()
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := ConfigureIface(LINK_NAME, result)
+			Expect(err).NotTo(HaveOccurred())
+
+			link, err := netlinksafe.LinkByName(LINK_NAME)
+			Expect(err).NotTo(HaveOccurred())
+
+			routeFilter := &netlink.Route{
+				LinkIndex: link.Attrs().Index,
+				Dst:       routev4,
+			}
+			routes, err := netlinksafe.RouteListFiltered(
+				netlink.FAMILY_V4,
+				routeFilter,
+				netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Modern kernels may collapse duplicate ip route adds into one FIB entry via RTA_MULTIPATH.
+			var multipathRoute *netlink.Route
+			for i := range routes {
+				if routes[i].Dst == nil || !ipNetEqual(routes[i].Dst, routev4) {
+					continue
+				}
+				if len(routes[i].MultiPath) > 0 {
+					multipathRoute = &routes[i]
+					break
+				}
+			}
+			foundGateways := map[string]bool{}
+			if multipathRoute != nil {
+				// When the kernel exposes fib_info_num_path>1 as RTA_MULTIPATH (regardless of nexthop API usage),
+				// assert the two nexthops directly.
+				Expect(multipathRoute.MultiPath).To(HaveLen(2))
+				for _, nh := range multipathRoute.MultiPath {
+					if nh.Gw == nil {
+						continue
+					}
+					if nh.Gw.Equal(routegwv4) || nh.Gw.Equal(altGateway) {
+						foundGateways[nh.Gw.String()] = true
+					}
+				}
+			} else {
+				// Fallback: some setups still list each nexthop as an individual route entry,
+				// so fall back to checking the per-route gateways.
+				for _, route := range routes {
+					if route.Dst == nil || route.Gw == nil {
+						continue
+					}
+					if !ipNetEqual(route.Dst, routev4) {
+						continue
+					}
+					if route.Gw.Equal(routegwv4) || route.Gw.Equal(altGateway) {
+						foundGateways[route.Gw.String()] = true
+					}
+				}
+			}
+
+			Expect(foundGateways).To(HaveLen(2))
+			Expect(foundGateways).To(HaveKey(routegwv4.String()))
+			Expect(foundGateways).To(HaveKey(altGateway.String()))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("keeps IPV6 addresses after the interface is brought down", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()

--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -99,6 +99,7 @@ var _ = Describe("static Operations", func() {
 			))
 			Expect(result.IPs).To(HaveLen(2))
 
+			// Result must preserve both default gateways in order to prove static IPAM keeps ECMP routes.
 			Expect(result.Routes).To(Equal([]*types.Route{
 				{Dst: mustCIDR("0.0.0.0/0")},
 				{Dst: mustCIDR("192.168.0.0/16"), GW: net.ParseIP("10.10.5.1")},
@@ -106,6 +107,54 @@ var _ = Describe("static Operations", func() {
 			}))
 
 			// Release the IP
+			err = testutils.CmdDelWithArgs(args, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It(fmt.Sprintf("[%s] keeps multiple gateways for the same destination (ECMP)", ver), func() {
+			const ifname string = "eth0"
+			const nspath string = "/some/where"
+
+			conf := fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"name": "mynet",
+				"type": "ipvlan",
+				"master": "foo0",
+				"ipam": {
+					"type": "static",
+					"addresses": [ {
+						"address": "10.10.0.1/24",
+						"gateway": "10.10.0.254"
+					} ],
+					"routes": [
+						{ "dst": "0.0.0.0/0", "gw": "10.10.0.254" },
+						{ "dst": "0.0.0.0/0", "gw": "10.10.0.253" }
+					]
+				}
+			}`, ver)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       nspath,
+				IfName:      ifname,
+				StdinData:   []byte(conf),
+			}
+
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := types100.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Routes).To(Equal([]*types.Route{
+				{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.254")},
+				{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.253")},
+			}))
+
 			err = testutils.CmdDelWithArgs(args, func() error {
 				return cmdDel(args)
 			})


### PR DESCRIPTION
When multiple routes entries share the same `dst` but list different `gw` values, they collectively enable ECMP (e.g. two default routes with distinct gateways).
```
      "routes": [
        { "dst": "0.0.0.0/0", "gw": "10.0.0.1" },
        { "dst": "0.0.0.0/0", "gw": "10.0.0.2" }
      ]
```

The implementation already handles this path—`ConfigureIface` programs both routes, and static IPAM returns them—so real traffic gets load-balanced across gateways today.
https://github.com/containernetworking/plugins/blob/v1.9.1/pkg/ipam/ipam_linux.go#L148
This commit adds explicit tests for this ECMP behavior.

The concrete contents of this commit is below.
- add static IPAM spec proving multiple routes with the same `dst` keep distinct gateways
- add `ConfigureIface` ECMP test that inspects netlink routes for both gateways