### PR TITLE
Move a comment to the right place

### DIFF
--- a/plugins/ipam/static/static_test.go
+++ b/plugins/ipam/static/static_test.go
@@ -99,7 +99,6 @@ var _ = Describe("static Operations", func() {
 			))
 			Expect(result.IPs).To(HaveLen(2))
 
-			// Result must preserve both default gateways in order to prove static IPAM keeps ECMP routes.
 			Expect(result.Routes).To(Equal([]*types.Route{
 				{Dst: mustCIDR("0.0.0.0/0")},
 				{Dst: mustCIDR("192.168.0.0/16"), GW: net.ParseIP("10.10.5.1")},
@@ -150,6 +149,7 @@ var _ = Describe("static Operations", func() {
 			result, err := types100.GetResult(r)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Result must preserve both default gateways in order to prove static IPAM keeps ECMP routes.
 			Expect(result.Routes).To(Equal([]*types.Route{
 				{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.254")},
 				{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("10.10.0.253")},


### PR DESCRIPTION
noticed by coderabbit while rebasing openshift/containernetworking-plugins

(well, sort of: it noticed that the comment was incorrect where it was, but it didn't notice that it apparently belonged in the following test)