### PR TITLE
bridge: fix IPv6 address order assumption in test

### DIFF
--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -2255,11 +2255,13 @@ var _ = Describe("bridge Operations", func() {
 						addrs, err := netlinksafe.AddrList(bridge, family)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(addrs).To(HaveLen(expNumAddrs))
-						addr := addrs[0].IPNet.String()
-						Expect(addr).To(Equal(cidr0))
+						addrStrs := make([]string, len(addrs))
+						for i, a := range addrs {
+							addrStrs[i] = a.IPNet.String()
+						}
+						Expect(addrStrs).To(ContainElement(cidr0))
 						if cidr1 != "" {
-							addr = addrs[1].IPNet.String()
-							Expect(addr).To(Equal(cidr1))
+							Expect(addrStrs).To(ContainElement(cidr1))
 						}
 					}
 


### PR DESCRIPTION
## Summary
  - `checkBridgeIPs` in the "ensure bridge address" test assumed that `AddrList` returns same-scope IPv6 addresses in reverse insertion order (newest first), and checked `addrs[0]`/`addrs[1]` by index.
  - Replace index-based checks with Gomega's `ContainElement` so the test verifies presence of both addresses **without assuming order**.

## Root cause
Linux kernel v7.0 changed the insertion order for same-scope IPv6 addresses in `ipv6_link_dev_addr` .
https://github.com/torvalds/linux/commit/cb3de96eea66

Our test was written against v6.x prepend behavior and passed in CI (which runs on a v6.x kernel).
On v7.0+ kernels, `AddrList` returns addresses in insertion order, causing the index-based checks to fail.
