### PR TITLE
 ipam: fix inconsistent behavior for same-prefix routes between IPv4 and IPv6

### DIFF
--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
+	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/netlinksafe"
@@ -35,6 +36,19 @@ const (
 
 	dadSettleTimeout = 5 * time.Second
 )
+
+type routeKey struct {
+	dst      string
+	table    int
+	scope    int
+	priority int
+}
+
+type routeGroup struct {
+	route netlink.Route
+	dst   net.IPNet
+	gws   []net.IP
+}
 
 // ConfigureIface takes the result of IPAM plugin and
 // applies to the ifName interface
@@ -120,7 +134,14 @@ func ConfigureIface(ifName string, res *current.Result) error {
 		}
 	}
 
-	for _, r := range res.Routes {
+	return configureRoutes(link, ifName, res.Routes, v4gw, v6gw)
+}
+
+func configureRoutes(link netlink.Link, ifName string, routes []*types.Route, v4gw, v6gw net.IP) error {
+	routeMap := map[routeKey]*routeGroup{}
+	var routeOrder []routeKey
+
+	for _, r := range routes {
 		routeIsV4 := r.Dst.IP.To4() != nil
 		gw := r.GW
 		if gw == nil {
@@ -130,23 +151,45 @@ func ConfigureIface(ifName string, res *current.Result) error {
 				gw = v6gw
 			}
 		}
-		route := netlink.Route{
-			Dst:       &r.Dst,
-			LinkIndex: link.Attrs().Index,
-			Gw:        gw,
-			Priority:  r.Priority,
-		}
 
+		table := 0
 		if r.Table != nil {
-			route.Table = *r.Table
+			table = *r.Table
 		}
-
+		scope := 0
 		if r.Scope != nil {
-			route.Scope = netlink.Scope(*r.Scope)
+			scope = *r.Scope
 		}
 
-		if err = netlink.RouteAddEcmp(&route); err != nil {
-			return fmt.Errorf("failed to add route '%v via %v dev %v metric %d (Scope: %v, Table: %d)': %v", r.Dst, gw, ifName, r.Priority, route.Scope, route.Table, err)
+		key := routeKey{dst: r.Dst.String(), table: table, scope: scope, priority: r.Priority}
+		if _, exists := routeMap[key]; !exists {
+			route := netlink.Route{
+				LinkIndex: link.Attrs().Index,
+				Priority:  r.Priority,
+				Table:     table,
+				Scope:     netlink.Scope(scope),
+			}
+			dst := r.Dst
+			routeMap[key] = &routeGroup{route: route, dst: dst, gws: []net.IP{gw}}
+			routeOrder = append(routeOrder, key)
+		} else {
+			routeMap[key].gws = append(routeMap[key].gws, gw)
+		}
+	}
+
+	for _, key := range routeOrder {
+		entry := routeMap[key]
+		route := entry.route
+		route.Dst = &entry.dst
+		for _, gw := range entry.gws {
+			route.MultiPath = append(route.MultiPath, &netlink.NexthopInfo{
+				LinkIndex: link.Attrs().Index,
+				Gw:        gw,
+			})
+		}
+		if err := netlink.RouteAddEcmp(&route); err != nil {
+			return fmt.Errorf("failed to add route '%v via %v dev %v metric %d (Scope: %v, Table: %d)': %v",
+				entry.dst, entry.gws, ifName, route.Priority, route.Scope, route.Table, err)
 		}
 	}
 

--- a/pkg/ipam/ipam_linux_test.go
+++ b/pkg/ipam/ipam_linux_test.go
@@ -345,6 +345,70 @@ var _ = Describe("ConfigureIface", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("configures ECMP routes for IPv4", func() {
+		ecmpGWv4 := net.ParseIP("1.2.3.6")
+		result.Routes = append(result.Routes, &types.Route{
+			Dst: *routev4,
+			GW:  ecmpGWv4,
+		})
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := ConfigureIface(LINK_NAME, result)
+			Expect(err).NotTo(HaveOccurred())
+
+			routes, err := netlinksafe.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+				Dst: routev4,
+			}, netlink.RT_FILTER_DST)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(routes).To(HaveLen(1))
+			Expect(routes[0].MultiPath).To(HaveLen(2))
+
+			gws := []string{
+				routes[0].MultiPath[0].Gw.String(),
+				routes[0].MultiPath[1].Gw.String(),
+			}
+			Expect(gws).To(ContainElement(routegwv4.String()))
+			Expect(gws).To(ContainElement(ecmpGWv4.String()))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures ECMP routes for IPv6", func() {
+		ecmpGWv6 := net.ParseIP("abcd:1234:ffff::11")
+		result.Routes = append(result.Routes, &types.Route{
+			Dst: *routev6,
+			GW:  ecmpGWv6,
+		})
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := ConfigureIface(LINK_NAME, result)
+			Expect(err).NotTo(HaveOccurred())
+
+			routes, err := netlinksafe.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+				Dst: routev6,
+			}, netlink.RT_FILTER_DST)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(routes).To(HaveLen(1))
+			Expect(routes[0].MultiPath).To(HaveLen(2))
+
+			gws := []string{
+				routes[0].MultiPath[0].Gw.String(),
+				routes[0].MultiPath[1].Gw.String(),
+			}
+			Expect(gws).To(ContainElement(routegwv6.String()))
+			Expect(gws).To(ContainElement(ecmpGWv6.String()))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("does not panic when interface is not specified", func() {
 		result = &current.Result{
 			Interfaces: []*current.Interface{


### PR DESCRIPTION
# Overview
When multiple routes have the same prefix, IPv4 inserted them as separate entries while IPv6 kernel behavior implicitly merged them into ECMP.
This caused the same config to behave differently depending on the address family.
This patch absorbs the kernel behavior difference on the `plugins` side to ensure consistent ECMP behavior regardless of address family.

## Related issue/PR
https://github.com/containernetworking/plugins/pull/615
https://github.com/containernetworking/plugins/issues/1249

# Current behavior
## IPv4
When we write as below in cni's json,
```
      "routes": [
        { "dst": "0.0.0.0/0", "gw": "10.0.0.1" },
        { "dst": "0.0.0.0/0", "gw": "10.0.0.2" }
      ]
```
Pod's FIB is below
```
default via 10.0.0.1 dev ens3 
default via 10.0.0.2 dev ens3 
```
## IPv6
When we write as below in cni's json,
```
  "routes": [
    { "dst": "::/0", "gw": "2001:db8::1" },
    { "dst": "::/0", "gw": "2001:db8::2" }
  ]
```
Pod's FIB is below
```
default metric 1024 pref medium
        nexthop via 2001:db8::1 dev ens3 weight 1 
        nexthop via 2001:db8::2 dev ens3 weight 1 
```

# Implementation
Group routes with the same destination prefix, table, scope, and priority, then apply them as a single ECMP route via `RouteAddEcmp` with MultiPath.
