### PR TITLE
ci: add loong64 architecture support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goarch: [amd64, arm, arm64, mips64le, ppc64le, riscv64, s390x]
+        goarch: [amd64, arm, arm64, mips64le, ppc64le, riscv64, s390x, loong64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
   pull_request: {}
 
 env:
-  LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le riscv64"
+  LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le riscv64 loong64"
 
 jobs:
   lint:


### PR DESCRIPTION

## Summary

- Add `loong64` (LoongArch 64-bit) to the Linux build matrix in test workflow
- Add `loong64` to the Linux release matrix for binary releases

## Changes

- `.github/workflows/test.yaml`: add `loong64` to `LINUX_ARCHES` env var
- `.github/workflows/release.yaml`: add `loong64` to the `goarch` strategy matrix

## Notes

No source code changes are needed:
- Go 1.21+ natively supports `GOARCH=loong64` — this project uses Go 1.26
- Vendored `golang.org/x/sys` already includes loong64-specific files

Fixes: https://github.com/containernetworking/plugins/issues/1263
