### PR TITLE
portmap: make DNAT entries last-write-wins

### DIFF
--- a/plugins/meta/portmap/portmap_iptables.go
+++ b/plugins/meta/portmap/portmap_iptables.go
@@ -164,11 +164,15 @@ func genToplevelDnatChain() chain {
 
 // genDnatChain creates the per-container chain.
 // Conditions are any static entry conditions for the chain.
+// Entry rules are prepended within CNI-HOSTPORT-DNAT so that the most recent
+// container using a host port wins without moving CNI-HOSTPORT-DNAT ahead of
+// Kubernetes service rules in PREROUTING/OUTPUT.
 func genDnatChain(netName, containerID string) chain {
 	return chain{
-		table:       "nat",
-		name:        utils.MustFormatChainNameWithPrefix(netName, containerID, "DN-"),
-		entryChains: []string{TopLevelDNATChainName},
+		table:        "nat",
+		name:         utils.MustFormatChainNameWithPrefix(netName, containerID, "DN-"),
+		entryChains:  []string{TopLevelDNATChainName},
+		prependEntry: true,
 	}
 }
 

--- a/plugins/meta/portmap/portmap_iptables_test.go
+++ b/plugins/meta/portmap/portmap_iptables_test.go
@@ -38,9 +38,10 @@ var _ = Describe("portmapping configuration (iptables)", func() {
 					ch := genDnatChain(netName, containerID)
 
 					Expect(ch).To(Equal(chain{
-						table:       "nat",
-						name:        "CNI-DN-bfd599665540dd91d5d28",
-						entryChains: []string{TopLevelDNATChainName},
+						table:        "nat",
+						name:         "CNI-DN-bfd599665540dd91d5d28",
+						entryChains:  []string{TopLevelDNATChainName},
+						prependEntry: true,
 					}))
 					configBytes := []byte(fmt.Sprintf(`{
 						"name": "test",
@@ -69,9 +70,10 @@ var _ = Describe("portmapping configuration (iptables)", func() {
 
 					ch = genDnatChain(conf.Name, containerID)
 					Expect(ch).To(Equal(chain{
-						table:       "nat",
-						name:        "CNI-DN-67e92b96e692a494b6b85",
-						entryChains: []string{"CNI-HOSTPORT-DNAT"},
+						table:        "nat",
+						name:         "CNI-DN-67e92b96e692a494b6b85",
+						entryChains:  []string{"CNI-HOSTPORT-DNAT"},
+						prependEntry: true,
 					}))
 
 					n, err := types.ParseCIDR("10.0.0.2/24")
@@ -171,9 +173,10 @@ var _ = Describe("portmapping configuration (iptables)", func() {
 					ch := genDnatChain(netName, containerID)
 
 					Expect(ch).To(Equal(chain{
-						table:       "nat",
-						name:        "CNI-DN-bfd599665540dd91d5d28",
-						entryChains: []string{TopLevelDNATChainName},
+						table:        "nat",
+						name:         "CNI-DN-bfd599665540dd91d5d28",
+						entryChains:  []string{TopLevelDNATChainName},
+						prependEntry: true,
 					}))
 					configBytes := []byte(fmt.Sprintf(`{
 						"name": "test",


### PR DESCRIPTION
The iptables portmap backend currently appends each per-container DNAT
  entry to CNI-HOSTPORT-DNAT. If a container is recreated with the same
  HostPort before the old mapping is fully removed, the older entry can
  continue to match first.

  Make genDnatChain set prependEntry=true so newly-created per-container
  DNAT entries are inserted before older entries in CNI-HOSTPORT-DNAT,
  giving hostport mappings last-write-wins semantics.

  This does not revert the service-ordering fix from #269. That fix was
  about not prepending CNI-HOSTPORT-DNAT into nat/PREROUTING or nat/OUTPUT,
  where it could take precedence over kube-proxy's KUBE-SERVICES rules.

  This change only affects ordering inside CNI-HOSTPORT-DNAT. The top-level
  CNI-HOSTPORT-DNAT jump remains appended to PREROUTING/OUTPUT, while
  kube-proxy ensures KUBE-SERVICES is installed in those top-level NAT
  chains. Therefore Kubernetes Service and NodePort rules continue to run
  before CNI hostport dispatch.

  Validation:
  - gofmt
  - git diff --check
  - focused portmap chain-generation tests with Go 1.25