### PR TITLE
chore: allow building custom list of plugins

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -11,7 +11,7 @@ export GOFLAGS="${GOFLAGS} -mod=vendor"
 mkdir -p "${PWD}/bin"
 
 echo "Building plugins ${GOOS}"
-PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/*"
+PLUGINS=${PLUGINS:-"plugins/meta/* plugins/main/* plugins/ipam/*"}
 for d in $PLUGINS; do
 	if [ -d "$d" ]; then
 		plugin="$(basename "$d")"


### PR DESCRIPTION
In the current build script, we have to compile all plugins and does not allow customization.
This PR allows to specify which plugins we want compiled.