### PR TITLE
dhcp: send DHCPRELEASE with the client IP addr as ciaddr

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -428,7 +428,14 @@ func (l *DHCPLease) renew() error {
 func (l *DHCPLease) release() error {
 	log.Printf("%v: releasing lease", l.clientID)
 
-	c, err := newDHCPClient(l.link, l.timeout)
+	c, err := newDHCPClient(
+		l.link,
+		l.timeout,
+		nclient4.WithUnicast(&net.UDPAddr{
+			IP:   l.latestLease.ACK.YourIPAddr,
+			Port: nclient4.ClientPort,
+		}),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The dhcp IPAM plugin sends DHCPRELEASE packets with 0.0.0.0 as the IP source address instead of the client's assigned IP.

This violates RFC 2131 section [4.4.4](https://datatracker.ietf.org/doc/html/rfc2131#section-4.4.4) (quote below) and causes DHCP servers (e.g. dnsmasq) to silently ignore the release. Leases are never freed - they only expire via timeout.

> Use of broadcast and unicast
> The DHCP client broadcasts DHCPDISCOVER, DHCPREQUEST and DHCPINFORM
> messages, unless the client knows the address of a DHCP server.  The
> client unicasts DHCPRELEASE messages to the server.

By using the `nclient4.WithUnicast()` option to create the `DHCPClient`, the client will send unicast msgs.

Fixes: #1278 