### PR TITLE
fix: fall back to binary presence when netfilter capability checks both fails

### DIFF
--- a/pkg/ip/ipmasq_linux.go
+++ b/pkg/ip/ipmasq_linux.go
@@ -30,10 +30,18 @@ import (
 // implementation will be used.
 func SetupIPMasqForNetworks(backend *string, ipns []*net.IPNet, network, ifname, containerID string) error {
 	if backend == nil {
-		// Prefer iptables, unless only nftables is available
+		// Prefer iptables, unless only nftables is available. FIXME: flip this default at some point.
 		defaultBackend := "iptables"
-		if !utils.SupportsIPTables() && utils.SupportsNFTables() {
+		supportsIPT := utils.SupportsIPTables()
+		supportsNFT := utils.SupportsNFTables()
+		if !supportsIPT && supportsNFT {
 			defaultBackend = "nftables"
+		} else if !supportsIPT && !supportsNFT {
+			// Both full checks failed (likely missing CAP_NET_ADMIN at detection
+			// time). Fall back to binary presence as tiebreaker.
+			if !utils.IPTablesBinaryAvailable() && utils.NFTablesBinaryAvailable() {
+				defaultBackend = "nftables"
+			}
 		}
 		backend = &defaultBackend
 	}

--- a/pkg/utils/netfilter.go
+++ b/pkg/utils/netfilter.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"os/exec"
+
 	"github.com/coreos/go-iptables/iptables"
 	"sigs.k8s.io/knftables"
 )
@@ -31,6 +33,20 @@ func SupportsIPTables() bool {
 	// We don't care whether the chain actually exists, only whether we can *check*
 	// whether it exists.
 	_, err = ipt.ChainExists("filter", "INPUT")
+	return err == nil
+}
+
+// IPTablesBinaryAvailable tests whether the iptables binary is present in PATH.
+// Unlike SupportsIPTables, this does not require CAP_NET_ADMIN.
+func IPTablesBinaryAvailable() bool {
+	_, err := exec.LookPath("iptables")
+	return err == nil
+}
+
+// NFTablesBinaryAvailable tests whether the nft binary is present in PATH.
+// Unlike SupportsNFTables, this does not require CAP_NET_ADMIN.
+func NFTablesBinaryAvailable() bool {
+	_, err := exec.LookPath("nft")
 	return err == nil
 }
 

--- a/pkg/utils/netfilter_test.go
+++ b/pkg/utils/netfilter_test.go
@@ -48,5 +48,20 @@ var _ = Describe("netfilter support", func() {
 		It("reports that nftables is not supported", func() {
 			Expect(SupportsNFTables()).To(BeFalse(), "found nftables outside of PATH??")
 		})
+		It("reports that iptables binary is not available", func() {
+			Expect(IPTablesBinaryAvailable()).To(BeFalse(), "found iptables outside of PATH??")
+		})
+		It("reports that nft binary is not available", func() {
+			Expect(NFTablesBinaryAvailable()).To(BeFalse(), "found nft outside of PATH??")
+		})
+	})
+
+	When("binaries are available", func() {
+		It("reports that iptables binary is available", func() {
+			Expect(IPTablesBinaryAvailable()).To(BeTrue(), "This test should only fail if iptables is not available, but the test suite as a whole requires it to be available.")
+		})
+		It("reports that nft binary is available", func() {
+			Expect(NFTablesBinaryAvailable()).To(BeTrue(), "This test should only fail if nft is not available, but the test suite as a whole requires it to be available.")
+		})
 	})
 })

--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -320,10 +320,21 @@ func ensureBackend(conf *PortMapConf) error {
 	// If backend wasn't requested explicitly, default to iptables, unless it is not
 	// available (and nftables is). FIXME: flip this default at some point.
 	if conf.Backend == nil {
-		if !utils.SupportsIPTables() && utils.SupportsNFTables() {
+		supportsIPT := utils.SupportsIPTables()
+		supportsNFT := utils.SupportsNFTables()
+		switch {
+		case !supportsIPT && supportsNFT:
 			conf.Backend = &nftablesBackend
-		} else {
+		case supportsIPT || supportsNFT:
 			conf.Backend = &iptablesBackend
+		default:
+			// Both full checks failed (likely missing CAP_NET_ADMIN at detection
+			// time). Fall back to binary presence as tiebreaker.
+			if !utils.IPTablesBinaryAvailable() && utils.NFTablesBinaryAvailable() {
+				conf.Backend = &nftablesBackend
+			} else {
+				conf.Backend = &iptablesBackend
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `IPTablesBinaryAvailable()` and `NFTablesBinaryAvailable()` to `pkg/utils` — lightweight PATH checks that require no kernel access
- Update `ensureBackend()` (portmap) and `SetupIPMasqForNetworks()` (ipmasq) to use these as a fallback detection tier when the full capability checks fail

## Problem

Closes #1280

Auto-detection of the nftables backend fails on systems where iptables is not installed, even when nftables is fully available.

`SupportsNFTables()` calls `knftables.New()`, which runs `nft --check` via exec. That requires `CAP_NET_ADMIN` to connect to the kernel nftables subsystem via netlink — even for a dry run. When the process lacks that capability at detection time, `SupportsNFTables()` returns `false`.

The detection logic was:

```go
if !utils.SupportsIPTables() && utils.SupportsNFTables() {
    use nftables
} else {
    use iptables  // unconditional fallback
}
