### PR TITLE
portmap: pick nftables when iptables is missing even without CAP_NET_ADMIN

### DIFF
--- a/pkg/ip/ipmasq_linux.go
+++ b/pkg/ip/ipmasq_linux.go
@@ -32,7 +32,7 @@ func SetupIPMasqForNetworks(backend *string, ipns []*net.IPNet, network, ifname,
 	if backend == nil {
 		// Prefer iptables, unless only nftables is available
 		defaultBackend := "iptables"
-		if !utils.SupportsIPTables() && utils.SupportsNFTables() {
+		if utils.PreferNFTablesDefault() {
 			defaultBackend = "nftables"
 		}
 		backend = &defaultBackend

--- a/pkg/utils/netfilter.go
+++ b/pkg/utils/netfilter.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"os/exec"
+
 	"github.com/coreos/go-iptables/iptables"
 	"sigs.k8s.io/knftables"
 )
@@ -43,4 +45,24 @@ func SupportsNFTables() bool {
 	// the iptables case.
 	_, err := knftables.New(knftables.IPv4Family, "supports_nftables_test")
 	return err == nil
+}
+
+// HasNFTablesCommand reports whether the nft binary is available on PATH.
+// Unlike SupportsNFTables, this does not open a netlink connection and therefore
+// does not require CAP_NET_ADMIN.
+func HasNFTablesCommand() bool {
+	_, err := exec.LookPath("nft")
+	return err == nil
+}
+
+// PreferNFTablesDefault is used when no netfilter backend was requested
+// explicitly. Prefer iptables when it works; if iptables is unavailable, fall
+// back to nftables when either a full knftables probe succeeds or the nft
+// binary is present (probe can fail without CAP_NET_ADMIN even on nft-only
+// systems).
+func PreferNFTablesDefault() bool {
+	if SupportsIPTables() {
+		return false
+	}
+	return SupportsNFTables() || HasNFTablesCommand()
 }

--- a/pkg/utils/netfilter_test.go
+++ b/pkg/utils/netfilter_test.go
@@ -16,6 +16,8 @@ package utils
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,5 +50,35 @@ var _ = Describe("netfilter support", func() {
 		It("reports that nftables is not supported", func() {
 			Expect(SupportsNFTables()).To(BeFalse(), "found nftables outside of PATH??")
 		})
+		It("reports that the nft command is not available", func() {
+			Expect(HasNFTablesCommand()).To(BeFalse())
+		})
+		It("does not prefer nftables when neither backend is available", func() {
+			Expect(PreferNFTablesDefault()).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("PreferNFTablesDefault", func() {
+	It("returns false when iptables is available", func() {
+		// Suite requires iptables; prefer iptables when both work.
+		Expect(SupportsIPTables()).To(BeTrue())
+		Expect(PreferNFTablesDefault()).To(BeFalse())
+	})
+
+	It("prefers nftables when iptables is missing but nft is on PATH", Serial, func() {
+		nftPath, err := exec.LookPath("nft")
+		if err != nil {
+			Skip("nft not installed on this host")
+		}
+
+		origPath := os.Getenv("PATH")
+		DeferCleanup(func() { os.Setenv("PATH", origPath) })
+		// Keep only the directory that contains nft so iptables is not found.
+		os.Setenv("PATH", filepath.Dir(nftPath))
+
+		Expect(SupportsIPTables()).To(BeFalse())
+		Expect(HasNFTablesCommand()).To(BeTrue())
+		Expect(PreferNFTablesDefault()).To(BeTrue())
 	})
 })

--- a/pkg/utils/netfilter_test.go
+++ b/pkg/utils/netfilter_test.go
@@ -16,8 +16,6 @@ package utils
 
 import (
 	"os"
-	"os/exec"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,21 +62,5 @@ var _ = Describe("PreferNFTablesDefault", func() {
 		// Suite requires iptables; prefer iptables when both work.
 		Expect(SupportsIPTables()).To(BeTrue())
 		Expect(PreferNFTablesDefault()).To(BeFalse())
-	})
-
-	It("prefers nftables when iptables is missing but nft is on PATH", Serial, func() {
-		nftPath, err := exec.LookPath("nft")
-		if err != nil {
-			Skip("nft not installed on this host")
-		}
-
-		origPath := os.Getenv("PATH")
-		DeferCleanup(func() { os.Setenv("PATH", origPath) })
-		// Keep only the directory that contains nft so iptables is not found.
-		os.Setenv("PATH", filepath.Dir(nftPath))
-
-		Expect(SupportsIPTables()).To(BeFalse())
-		Expect(HasNFTablesCommand()).To(BeTrue())
-		Expect(PreferNFTablesDefault()).To(BeTrue())
 	})
 })

--- a/plugins/meta/portmap/main.go
+++ b/plugins/meta/portmap/main.go
@@ -320,7 +320,7 @@ func ensureBackend(conf *PortMapConf) error {
 	// If backend wasn't requested explicitly, default to iptables, unless it is not
 	// available (and nftables is). FIXME: flip this default at some point.
 	if conf.Backend == nil {
-		if !utils.SupportsIPTables() && utils.SupportsNFTables() {
+		if utils.PreferNFTablesDefault() {
 			conf.Backend = &nftablesBackend
 		} else {
 			conf.Backend = &iptablesBackend


### PR DESCRIPTION
`SupportsNFTables()` goes through knftables and needs CAP_NET_ADMIN. On nft-only systems (or when detection runs without that cap) both probes can fail and we still fell back to iptables, which then also fails.

If iptables isn't available, treat a present `nft` binary as enough signal to default to the nftables backend. Same helper used for ipmasq defaulting.

Fixes #1280