### PR TITLE
host-local: implement CNI v1.1 GC

### DIFF
--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -21,12 +21,17 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend"
 )
 
 const (
 	lastIPFilePrefix = "last_reserved_ip."
 	LineBreak        = "\r\n"
+	// lockFileName is the file NewFileLock creates when it is handed a
+	// directory. It shares the data dir with the reservations, so GC has to know
+	// its name in order not to delete it.
+	lockFileName = "lock"
 )
 
 var defaultDataDir = "/var/lib/cni/networks"
@@ -163,6 +168,63 @@ func (s *Store) ReleaseByID(id string, ifname string) error {
 		_, err = s.ReleaseByKey(match)
 	}
 	return err
+}
+
+// GC releases every reservation whose attachment is absent from attachments,
+// which the runtime supplies as the complete set of attachments it still
+// considers live. It is how a reservation leaked by a DEL that never arrived
+// gets reclaimed.
+//
+// Like ReleaseByID this is deliberately tolerant of per-file errors: releasing
+// as much as possible is more useful than stopping at the first unreadable
+// reservation.
+func (s *Store) GC(attachments []types.GCAttachment) error {
+	s.Lock()
+	defer s.Unlock()
+
+	valid := make(map[string]struct{}, len(attachments))
+	// Reservations written before the ifname was recorded hold only a container
+	// ID, so keep a second set to match those. Without it the first GC after an
+	// upgrade would release every pre-upgrade allocation.
+	validLegacy := make(map[string]struct{}, len(attachments))
+	for _, a := range attachments {
+		id := strings.TrimSpace(a.ContainerID)
+		valid[id+LineBreak+a.IfName] = struct{}{}
+		validLegacy[id] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(s.dataDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !isReservation(e.Name()) {
+			continue
+		}
+		path := filepath.Join(s.dataDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		key := strings.TrimSpace(string(data))
+		if _, ok := valid[key]; ok {
+			continue
+		}
+		if !strings.Contains(key, LineBreak) {
+			if _, ok := validLegacy[key]; ok {
+				continue
+			}
+		}
+		_ = os.Remove(path)
+	}
+	return nil
+}
+
+// isReservation reports whether a file in a network's data dir is an address
+// reservation. The lock and the per-range last_reserved_ip markers share that
+// directory and have to survive a GC.
+func isReservation(name string) bool {
+	return name != lockFileName && !strings.HasPrefix(name, lastIPFilePrefix)
 }
 
 // GetByID returns the IPs which have been allocated to the specific ID

--- a/plugins/ipam/host-local/backend/disk/gc_test.go
+++ b/plugins/ipam/host-local/backend/disk/gc_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+var _ = Describe("Store GC", func() {
+	const network = "gcnet"
+
+	var (
+		dataDir string
+		store   *Store
+	)
+
+	BeforeEach(func() {
+		var err error
+		dataDir, err = os.MkdirTemp("", "host_local_gc")
+		Expect(err).NotTo(HaveOccurred())
+		store, err = New(network, dataDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(store.Close()).To(Succeed())
+		Expect(os.RemoveAll(dataDir)).To(Succeed())
+	})
+
+	// reserved writes a reservation the way Reserve does, so the tests exercise
+	// the real on-disk format rather than a guess at it.
+	reserved := func(ip, id, ifname string) {
+		ok, err := store.Reserve(id, ifname, net.ParseIP(ip), "0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	}
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dataDir, network, name))
+		return err == nil
+	}
+
+	It("releases reservations that are not in the valid set", func() {
+		reserved("10.0.0.1", "keep-me", "eth0")
+		reserved("10.0.0.2", "gone", "eth0")
+
+		Expect(store.GC([]types.GCAttachment{
+			{ContainerID: "keep-me", IfName: "eth0"},
+		})).To(Succeed())
+
+		Expect(exists("10.0.0.1")).To(BeTrue(), "valid attachment was released")
+		Expect(exists("10.0.0.2")).To(BeFalse(), "stale attachment was kept")
+	})
+
+	It("matches on the interface as well as the container", func() {
+		// The same container holding two interfaces is two attachments. A
+		// runtime that reports only one of them wants the other released.
+		reserved("10.0.0.1", "twoif", "eth0")
+		reserved("10.0.0.2", "twoif", "eth1")
+
+		Expect(store.GC([]types.GCAttachment{
+			{ContainerID: "twoif", IfName: "eth0"},
+		})).To(Succeed())
+
+		Expect(exists("10.0.0.1")).To(BeTrue())
+		Expect(exists("10.0.0.2")).To(BeFalse(), "released only by container, ignoring ifname")
+	})
+
+	It("releases everything when the valid set is empty", func() {
+		reserved("10.0.0.1", "a", "eth0")
+		reserved("10.0.0.2", "b", "eth0")
+
+		Expect(store.GC(nil)).To(Succeed())
+
+		Expect(exists("10.0.0.1")).To(BeFalse())
+		Expect(exists("10.0.0.2")).To(BeFalse())
+	})
+
+	It("leaves the lock and last_reserved_ip bookkeeping files alone", func() {
+		// Reserve writes last_reserved_ip.0, and New creates the lock. Both live
+		// in the same directory as the reservations and are not reservations, so
+		// a GC that just walks the directory would delete them.
+		reserved("10.0.0.1", "gone", "eth0")
+
+		Expect(store.GC(nil)).To(Succeed())
+
+		Expect(exists("10.0.0.1")).To(BeFalse())
+		Expect(exists("lock")).To(BeTrue(), "GC deleted the lock file")
+		Expect(exists(lastIPFilePrefix+"0")).To(BeTrue(), "GC deleted last_reserved_ip")
+	})
+
+	It("understands reservations written before ifname was recorded", func() {
+		// Older versions wrote just the container ID. ReleaseByID already falls
+		// back to matching those, and GC has to agree or it would delete live
+		// allocations on the first run after an upgrade.
+		legacy := filepath.Join(dataDir, network, "10.0.0.9")
+		Expect(os.WriteFile(legacy, []byte("legacy-id"), 0o600)).To(Succeed())
+
+		Expect(store.GC([]types.GCAttachment{
+			{ContainerID: "legacy-id", IfName: "eth0"},
+		})).To(Succeed())
+
+		Expect(exists("10.0.0.9")).To(BeTrue(), "legacy reservation was wrongly released")
+	})
+
+	It("still releases a legacy reservation that is genuinely stale", func() {
+		legacy := filepath.Join(dataDir, network, "10.0.0.9")
+		Expect(os.WriteFile(legacy, []byte("legacy-id"), 0o600)).To(Succeed())
+
+		Expect(store.GC([]types.GCAttachment{
+			{ContainerID: "someone-else", IfName: "eth0"},
+		})).To(Succeed())
+
+		Expect(exists("10.0.0.9")).To(BeFalse())
+	})
+
+	It("frees the address for reuse", func() {
+		// The point of GC is reclaiming leaked reservations, so the freed
+		// address has to actually be allocatable again.
+		reserved("10.0.0.1", "leaked", "eth0")
+		Expect(store.GC(nil)).To(Succeed())
+
+		ok, err := store.Reserve("newcomer", "eth0", net.ParseIP("10.0.0.1"), "0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue(), "address was not reusable after GC")
+	})
+})

--- a/plugins/ipam/host-local/backend/disk/lock.go
+++ b/plugins/ipam/host-local/backend/disk/lock.go
@@ -34,7 +34,7 @@ func NewFileLock(lockPath string) (*FileLock, error) {
 	}
 
 	if fi.IsDir() {
-		lockPath = path.Join(lockPath, "lock")
+		lockPath = path.Join(lockPath, lockFileName)
 	}
 
 	f, err := filemutex.New(lockPath)

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -680,6 +680,111 @@ var _ = Describe("host-local Operations", func() {
 	}
 })
 
+var _ = Describe("host-local GC operations", func() {
+	const netName = "gcplugin"
+
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "host_local_gc_plugin")
+		Expect(err).NotTo(HaveOccurred())
+		// The dir is interpolated into a JSON config, and a Windows path's
+		// backslashes would be read as string escapes.
+		tmpDir = filepath.ToSlash(tmpDir)
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	// confWith renders the network config, optionally carrying the
+	// cni.dev/valid-attachments list that only a GC invocation supplies.
+	confWith := func(validAttachments string) []byte {
+		attach := ""
+		if validAttachments != "" {
+			attach = fmt.Sprintf(`"cni.dev/valid-attachments": [%s],`, validAttachments)
+		}
+		return []byte(fmt.Sprintf(`{
+			"cniVersion": "1.1.0",
+			"name": "%s",
+			"type": "host-local",
+			%s
+			"ipam": {
+				"type": "host-local",
+				"dataDir": "%s",
+				"ranges": [[{ "subnet": "10.9.0.0/24" }]]
+			}
+		}`, netName, attach, tmpDir))
+	}
+
+	add := func(containerID, ifname string) string {
+		args := &skel.CmdArgs{
+			ContainerID: containerID,
+			Netns:       "/some/where",
+			IfName:      ifname,
+			StdinData:   confWith(""),
+		}
+		r, _, err := testutils.CmdAddWithArgs(args, func() error { return cmdAdd(args) })
+		Expect(err).NotTo(HaveOccurred())
+		result, err := types100.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+		return result.IPs[0].Address.IP.String()
+	}
+
+	reservationExists := func(ip string) bool {
+		_, err := os.Stat(filepath.Join(tmpDir, netName, ip))
+		return err == nil
+	}
+
+	It("releases reservations the runtime no longer reports as attached", func() {
+		liveIP := add("live", "eth0")
+		leakedIP := add("leaked", "eth0")
+		Expect(reservationExists(liveIP)).To(BeTrue())
+		Expect(reservationExists(leakedIP)).To(BeTrue())
+
+		args := &skel.CmdArgs{
+			StdinData: confWith(`{"containerID": "live", "ifname": "eth0"}`),
+		}
+		Expect(cmdGC(args)).To(Succeed())
+
+		Expect(reservationExists(liveIP)).To(BeTrue(), "GC released a live attachment")
+		Expect(reservationExists(leakedIP)).To(BeFalse(), "GC kept a leaked attachment")
+	})
+
+	It("releases every reservation when the runtime reports no attachments", func() {
+		// An absent list is not the same as "nothing to collect": a runtime with
+		// no live attachments for this network expects the store emptied.
+		ip := add("leaked", "eth0")
+		Expect(reservationExists(ip)).To(BeTrue())
+
+		args := &skel.CmdArgs{StdinData: confWith("")}
+		Expect(cmdGC(args)).To(Succeed())
+
+		Expect(reservationExists(ip)).To(BeFalse())
+	})
+
+	It("leaves the store usable for subsequent allocations", func() {
+		leakedIP := add("leaked", "eth0")
+
+		args := &skel.CmdArgs{StdinData: confWith("")}
+		Expect(cmdGC(args)).To(Succeed())
+
+		newIP := add("newcomer", "eth0")
+		Expect(reservationExists(newIP)).To(BeTrue())
+		Expect(reservationExists(leakedIP)).To(BeFalse())
+
+		// Note the new allocation does NOT reuse the reclaimed address straight
+		// away: host-local resumes from last_reserved_ip rather than rescanning
+		// the range, so the address comes back into play on wrap-around. It is
+		// genuinely free either way, which the disk-level GC tests assert
+		// directly via Reserve. GC deliberately does not rewind
+		// last_reserved_ip, since that would change allocation order for
+		// everyone rather than just reclaiming leaks.
+		Expect(newIP).NotTo(Equal(leakedIP))
+	})
+})
+
 func mustCIDR(s string) net.IPNet {
 	ip, n, err := net.ParseCIDR(s)
 	n.IP = ip

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -34,9 +35,37 @@ func main() {
 		Add:   cmdAdd,
 		Check: cmdCheck,
 		Del:   cmdDel,
-		/* FIXME GC */
+		GC:    cmdGC,
 		/* FIXME Status */
 	}, version.All, bv.BuildString("host-local"))
+}
+
+// cmdGC releases reservations for attachments the runtime no longer considers
+// live, which is how an allocation leaked by a DEL that never arrived is
+// reclaimed.
+//
+// An empty valid-attachments list is meaningful and means every reservation for
+// this network is stale, so it must not be treated as "nothing to do".
+func cmdGC(args *skel.CmdArgs) error {
+	ipamConf, _, err := allocator.LoadIPAMConfig(args.StdinData, args.Args)
+	if err != nil {
+		return err
+	}
+
+	// LoadIPAMConfig parses the ipam block and does not carry the top level
+	// cni.dev/valid-attachments, so read that separately.
+	n := types.NetConf{}
+	if err := json.Unmarshal(args.StdinData, &n); err != nil {
+		return fmt.Errorf("failed to parse network config: %w", err)
+	}
+
+	store, err := disk.New(ipamConf.Name, ipamConf.DataDir)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	return store.GC(n.ValidAttachments)
 }
 
 func cmdCheck(args *skel.CmdArgs) error {


### PR DESCRIPTION

Fixes #1047.

Implements the GC verb for host-local, replacing the `/* FIXME GC */` placeholder in `main.go`. The runtime supplies the complete set of attachments it still considers live via `cni.dev/valid-attachments`, and every reservation outside that set is released. That reclaims an allocation leaked by a DEL which never arrived, which is the case the issue calls out.

As far as I can tell this is the first GC implementation in this repo, so I have tried to keep the semantics conservative and to write down the reasoning where a later plugin will face the same question.

### Three things the implementation has to get right

Each has a test, because each is a way to silently destroy live allocations rather than a way to fail loudly.

**The data dir is not only reservations.** `lock` and the per-range `last_reserved_ip.<rangeID>` markers live alongside them, so a GC that just walked the directory would delete them. `isReservation` skips both, and `lockFileName` is now a shared constant so the skip cannot drift from the name `NewFileLock` actually uses.

**Reservations predating ifname hold only a container ID.** `ReleaseByID` already has a fallback for those, and GC has to agree with it. Without that, the first GC after an upgrade would release every pre-upgrade allocation on the host.

**An empty valid-attachments list is meaningful.** It means every reservation for this network is stale, not that there is nothing to do. Treating absent as no-op would make GC quietly useless in exactly the situation it exists for.

### One deliberate non-behaviour

GC does not rewind `last_reserved_ip`. A reclaimed address therefore comes back into service on wrap-around rather than being the next one handed out. Rewinding would change allocation order for everyone in order to make reclamation look more immediate, which seemed like the wrong trade for a garbage collector. The address is genuinely free either way, and the disk-level test asserts that directly by reserving it again.

I have called this out because it is the one thing where a reasonable reviewer might want the opposite, and it is a one-line change if you do.

### Scope

- `GC` is a method on `*disk.Store` rather than an addition to the `backend.Store` interface, matching how `cmdCheck` already reaches for the concrete store. Happy to move it onto the interface if you would rather every backend be required to implement it; that just means touching the fake store too. I asked on the issue and went with the smaller change in the meantime.
- STATUS is left as a separate change, so this one stays reviewable.

### Tests

`plugins/ipam/host-local/backend/disk/gc_test.go`, 7 specs at the store level: valid set honoured, ifname distinguishes two attachments of the same container, empty set releases everything, lock and `last_reserved_ip` survive, legacy container-ID-only reservations are both kept when live and released when stale, and a reclaimed address is reservable again.

`plugins/ipam/host-local/host_local_test.go`, 3 specs at the plugin level driving `cmdGC` through a real config: a leaked attachment is released while a live one is kept, an empty list empties the store, and the store still serves allocations afterwards.

```
go test ./plugins/ipam/host-local/...
ok  	github.com/containernetworking/plugins/plugins/ipam/host-local
ok  	github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator
ok  	github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk
```

`go build ./...` is clean and `go vet ./plugins/ipam/host-local/...` is clean.

Unrelated pre-existing failure, confirmed by stashing this branch and re-running on a clean `main`: `pkg/utils/sysctl` fails without root because it writes under `/proc/sys`. Not touched by this change.