### PR TITLE
pkg/ip, host-local: fix panic on a RangeStart at the top of a family

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -19,7 +19,8 @@ import (
 	"net"
 )
 
-// NextIP returns IP incremented by 1, if IP is invalid, return nil
+// NextIP returns IP incremented by 1, or nil if IP is invalid or already the
+// last address in its family.
 func NextIP(ip net.IP) net.IP {
 	normalizedIP := normalizeIP(ip)
 	if normalizedIP == nil {
@@ -68,11 +69,15 @@ func intToIP(i *big.Int, isIPv6 bool) net.IP {
 		return intBytes
 	}
 
+	ipLen := net.IPv4len
 	if isIPv6 {
-		return append(make([]byte, net.IPv6len-len(intBytes)), intBytes...)
+		ipLen = net.IPv6len
 	}
-
-	return append(make([]byte, net.IPv4len-len(intBytes)), intBytes...)
+	// The value overflowed past the last address of its family.
+	if len(intBytes) > ipLen {
+		return nil
+	}
+	return append(make([]byte, ipLen-len(intBytes)), intBytes...)
 }
 
 // normalizeIP will normalize IP by family,

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -31,7 +31,8 @@ func NextIP(ip net.IP) net.IP {
 	return intToIP(i.Add(i, big.NewInt(1)), len(normalizedIP) == net.IPv6len)
 }
 
-// PrevIP returns IP decremented by 1, if IP is invalid, return nil
+// PrevIP returns IP decremented by 1, or nil if IP is invalid or already the
+// first address in its family.
 func PrevIP(ip net.IP) net.IP {
 	normalizedIP := normalizeIP(ip)
 	if normalizedIP == nil {
@@ -63,21 +64,29 @@ func ipToInt(ip net.IP) *big.Int {
 }
 
 func intToIP(i *big.Int, isIPv6 bool) net.IP {
-	intBytes := i.Bytes()
-
-	if len(intBytes) == net.IPv4len || len(intBytes) == net.IPv6len {
-		return intBytes
+	// big.Int.Bytes returns the absolute value, so a value that went below the
+	// first address of its family would otherwise come back as a positive IP.
+	if i.Sign() < 0 {
+		return nil
 	}
 
 	ipLen := net.IPv4len
 	if isIPv6 {
 		ipLen = net.IPv6len
 	}
+
+	intBytes := i.Bytes()
 	// The value overflowed past the last address of its family.
 	if len(intBytes) > ipLen {
 		return nil
 	}
-	return append(make([]byte, ipLen-len(intBytes)), intBytes...)
+
+	// Always return the family's fixed width. Choosing the length from the
+	// minimal big.Int encoding would turn a low IPv6 value whose leading bytes
+	// are zero into a 4-byte IPv4 address.
+	out := make(net.IP, ipLen)
+	copy(out[ipLen-len(intBytes):], intBytes)
+	return out
 }
 
 // normalizeIP will normalize IP by family,

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -71,6 +71,11 @@ var _ = Describe("CIDR functions", func() {
 				net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
 				nil,
 			},
+			{
+				// a low IPv6 result must stay 16-byte IPv6, not collapse to IPv4
+				net.ParseIP("::ff:ffff"),
+				net.ParseIP("::100:0"),
+			},
 		}
 
 		for _, test := range testCases {
@@ -112,6 +117,20 @@ var _ = Describe("CIDR functions", func() {
 			{
 				net.ParseIP("0::124"),
 				net.ParseIP("0::123"),
+			},
+			{
+				// a low IPv6 result must stay 16-byte IPv6, not collapse to IPv4
+				net.ParseIP("::1:0:0"),
+				net.ParseIP("::ffff:ffff"),
+			},
+			{
+				// underflow below the first address returns nil, not the wrapped absolute value
+				net.ParseIP("0.0.0.0"),
+				nil,
+			},
+			{
+				net.ParseIP("::"),
+				nil,
 			},
 		}
 

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -55,6 +55,22 @@ var _ = Describe("CIDR functions", func() {
 				net.ParseIP("0::123"),
 				net.ParseIP("0::124"),
 			},
+			{
+				net.ParseIP("255.255.255.254"),
+				net.IPv4(255, 255, 255, 255).To4(),
+			},
+			{
+				net.ParseIP("255.255.255.255"),
+				nil,
+			},
+			{
+				net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"),
+				net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+			},
+			{
+				net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+				nil,
+			},
 		}
 
 		for _, test := range testCases {

--- a/plugins/ipam/host-local/backend/allocator/config_test.go
+++ b/plugins/ipam/host-local/backend/allocator/config_test.go
@@ -418,6 +418,25 @@ var _ = Describe("IPAM config", func() {
 		Expect(err).To(MatchError("invalid range set 0: mixed address families"))
 	})
 
+	It("should reject a range whose RangeStart sits at the top of the address family", func() {
+		// This config used to be accepted and then panic inside Get; the
+		// RangeStart was only checked against a not-yet-defaulted RangeEnd.
+		input := `{
+				"cniVersion": "0.3.1",
+				"name": "mynet",
+				"type": "ipvlan",
+				"master": "foo0",
+				"ipam": {
+					"type": "host-local",
+					"ranges": [
+						[{"subnet":"255.255.255.252/30","rangeStart":"255.255.255.255","gateway":"255.255.255.255"}]
+					]
+				}
+			}`
+		_, _, err := LoadIPAMConfig([]byte(input), "")
+		Expect(err).To(MatchError("invalid range set 0: RangeStart 255.255.255.255 is after RangeEnd 255.255.255.254 in network 255.255.255.252/30"))
+	})
+
 	It("Should should error on too many ranges", func() {
 		input := `{
 				"cniVersion": "0.2.0",

--- a/plugins/ipam/host-local/backend/allocator/range.go
+++ b/plugins/ipam/host-local/backend/allocator/range.go
@@ -84,6 +84,11 @@ func (r *Range) Canonicalize() error {
 		r.RangeEnd = lastIP(r.Subnet)
 	}
 
+	// RangeEnd may have just been defaulted, so check the ordering now.
+	if ip.Cmp(r.RangeStart, r.RangeEnd) > 0 {
+		return fmt.Errorf("RangeStart %s is after RangeEnd %s in network %s", r.RangeStart.String(), r.RangeEnd.String(), (*net.IPNet)(&r.Subnet).String())
+	}
+
 	return nil
 }
 

--- a/plugins/ipam/host-local/backend/allocator/range_test.go
+++ b/plugins/ipam/host-local/backend/allocator/range_test.go
@@ -120,6 +120,26 @@ var _ = Describe("IP ranges", func() {
 		Expect(err).Should(MatchError("RangeStart 192.0.2.50 not in network 192.0.2.0/24"))
 	})
 
+	It("should reject a RangeStart that lands after the defaulted RangeEnd", func() {
+		// RangeStart is checked before RangeEnd is defaulted, so a broadcast
+		// RangeStart (one above the default RangeEnd) used to slip through.
+		r := Range{
+			Subnet:     mustSubnet("192.0.2.0/24"),
+			RangeStart: net.ParseIP("192.0.2.255"),
+		}
+		err := r.Canonicalize()
+		Expect(err).Should(MatchError("RangeStart 192.0.2.255 is after RangeEnd 192.0.2.254 in network 192.0.2.0/24"))
+
+		// The same gap at the top of the family, where this shape used to
+		// reach the iterator and panic.
+		r = Range{
+			Subnet:     mustSubnet("255.255.255.252/30"),
+			RangeStart: net.ParseIP("255.255.255.255"),
+		}
+		err = r.Canonicalize()
+		Expect(err).Should(MatchError("RangeStart 255.255.255.255 is after RangeEnd 255.255.255.254 in network 255.255.255.252/30"))
+	})
+
 	It("should parse all fields correctly", func() {
 		snstr := "192.0.2.0/24"
 		r := Range{


### PR DESCRIPTION
Fixes #1292.

`intToIP` converts arithmetic results back to fixed-width `net.IP` values. It must preserve the selected address family and reject results outside that family.

Incrementing the final IPv4 or IPv6 address produces a value one byte wider than the family, which makes the padding calculation use a negative length and panic. The existing conversion also returned a four-byte IPv4 value when a valid IPv6 result happened to have exactly four significant bytes (for example `NextIP(::ff:ffff)` returned `1.0.0.0` rather than `::100:0`), and because `big.Int.Bytes` returns the absolute value, a subtraction below the first address of a family came back as the wrapped value instead of `nil`.

The host-local reproducer in #1292 is IPv4-specific. An explicit IPv4 `rangeStart` at the subnet broadcast address can be greater than the default `rangeEnd`, which excludes broadcast. `Range.Canonicalize` checked `RangeStart` before assigning the default end, so the reversed range was accepted. At `255.255.255.255` this reaches `NextIP` and panics; in a lower subnet a broadcast `rangeStart` walks outside the configured range before it reaches a family boundary. IPv6 defaults `rangeEnd` to the subnet's final address, so an all-ones `rangeStart` is also `rangeEnd` and the iterator exhausts the range before calling `NextIP`; the direct `NextIP(max IPv6)` helper call has the same arithmetic overflow, which the new unit test covers.

Changes:

- `pkg/ip`: decide the family width first, reject sign-negative underflow and oversized overflow, and always return the selected family's fixed width.
- `host-local`: reject `RangeStart > RangeEnd` after both values have been resolved.

Tests cover both family maxima, IPv6 family-width preservation, both family minima for `PrevIP`, the defaulted-end ordering check, and the exact configuration from #1292.
